### PR TITLE
release/v1.8.0 Jarvis

### DIFF
--- a/Docs/architecture.md
+++ b/Docs/architecture.md
@@ -349,24 +349,25 @@ Current guarantees remain unchanged:
 - no coupling of advisory semantics to runtime-control behavior
 - no authority expansion beyond the existing diagnostics-only advisory boundary
 
-`FB-013` remains open after rev3a pending the next narrow decision on whether a definition-only confidence-semantics slice is still needed for `v1.8.0`.
+## v1.8.0 Implemented Rev3b Internal Confidence Semantics
 
-## v1.8.0 Planned Rev3b Internal Confidence Semantics
+`FB-013` rev3b is now implemented as the definition-only and internal confidence-semantics slice for `v1.8.0`.
 
-`FB-013` rev3b should remain a definition-only and internal confidence-semantics pass.
+Implemented rev3b state:
 
-That narrow confidence slice should:
+- confidence is defined only as evidence-directness or evidence-quality for advisory inference
+- confidence remains absent from surfaced operator-facing output
+- internal confidence handling stays aligned only with the existing exact-recurrence and varied-history advisory evidence lanes
 
-- define confidence only as evidence-directness or evidence-quality for advisory inference
-- keep confidence absent from surfaced operator-facing output
+Current guarantees remain unchanged:
 
-That narrow confidence slice must not:
+- no surfaced confidence scoring
+- no interpretation of confidence as severity, urgency, escalation level, recommendation strength, predictive correctness, runtime-policy permission, or authority over current-run truth
+- no coupling of confidence semantics to runtime-control behavior
+- no authority expansion beyond the existing diagnostics-only advisory boundary
+- no confidence, historical, or advisory language added to crash-report or incident-summary truth surfaces
 
-- interpret confidence as severity, urgency, escalation level, recommendation strength, predictive correctness, runtime-policy permission, or authority over current-run truth
-- couple confidence semantics to runtime-control behavior
-- expand authority beyond the existing diagnostics-only advisory boundary
-- add confidence, historical, or advisory language to crash-report or incident-summary truth surfaces
-- redesign advisory output beyond what is needed to preserve the internal-only confidence boundary
+Taken together, `FB-013` rev3a and rev3b complete the advisory provenance and confidence semantics track for `v1.8.0` without introducing surfaced confidence output or runtime-policy meaning.
 
 ## Read-Only Memory Rule
 

--- a/Docs/architecture.md
+++ b/Docs/architecture.md
@@ -309,6 +309,26 @@ Current guarantees remain unchanged:
 - no reinterpretation of recurrence as runtime policy significance
 - no coupling of historical recurrence to runtime-control behavior
 
+## v1.8.0 Planned Rev2b Deterministic Stability Model
+
+`FB-012` rev2b should begin as a deterministic recent-history stability-model pass, not as a broader recurrence or advisory redesign.
+
+That first stability slice should:
+
+- compute stability only from recurrence-eligible finalized failure records
+- use an explicit recent-history window of the most recent `5` eligible finalized failure records
+- treat `stable` as a recent window containing `0` or `1` unique normalized full fingerprints
+- treat `varied` as a recent window containing more than `1` unique normalized full fingerprints
+- exclude success records, empty fingerprints, malformed lines, contract-invalid records, and hostile or unreadable history cases from stability calculations
+
+That first stability slice must not:
+
+- introduce fuzzy matching
+- introduce confidence or provenance semantics
+- redesign advisory wording
+- reinterpret stability as runtime policy significance
+- couple historical stability to runtime-control behavior
+
 ## Read-Only Memory Rule
 
 Historical memory in `v1.7.0` must remain a derived, read-only layer over `v1.6.0` truth.

--- a/Docs/architecture.md
+++ b/Docs/architecture.md
@@ -290,22 +290,24 @@ Current guarantees remain unchanged:
 - historical context remains non-authoritative
 - advisory output remains non-binding
 
-## v1.8.0 Planned Rev2a Narrow Scope
+## v1.8.0 Implemented Rev2a Strict Fingerprint Contract
 
-`FB-012` rev2a should begin as a strict failure-fingerprint contract pass, not as a broader recurrence redesign.
+`FB-012` rev2a is now implemented as the first strict failure-fingerprint contract slice for `v1.8.0`.
 
-That first slice should:
+Implemented rev2a state:
 
-- formalize the current implemented fingerprint shape using only existing finalized truth surfaces already recorded by the historical layer
-- formalize initial recurrence grouping as strict equality on the normalized full fingerprint
-- exclude success records and empty fingerprints from recurrence grouping
+- fingerprints apply only to finalized failure records
+- success records keep empty `failure_fingerprint` values
+- failure records require non-empty normalized `failure_fingerprint` values
+- initial recurrence grouping uses strict equality on the normalized full fingerprint
+- success records and empty fingerprints are excluded from recurrence grouping
 
-That first slice must not:
+Current guarantees remain unchanged:
 
-- introduce fuzzy matching
-- introduce confidence or provenance semantics
-- reinterpret recurrence as runtime policy significance
-- couple historical recurrence to runtime-control behavior
+- no fuzzy matching
+- no confidence or provenance semantics
+- no reinterpretation of recurrence as runtime policy significance
+- no coupling of historical recurrence to runtime-control behavior
 
 ## Read-Only Memory Rule
 

--- a/Docs/architecture.md
+++ b/Docs/architecture.md
@@ -237,6 +237,42 @@ It should be treated as:
 - a non-authoritative and non-binding intelligence layer
 - a stopping point before any future confidence scoring, broader advisory expansion, or behavior-coupled intelligence work
 
+## v1.8.0 Direction
+
+`v1.8.0` should be treated as a trust-and-validation phase for cross-run historical intelligence.
+
+Its job is not to make Jarvis more behaviorally aggressive or more authoritative.
+Its job is to make the existing historical layer more trustworthy, repeatable, and future-safe before any broader intelligence work is considered.
+
+Official objective:
+
+- validation-first multi-run historical-intelligence infrastructure
+- stronger replay and verification across launches
+- clearer recurrence and provenance semantics built on existing `v1.7.0` boundaries
+- no runtime-control coupling
+- no authority expansion
+
+## v1.8.0 Safest First Revision
+
+The safest first revision for `v1.8.0` is:
+
+- `FB-014` multi-run orchestration regression harness
+
+That first revision should remain:
+
+- tooling and verification focused
+- cross-run and replay oriented
+- isolated from launcher runtime-control behavior
+- sufficient to validate recorder, summarizer, diagnostics-context, and diagnostics-advisory behavior across repeated launches
+
+Explicit non-goals for `v1.8.0` rev1:
+
+- confidence scoring
+- advisory authority expansion
+- historical readback into runtime behavior
+- retry, escalation, threshold, or classification changes
+- boot-level orchestration work
+
 ## Read-Only Memory Rule
 
 Historical memory in `v1.7.0` must remain a derived, read-only layer over `v1.6.0` truth.

--- a/Docs/architecture.md
+++ b/Docs/architecture.md
@@ -331,6 +331,23 @@ Current guarantees remain unchanged:
 
 Taken together, `FB-012` rev2a and rev2b complete the failure fingerprint and recurrence model track for `v1.8.0` without changing runtime policy.
 
+## v1.8.0 Planned Rev3a Provenance-First Advisory Semantics
+
+`FB-013` rev3a should begin as a provenance-first advisory semantics pass, not as surfaced confidence scoring or a broader advisory redesign.
+
+That first advisory slice should:
+
+- explicitly distinguish current-run truth, prior finalized historical context, and advisory inference
+- keep advisory inference non-binding and non-authoritative
+- treat confidence, if mentioned at all in this first slice, as definition-only or internal explanatory metadata rather than surfaced operator-facing output
+
+That first advisory slice must not:
+
+- interpret confidence as severity, urgency, escalation level, recommendation strength, or runtime-policy permission
+- couple advisory semantics to runtime-control behavior
+- expand authority beyond the existing diagnostics-only advisory boundary
+- add historical or advisory content to crash-report or incident-summary truth surfaces
+
 ## Read-Only Memory Rule
 
 Historical memory in `v1.7.0` must remain a derived, read-only layer over `v1.6.0` truth.

--- a/Docs/architecture.md
+++ b/Docs/architecture.md
@@ -290,6 +290,23 @@ Current guarantees remain unchanged:
 - historical context remains non-authoritative
 - advisory output remains non-binding
 
+## v1.8.0 Planned Rev2a Narrow Scope
+
+`FB-012` rev2a should begin as a strict failure-fingerprint contract pass, not as a broader recurrence redesign.
+
+That first slice should:
+
+- formalize the current implemented fingerprint shape using only existing finalized truth surfaces already recorded by the historical layer
+- formalize initial recurrence grouping as strict equality on the normalized full fingerprint
+- exclude success records and empty fingerprints from recurrence grouping
+
+That first slice must not:
+
+- introduce fuzzy matching
+- introduce confidence or provenance semantics
+- reinterpret recurrence as runtime policy significance
+- couple historical recurrence to runtime-control behavior
+
 ## Read-Only Memory Rule
 
 Historical memory in `v1.7.0` must remain a derived, read-only layer over `v1.6.0` truth.

--- a/Docs/architecture.md
+++ b/Docs/architecture.md
@@ -331,22 +331,25 @@ Current guarantees remain unchanged:
 
 Taken together, `FB-012` rev2a and rev2b complete the failure fingerprint and recurrence model track for `v1.8.0` without changing runtime policy.
 
-## v1.8.0 Planned Rev3a Provenance-First Advisory Semantics
+## v1.8.0 Implemented Rev3a Provenance-First Advisory Semantics
 
-`FB-013` rev3a should begin as a provenance-first advisory semantics pass, not as surfaced confidence scoring or a broader advisory redesign.
+`FB-013` rev3a is now implemented as the provenance-first advisory semantics slice for `v1.8.0`.
 
-That first advisory slice should:
+Implemented rev3a state:
 
-- explicitly distinguish current-run truth, prior finalized historical context, and advisory inference
-- keep advisory inference non-binding and non-authoritative
-- treat confidence, if mentioned at all in this first slice, as definition-only or internal explanatory metadata rather than surfaced operator-facing output
+- diagnostics-facing output now explicitly distinguishes current-run truth, prior finalized historical context, and advisory inference
+- advisory inference remains non-binding and non-authoritative
+- confidence remains absent from surfaced operator-facing output in this first slice
+- crash-report and incident-summary truth surfaces remain free of historical or advisory provenance language
 
-That first advisory slice must not:
+Current guarantees remain unchanged:
 
-- interpret confidence as severity, urgency, escalation level, recommendation strength, or runtime-policy permission
-- couple advisory semantics to runtime-control behavior
-- expand authority beyond the existing diagnostics-only advisory boundary
-- add historical or advisory content to crash-report or incident-summary truth surfaces
+- no surfaced confidence scoring
+- no interpretation of confidence as severity, urgency, escalation level, recommendation strength, or runtime-policy permission
+- no coupling of advisory semantics to runtime-control behavior
+- no authority expansion beyond the existing diagnostics-only advisory boundary
+
+`FB-013` remains open after rev3a pending the next narrow decision on whether a definition-only confidence-semantics slice is still needed for `v1.8.0`.
 
 ## Read-Only Memory Rule
 

--- a/Docs/architecture.md
+++ b/Docs/architecture.md
@@ -273,6 +273,23 @@ Explicit non-goals for `v1.8.0` rev1:
 - retry, escalation, threshold, or classification changes
 - boot-level orchestration work
 
+## v1.8.0 Implemented Rev1 Foundation
+
+`FB-014` rev1 is now implemented as the validation-first harness foundation for `v1.8.0`.
+
+Current implemented rev1 foundation:
+
+- rev1a: dormant contained-execution seams in the launcher for isolated log-root control, target-script override, and optional diagnostics or voice no-op seams
+- rev1b: first reusable contained harness runner covering healthy runs, failed runs with no prior history, and failed runs with matching prior failure history
+- rev1c: harness scenario expansion covering varied prior failure history, success-only prior history, malformed history input, and hostile or unreadable history storage fallback
+
+Current guarantees remain unchanged:
+
+- harness execution remains external validation tooling rather than runtime-control behavior
+- launcher and runtime behavior remain unchanged in production mode when seams are unset
+- historical context remains non-authoritative
+- advisory output remains non-binding
+
 ## Read-Only Memory Rule
 
 Historical memory in `v1.7.0` must remain a derived, read-only layer over `v1.6.0` truth.

--- a/Docs/architecture.md
+++ b/Docs/architecture.md
@@ -351,6 +351,23 @@ Current guarantees remain unchanged:
 
 `FB-013` remains open after rev3a pending the next narrow decision on whether a definition-only confidence-semantics slice is still needed for `v1.8.0`.
 
+## v1.8.0 Planned Rev3b Internal Confidence Semantics
+
+`FB-013` rev3b should remain a definition-only and internal confidence-semantics pass.
+
+That narrow confidence slice should:
+
+- define confidence only as evidence-directness or evidence-quality for advisory inference
+- keep confidence absent from surfaced operator-facing output
+
+That narrow confidence slice must not:
+
+- interpret confidence as severity, urgency, escalation level, recommendation strength, predictive correctness, runtime-policy permission, or authority over current-run truth
+- couple confidence semantics to runtime-control behavior
+- expand authority beyond the existing diagnostics-only advisory boundary
+- add confidence, historical, or advisory language to crash-report or incident-summary truth surfaces
+- redesign advisory output beyond what is needed to preserve the internal-only confidence boundary
+
 ## Read-Only Memory Rule
 
 Historical memory in `v1.7.0` must remain a derived, read-only layer over `v1.6.0` truth.

--- a/Docs/architecture.md
+++ b/Docs/architecture.md
@@ -309,25 +309,27 @@ Current guarantees remain unchanged:
 - no reinterpretation of recurrence as runtime policy significance
 - no coupling of historical recurrence to runtime-control behavior
 
-## v1.8.0 Planned Rev2b Deterministic Stability Model
+## v1.8.0 Implemented Rev2b Deterministic Stability Model
 
-`FB-012` rev2b should begin as a deterministic recent-history stability-model pass, not as a broader recurrence or advisory redesign.
+`FB-012` rev2b is now implemented as the deterministic recent-history stability-model slice for `v1.8.0`.
 
-That first stability slice should:
+Implemented rev2b state:
 
-- compute stability only from recurrence-eligible finalized failure records
-- use an explicit recent-history window of the most recent `5` eligible finalized failure records
-- treat `stable` as a recent window containing `0` or `1` unique normalized full fingerprints
-- treat `varied` as a recent window containing more than `1` unique normalized full fingerprints
-- exclude success records, empty fingerprints, malformed lines, contract-invalid records, and hostile or unreadable history cases from stability calculations
+- stability is computed only from recurrence-eligible finalized failure records
+- the recent-history window is explicitly the most recent `5` eligible finalized failure records
+- `stable` means a recent window containing `0` or `1` unique normalized full fingerprints
+- `varied` means a recent window containing more than `1` unique normalized full fingerprints
+- success records, empty fingerprints, malformed lines, contract-invalid records, and hostile or unreadable history cases are excluded from stability calculations
 
-That first stability slice must not:
+Current guarantees remain unchanged:
 
-- introduce fuzzy matching
-- introduce confidence or provenance semantics
-- redesign advisory wording
-- reinterpret stability as runtime policy significance
-- couple historical stability to runtime-control behavior
+- no fuzzy matching
+- no confidence or provenance semantics
+- no advisory redesign
+- no reinterpretation of stability as runtime policy significance
+- no coupling of historical stability to runtime-control behavior
+
+Taken together, `FB-012` rev2a and rev2b complete the failure fingerprint and recurrence model track for `v1.8.0` without changing runtime policy.
 
 ## Read-Only Memory Rule
 

--- a/Docs/development_rules.md
+++ b/Docs/development_rules.md
@@ -134,6 +134,8 @@ Important architecture, orchestration, and behavior decisions should be written 
 
 Project docs are part of the source of truth and should be read before planning future revisions.
 
+When using Codex or ChatGPT for project tasks, prefer the structured prompt format in `docs/jarvis_task_template.md` so requests include clear goal, context, evidence, constraints, allowed surfaces, and done-when criteria.
+
 ## Historical Intelligence Rules
 
 Cross-run intelligence must be contract-defined in repo docs before implementation begins.

--- a/Docs/feature_backlog.md
+++ b/Docs/feature_backlog.md
@@ -431,7 +431,7 @@ This is now implemented through `v1.8.0 rev2a` and `v1.8.0 rev2b`, which togethe
 
 ### [ID: FB-013] Advisory provenance and confidence semantics
 
-Status: Deferred  
+Status: Implemented (v1.8.0 rev3a)  
 Priority: Medium  
 Suggested Version: v1.8.0  
 Suggested Revision: rev3  
@@ -461,7 +461,7 @@ Out of Scope:
 - escalation changes
 
 Notes:
-This should remain advisory-only and should follow the validated recurrence model in `v1.8.0`.
+This is now implemented through `v1.8.0 rev3a` as the provenance-first advisory semantics slice, which explicitly distinguishes current-run truth, prior finalized historical context, and advisory inference while keeping advisory wording non-binding, non-authoritative, and free of surfaced confidence scoring. `FB-013` remains open pending the next narrow decision on whether a definition-only confidence-semantics slice is still needed.
 
 ---
 

--- a/Docs/feature_backlog.md
+++ b/Docs/feature_backlog.md
@@ -397,8 +397,8 @@ This contract was defined in repo docs before implementation began and remains t
 
 Status: Deferred  
 Priority: High  
-Suggested Version: v1.7.0  
-Suggested Revision: TBD  
+Suggested Version: v1.8.0  
+Suggested Revision: rev2  
 
 Description:
 Define how the system recognizes recurring outcomes across launches without changing the closed `v1.6.0` runtime classification model.
@@ -425,7 +425,7 @@ Out of Scope:
 - escalation changes
 
 Notes:
-This should build directly on the historical memory contract.
+This should follow the multi-run regression harness in `v1.8.0` and build directly on the historical memory contract.
 
 ---
 
@@ -433,8 +433,8 @@ This should build directly on the historical memory contract.
 
 Status: Deferred  
 Priority: Medium  
-Suggested Version: v1.7.0  
-Suggested Revision: TBD  
+Suggested Version: v1.8.0  
+Suggested Revision: rev3  
 
 Description:
 Define how advisory outputs describe provenance, confidence, and evidence quality without becoming authoritative policy.
@@ -461,7 +461,7 @@ Out of Scope:
 - escalation changes
 
 Notes:
-This should remain advisory-only throughout `v1.7.0`.
+This should remain advisory-only and should follow the validated recurrence model in `v1.8.0`.
 
 ---
 
@@ -469,8 +469,8 @@ This should remain advisory-only throughout `v1.7.0`.
 
 Status: Deferred  
 Priority: Medium  
-Suggested Version: v1.7.0  
-Suggested Revision: TBD  
+Suggested Version: v1.8.0  
+Suggested Revision: rev1  
 
 Description:
 Create a reusable multi-run validation concept for historical-memory, diagnostics-enrichment, and advisory-only orchestration work.
@@ -495,7 +495,7 @@ Out of Scope:
 - UI redesign
 
 Notes:
-This future-proofs `v1.7.0` without reopening `v1.6.0` behavior.
+This is the safest first implementation target for `v1.8.0` and future-proofs the historical-intelligence layer without reopening `v1.6.0` behavior.
 
 ---
 
@@ -503,7 +503,7 @@ This future-proofs `v1.7.0` without reopening `v1.6.0` behavior.
 
 Status: Deferred  
 Priority: Medium  
-Suggested Version: v1.7.0  
+Suggested Version: Post-v1.8.0  
 Suggested Revision: TBD  
 
 Description:
@@ -530,7 +530,7 @@ Out of Scope:
 - launcher behavior changes
 
 Notes:
-This is preparation work only and must not introduce boot-level runtime control in `v1.7.0`.
+This is preparation work only, must not introduce boot-level runtime control, and is not part of the validation-first `v1.8.0` track.
 
 ---
 

--- a/Docs/feature_backlog.md
+++ b/Docs/feature_backlog.md
@@ -467,7 +467,7 @@ This should remain advisory-only and should follow the validated recurrence mode
 
 ### [ID: FB-014] Multi-run orchestration regression harness
 
-Status: Deferred  
+Status: Implemented (v1.8.0 rev1)  
 Priority: Medium  
 Suggested Version: v1.8.0  
 Suggested Revision: rev1  
@@ -495,7 +495,7 @@ Out of Scope:
 - UI redesign
 
 Notes:
-This is the safest first implementation target for `v1.8.0` and future-proofs the historical-intelligence layer without reopening `v1.6.0` behavior.
+This was the safest first implementation target for `v1.8.0` and is now implemented as the validation-first harness foundation through rev1a, rev1b, and rev1c without reopening `v1.6.0` behavior. The next intended implementation track remains `FB-012`.
 
 ---
 

--- a/Docs/feature_backlog.md
+++ b/Docs/feature_backlog.md
@@ -395,7 +395,7 @@ This contract was defined in repo docs before implementation began and remains t
 
 ### [ID: FB-012] Failure fingerprint and recurrence model
 
-Status: Implemented (v1.8.0 rev2a)  
+Status: Implemented (v1.8.0)  
 Priority: High  
 Suggested Version: v1.8.0  
 Suggested Revision: rev2  
@@ -425,7 +425,7 @@ Out of Scope:
 - escalation changes
 
 Notes:
-This now has its first implemented slice in `v1.8.0 rev2a`, which formalized the strict failure-fingerprint contract and strict recurrence equality without reopening `v1.6.0` behavior. The next intended implementation step remains `FB-012 rev2b`.
+This is now implemented through `v1.8.0 rev2a` and `v1.8.0 rev2b`, which together formalized the strict failure-fingerprint contract, strict recurrence equality, and deterministic recent-history stability model without reopening `v1.6.0` behavior. The next intended implementation track remains `FB-013`.
 
 ---
 

--- a/Docs/feature_backlog.md
+++ b/Docs/feature_backlog.md
@@ -395,7 +395,7 @@ This contract was defined in repo docs before implementation began and remains t
 
 ### [ID: FB-012] Failure fingerprint and recurrence model
 
-Status: Deferred  
+Status: Implemented (v1.8.0 rev2a)  
 Priority: High  
 Suggested Version: v1.8.0  
 Suggested Revision: rev2  
@@ -425,7 +425,7 @@ Out of Scope:
 - escalation changes
 
 Notes:
-This should follow the multi-run regression harness in `v1.8.0` and build directly on the historical memory contract.
+This now has its first implemented slice in `v1.8.0 rev2a`, which formalized the strict failure-fingerprint contract and strict recurrence equality without reopening `v1.6.0` behavior. The next intended implementation step remains `FB-012 rev2b`.
 
 ---
 

--- a/Docs/feature_backlog.md
+++ b/Docs/feature_backlog.md
@@ -431,7 +431,7 @@ This is now implemented through `v1.8.0 rev2a` and `v1.8.0 rev2b`, which togethe
 
 ### [ID: FB-013] Advisory provenance and confidence semantics
 
-Status: Implemented (v1.8.0 rev3a)  
+Status: Implemented (v1.8.0)  
 Priority: Medium  
 Suggested Version: v1.8.0  
 Suggested Revision: rev3  
@@ -461,7 +461,7 @@ Out of Scope:
 - escalation changes
 
 Notes:
-This is now implemented through `v1.8.0 rev3a` as the provenance-first advisory semantics slice, which explicitly distinguishes current-run truth, prior finalized historical context, and advisory inference while keeping advisory wording non-binding, non-authoritative, and free of surfaced confidence scoring. `FB-013` remains open pending the next narrow decision on whether a definition-only confidence-semantics slice is still needed.
+This is now implemented through `v1.8.0 rev3a` and `v1.8.0 rev3b`, which together formalized provenance-first advisory semantics and internal-only confidence meaning without introducing surfaced confidence output, runtime coupling, or policy significance. This completes `FB-013` for `v1.8.0`.
 
 ---
 

--- a/Docs/jarvis_task_template.md
+++ b/Docs/jarvis_task_template.md
@@ -1,0 +1,198 @@
+# Jarvis Task Template
+
+You are working inside the Jarvis project as an implementation and analysis partner.
+
+## Authoritative Source of Truth
+
+Treat the following files as authoritative unless a direct verified implementation-state conflict is found:
+
+- C:\Jarvis\docs\development_rules.md
+- C:\Jarvis\docs\architecture.md
+- C:\Jarvis\docs\jarvis_vision.md
+- C:\Jarvis\docs\feature_backlog.md
+- C:\Jarvis\docs\orchestration.md
+- C:\Jarvis\docs\[relevant prior version closeout docs]
+
+If anything in this request conflicts with those docs, call it out explicitly before proceeding.
+
+## Current Project State
+
+Version:
+[fill in version]
+
+Branch:
+[fill in branch]
+
+Task mode:
+[analysis-only / planning-only / docs-only / patch / review / release-workflow]
+
+Default expectation:
+- If task mode is `patch`, perform the change unless blocked by a real conflict.
+- If task mode is `analysis-only`, `planning-only`, or `docs-only`, do not patch.
+
+Current accepted state:
+- [fill in the current version status]
+- [fill in the relevant completed revisions]
+- [fill in the relevant guarantees already established]
+
+## Evidence Inputs
+
+Use the following as part of the task evidence set when relevant:
+- [uploaded files]
+- [logs]
+- [screenshots]
+- [trace output]
+- [manual test notes]
+- [prior verification artifacts]
+
+If critical evidence is missing, say so explicitly.
+
+## Locked Boundaries / Do Not Reopen
+
+Do not casually reopen or "small improve":
+- [locked behavior 1]
+- [locked behavior 2]
+- [locked behavior 3]
+
+If any future version should intentionally change those, treat that as a deliberate new system phase, not a cleanup tweak.
+
+## Task
+
+Your job is to:
+[describe the exact task in one or two sentences]
+
+## Goal
+
+The goal of this task is:
+[describe the concrete desired result]
+
+## Scope
+
+In scope:
+- [scope item 1]
+- [scope item 2]
+- [scope item 3]
+
+Out of scope:
+- [out-of-scope item 1]
+- [out-of-scope item 2]
+- [out-of-scope item 3]
+
+## Allowed Changes
+
+You may change:
+- [allowed file / module / doc 1]
+- [allowed file / module / doc 2]
+
+You may add only if required for the approved scope:
+- [new helper / runner / doc if needed]
+
+## What Must Not Change
+
+Do not change:
+- [file, subsystem, or behavior 1]
+- [file, subsystem, or behavior 2]
+- [file, subsystem, or behavior 3]
+
+## Constraints
+
+Follow these strictly:
+- analyze first
+- patch second
+- verify exact failure path or behavior before changing logic
+- no blind iteration
+- one fix per revision
+- no regressions
+- minimal isolated changes only
+- preserve architecture boundaries
+- instrument first, patch second
+- keep source-of-truth docs aligned with actual implemented state
+- production behavior must remain unchanged unless explicitly in scope
+
+Additional task-specific constraints:
+- [constraint 1]
+- [constraint 2]
+- [constraint 3]
+
+## Guidance
+
+Operate like a careful senior collaborator, not a narrow worker bee.
+
+That means:
+- validate assumptions against the docs and current repo state
+- choose the narrowest safe implementation
+- call out risks or drift clearly
+- avoid speculative rewrites
+- do not widen scope without justification
+- if the task is too broad, tighten it and explain why
+
+## Required Workflow
+
+Before patching:
+1. Read the source-of-truth docs
+2. Inspect the relevant repo/code state
+3. Inspect the provided evidence inputs
+4. Explain the exact planned scope
+5. Call out any conflicts, risks, or cleaner narrower alternatives
+
+Then:
+1. Perform only the approved narrow change
+2. Verify the result directly
+3. Report what changed and what was verified
+
+## Verification Requirements
+
+At minimum, verify:
+- [verification item 1]
+- [verification item 2]
+- [verification item 3]
+
+If applicable, also verify:
+- healthy path
+- failure path
+- artifact cleanup
+- no regressions in locked behavior
+- no drift outside the allowed surfaces
+
+## Done When
+
+This task is complete only when:
+- [done condition 1]
+- [done condition 2]
+- [done condition 3]
+- no unrelated behavior changed
+- the result stays inside scope
+- verification evidence supports the claimed result
+
+## Stop Conditions
+
+Stop and explicitly report if:
+- source-of-truth docs conflict with the request
+- critical evidence is missing
+- the task would require reopening locked architecture
+- the task is too broad for one revision
+- safe verification is not possible
+
+## Required Output Format
+
+A. Source-of-truth validation result  
+B. Recommended scope / implementation plan  
+C. Files changed or to be changed  
+D. Risks, conflicts, or notable design choices  
+E. Verification summary  
+F. Any doc updates made or why none were needed  
+
+If relevant, also include:  
+G. Commit summary  
+H. Commit description  
+I. PR title  
+J. PR description  
+
+## Important
+
+- Do not write code if this is analysis-only
+- Do not patch files if this is planning-only
+- Do not reopen closed version behavior
+- Do not smuggle in policy or authority changes
+- Do not modify backlog status or add backlog items unless the task explicitly authorizes backlog updates
+- If the task is too broad, tighten it and explain why

--- a/Docs/orchestration.md
+++ b/Docs/orchestration.md
@@ -275,6 +275,19 @@ Not allowed in early `v1.8.0`:
 
 Future `v1.8.0` work may formalize recurrence and provenance semantics only after validation infrastructure is in place.
 
+## v1.8.0 Implemented Rev1 State
+
+`FB-014` rev1 now exists as external validation tooling around the historical-intelligence layer.
+
+Implemented rev1 state:
+
+- rev1a added dormant launcher seams for contained execution without touching the live production logs tree
+- rev1b added the first reusable contained harness runner
+- rev1c expanded that runner to cover baseline prior-history and fallback scenarios
+
+This implemented rev1 state does not alter orchestration behavior.
+It validates the existing recorder, summarizer, diagnostics-context, and diagnostics-advisory surfaces from outside the runtime-control path.
+
 ## Future Expansion (Not Yet Implemented)
 
 Examples of later orchestration topics:

--- a/Docs/orchestration.md
+++ b/Docs/orchestration.md
@@ -248,6 +248,33 @@ No contradictions remain between:
 - diagnostics `TRACE` advisory wording
 - documented version boundaries
 
+## v1.8.0 Validation-First Boundary
+
+`v1.8.0` should begin as a validation-first phase for the historical-intelligence layer introduced in `v1.7.0`.
+
+The safest first target is:
+
+- `FB-014` multi-run orchestration regression harness
+
+Allowed in early `v1.8.0`:
+
+- repeatable multi-run verification of history recording
+- recurrence and fallback validation across repeated launches
+- diagnostics historical-context verification
+- diagnostics advisory-surface verification
+
+Not allowed in early `v1.8.0`:
+
+- retry or escalation changes
+- threshold or classification changes
+- diagnostics-trigger changes
+- confidence scoring
+- broader advisory expansion
+- historical content added to crash-report or incident-summary truth surfaces
+- readback from history into runtime behavior
+
+Future `v1.8.0` work may formalize recurrence and provenance semantics only after validation infrastructure is in place.
+
 ## Future Expansion (Not Yet Implemented)
 
 Examples of later orchestration topics:

--- a/Docs/v1.8.0_closeout.md
+++ b/Docs/v1.8.0_closeout.md
@@ -1,0 +1,141 @@
+# Jarvis v1.8.0 Closeout
+
+## Version
+
+v1.8.0
+
+## Scope
+
+Validation-first trust-and-verification phase for cross-run historical intelligence above the closed `v1.6.0` orchestration layer and the completed `v1.7.0` historical-memory foundation.
+
+---
+
+## What Is Complete
+
+### Multi-Run Validation Foundation
+
+* contained-execution launcher seams for isolated harness runs
+* reusable contained multi-run harness runner
+* scenario expansion across recurrence, stability, and fallback lanes
+
+### Failure Fingerprint and Recurrence Model
+
+* finalized-failure-only fingerprint contract
+* empty fingerprints for success records
+* normalized full-fingerprint equality for recurrence grouping
+* exclusion of success and empty fingerprints from recurrence counting
+
+### Deterministic Stability Model
+
+* recent-history stability computed only from recurrence-eligible finalized failure records
+* explicit recent-history window of 5 eligible finalized failure records
+* deterministic `stable` and `varied` semantics
+* exclusion of malformed, contract-invalid, and hostile-history effects from stability calculations
+
+### Provenance-First Advisory Semantics
+
+* explicit distinction between current-run truth, prior finalized historical context, and advisory inference
+* diagnostics-facing historical context remains derived from prior finalized recorded history only
+* diagnostics-facing advisory inference remains non-binding and non-authoritative
+
+### Internal Confidence Semantics
+
+* internal-only advisory-inference confidence metadata
+* confidence limited to evidence-directness or evidence-quality for advisory inference
+* confidence aligned only with the validated exact-recurrence and varied-history advisory evidence lanes
+* confidence remains absent from surfaced operator-facing output
+
+### Source-of-Truth Alignment
+
+* `FB-014`, `FB-012`, and `FB-013` are recorded as implemented for `v1.8.0`
+* architecture, orchestration, backlog, and version-closeout state are aligned to the completed validation-first track
+
+---
+
+## Current Guarantees
+
+* the launcher remains the source of truth for current-run state
+* harness execution remains external validation tooling rather than runtime-control behavior
+* historical context remains non-authoritative
+* advisory output remains non-binding
+* confidence remains internal-only and absent from surfaced operator-facing output
+* crash reports and incident summaries remain current-run truth surfaces
+* no readback from history, advisory inference, or confidence into runtime behavior
+* no retry, escalation, threshold, classification, diagnostics-trigger, summary-structure, or triage-guidance changes were introduced
+* if history is missing, malformed, unreadable, corrupt, or hostile, behavior degrades cleanly to finalized `v1.6.0` behavior plus existing fail-safe handling
+
+---
+
+## What Is Intentionally Not Implemented
+
+* surfaced confidence scoring or labels
+* fuzzy historical matching
+* authoritative historical ranking
+* advisory-to-control conversion
+* severity, urgency, escalation, or recommendation-strength semantics from confidence
+* historical or advisory content in crash-report or incident-summary truth surfaces
+* retry or escalation redesign
+* boot-level orchestration work
+* support-bundle work
+
+---
+
+## Final Audit Outcome
+
+The implemented `v1.8.0` layer was audited across:
+
+* launcher seams and contained harness behavior
+* runtime logs
+* crash logs
+* history records
+* diagnostics `TRACE` historical-context and advisory wording
+* internal confidence boundaries
+* source-of-truth docs and backlog state
+
+No contradictions remain across those surfaces.
+
+Observed version-level behavior is consistent:
+
+* current-run truth remains in runtime and crash-report summary surfaces
+* cross-run recurrence and stability semantics are deterministic and bounded
+* historical context remains explicitly derived from prior finalized history
+* advisory inference remains explicitly non-binding and non-authoritative
+* confidence remains internal-only and does not appear in surfaced operator-facing output
+
+---
+
+## Verified Scenarios
+
+* healthy run with no historical or advisory output
+* failed run with no prior history
+* failed run with matching prior finalized failure history
+* failed run with varied recent prior finalized failure history
+* failed run with success-only prior history
+* failed run with stable recent-window boundary behavior
+* failed run with malformed history input
+* failed run with hostile or unreadable history storage
+* internal advisory-confidence contract probe with no surfaced confidence output
+* diagnostics artifact cleanup after contained verification runs
+
+---
+
+## Verification Notes
+
+* validation was performed using contained launcher runs
+* diagnostics and voice were stubbed during testing
+* runtime, crash, history, diagnostics, and advisory behavior were reviewed together
+* harness verification confirmed the live production logs tree was not modified during contained runs
+* harness verification explicitly checked that confidence tokens do not appear in surfaced output
+* doc and backlog state were checked against the implemented `FB-014`, `FB-012`, and `FB-013` layers
+
+---
+
+## Final Status
+
+v1.8.0 is complete.
+
+No further code changes are required for this version.
+
+This version establishes a validated, deterministic, and non-authoritative cross-run historical-intelligence foundation without changing the closed `v1.6.0` runtime-control model.
+
+The next safe high-level target after `v1.8.0` is post-`v1.8.0` architecture work such as `FB-015`, not launcher-policy tuning.

--- a/desktop/jarvis_desktop_launcher.pyw
+++ b/desktop/jarvis_desktop_launcher.pyw
@@ -46,6 +46,8 @@ CONSECUTIVE_STARTUP_ABORT_THRESHOLD = 2
 CONSECUTIVE_IDENTICAL_CRASH_THRESHOLD = 2
 HISTORY_SCHEMA_VERSION = 1
 HISTORY_STABILITY_WINDOW_SIZE = 5
+ADVISORY_CONFIDENCE_DIRECT_EVIDENCE = "direct_evidence"
+ADVISORY_CONFIDENCE_PATTERN_EVIDENCE = "pattern_evidence"
 
 os.makedirs(LOG_DIR, exist_ok=True)
 
@@ -445,22 +447,37 @@ def summarize_prior_history_for_diagnostics(records, current_failure_fingerprint
     }
 
 
-def select_historical_advisory_hint(prior_history_context):
+def build_historical_advisory_inference(prior_history_context):
     if not prior_history_context.get("history_loaded"):
-        return ""
+        return {}
 
     matching_failure_recurrence = int(prior_history_context.get("matching_failure_recurrence", 0) or 0)
     if matching_failure_recurrence > 0:
-        return format_advisory_inference_line(
-            f"this finalized failure fingerprint has appeared in {matching_failure_recurrence} prior finalized failed run(s)."
-        )
+        return {
+            "message": (
+                f"this finalized failure fingerprint has appeared in {matching_failure_recurrence} "
+                "prior finalized failed run(s)."
+            ),
+            "confidence": ADVISORY_CONFIDENCE_DIRECT_EVIDENCE,
+        }
 
     if (prior_history_context.get("recent_history_stability") or "").strip() == "varied":
-        return format_advisory_inference_line(
-            "recent prior finalized failed runs have been varied, so this run appears within a changing failure history."
-        )
+        return {
+            "message": (
+                "recent prior finalized failed runs have been varied, so this run appears within a changing "
+                "failure history."
+            ),
+            "confidence": ADVISORY_CONFIDENCE_PATTERN_EVIDENCE,
+        }
 
-    return ""
+    return {}
+
+
+def select_historical_advisory_hint(prior_history_context):
+    advisory_inference = build_historical_advisory_inference(prior_history_context)
+    if not advisory_inference:
+        return ""
+    return format_advisory_inference_line(advisory_inference["message"])
 
 
 def build_failure_fingerprint(final_outcome, final_classification, failure_cause="", failure_origin=""):

--- a/desktop/jarvis_desktop_launcher.pyw
+++ b/desktop/jarvis_desktop_launcher.pyw
@@ -82,6 +82,52 @@ def normalize_policy_value(value, prefix=""):
     return " ".join(text.split()).casefold()
 
 
+def build_failure_fingerprint_parts(final_classification, failure_cause="", failure_origin=""):
+    parts = []
+    normalized_classification = normalize_policy_value(final_classification)
+    normalized_cause = normalize_policy_value(failure_cause)
+    normalized_origin = normalize_policy_value(failure_origin, "Failure origin: ")
+
+    if normalized_classification:
+        parts.append(("classification", normalized_classification))
+    if normalized_cause:
+        parts.append(("cause", normalized_cause))
+    if normalized_origin:
+        parts.append(("origin", normalized_origin))
+
+    return parts
+
+
+def normalize_failure_fingerprint_text(failure_fingerprint):
+    text = (failure_fingerprint or "").strip()
+    if not text:
+        return ""
+
+    normalized_parts = []
+    for raw_part in text.split("|"):
+        part = raw_part.strip()
+        if not part or "=" not in part:
+            return ""
+
+        key, raw_value = part.split("=", 1)
+        normalized_key = " ".join(key.split()).casefold()
+        normalized_value = normalize_policy_value(raw_value)
+        if not normalized_key or not normalized_value:
+            return ""
+
+        normalized_parts.append(f"{normalized_key}={normalized_value}")
+
+    return "|".join(normalized_parts)
+
+
+def recurrence_eligible_history_record(record):
+    if not isinstance(record, dict):
+        return False
+    if (record.get("final_outcome") or "").strip() != "FAILURE":
+        return False
+    return bool(normalize_failure_fingerprint_text(record.get("failure_fingerprint")))
+
+
 def repeated_identical_crash(previous_cause, previous_origin, current_cause, current_origin):
     if not previous_cause or not current_cause:
         return False
@@ -260,6 +306,14 @@ def validate_history_record(record):
     if record.get("final_outcome") not in {"SUCCESS", "FAILURE"}:
         return "History record final_outcome must be SUCCESS or FAILURE."
 
+    normalized_failure_fingerprint = normalize_failure_fingerprint_text(record.get("failure_fingerprint"))
+    if record.get("final_outcome") == "SUCCESS" and record.get("failure_fingerprint", "").strip():
+        return "History record failure_fingerprint must be empty for SUCCESS."
+    if record.get("final_outcome") == "FAILURE" and not normalized_failure_fingerprint:
+        return "History record failure_fingerprint must be a non-empty normalized fingerprint for FAILURE."
+    if normalized_failure_fingerprint and record.get("failure_fingerprint") != normalized_failure_fingerprint:
+        return "History record failure_fingerprint must already be normalized."
+
     for field_name in required_string_fields:
         field_value = record.get(field_name)
         if not isinstance(field_value, str):
@@ -304,10 +358,15 @@ def load_history_records():
 
 
 def count_history_recurrence(records, failure_fingerprint):
-    fingerprint = (failure_fingerprint or "").strip()
+    fingerprint = normalize_failure_fingerprint_text(failure_fingerprint)
     if not fingerprint:
         return 0
-    return sum(1 for record in records if (record.get("failure_fingerprint") or "").strip() == fingerprint)
+    return sum(
+        1
+        for record in records
+        if recurrence_eligible_history_record(record)
+        and normalize_failure_fingerprint_text(record.get("failure_fingerprint")) == fingerprint
+    )
 
 
 def characterize_history_stability(records):
@@ -341,7 +400,9 @@ def summarize_loaded_history(records):
         }
 
     latest_record = records[-1]
-    latest_failure_fingerprint = (latest_record.get("failure_fingerprint") or "").strip()
+    latest_failure_fingerprint = ""
+    if recurrence_eligible_history_record(latest_record):
+        latest_failure_fingerprint = normalize_failure_fingerprint_text(latest_record.get("failure_fingerprint"))
 
     return {
         "history_loaded": True,
@@ -355,8 +416,7 @@ def summarize_prior_history_for_diagnostics(records, current_failure_fingerprint
     relevant_failure_records = [
         record
         for record in records
-        if (record.get("final_outcome") or "").strip() == "FAILURE"
-        and (record.get("failure_fingerprint") or "").strip()
+        if recurrence_eligible_history_record(record)
     ]
 
     if not relevant_failure_records:
@@ -397,19 +457,14 @@ def build_failure_fingerprint(final_outcome, final_classification, failure_cause
     if final_outcome != "FAILURE":
         return ""
 
-    parts = []
-    normalized_classification = normalize_policy_value(final_classification)
-    normalized_cause = normalize_policy_value(failure_cause)
-    normalized_origin = normalize_policy_value(failure_origin, "Failure origin: ")
-
-    if normalized_classification:
-        parts.append(f"classification={normalized_classification}")
-    if normalized_cause:
-        parts.append(f"cause={normalized_cause}")
-    if normalized_origin:
-        parts.append(f"origin={normalized_origin}")
-
-    return "|".join(parts)
+    return "|".join(
+        f"{key}={value}"
+        for key, value in build_failure_fingerprint_parts(
+            final_classification,
+            failure_cause,
+            failure_origin,
+        )
+    )
 
 
 def build_history_record(

--- a/desktop/jarvis_desktop_launcher.pyw
+++ b/desktop/jarvis_desktop_launcher.pyw
@@ -10,15 +10,30 @@ import datetime
 import platform
 import secrets
 
+
+def env_flag(name):
+    value = (os.environ.get(name) or "").strip().casefold()
+    return value in {"1", "true", "yes", "on"}
+
+
+def env_path_override(name, default_path):
+    value = (os.environ.get(name) or "").strip()
+    return os.path.abspath(value) if value else default_path
+
+
 ROOT_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-TARGET_SCRIPT = os.path.join(ROOT_DIR, "jarvis_desktop_main.py")
-LOG_DIR = os.path.join(ROOT_DIR, "logs")
+DEFAULT_TARGET_SCRIPT = os.path.join(ROOT_DIR, "jarvis_desktop_main.py")
+DEFAULT_LOG_DIR = os.path.join(ROOT_DIR, "logs")
+TARGET_SCRIPT = env_path_override("JARVIS_HARNESS_TARGET_SCRIPT", DEFAULT_TARGET_SCRIPT)
+LOG_DIR = env_path_override("JARVIS_HARNESS_LOG_ROOT", DEFAULT_LOG_DIR)
 CRASH_DIR = os.path.join(LOG_DIR, "crash")
 STATUS_FILE = os.path.join(LOG_DIR, "diagnostics_status.txt")
 STOP_SIGNAL_FILE = os.path.join(LOG_DIR, "diagnostics_stop.signal")
 STARTUP_ABORT_SIGNAL_FILE = os.path.join(LOG_DIR, "renderer_startup_abort.signal")
 DIAGNOSTICS_SCRIPT = os.path.join(os.path.dirname(os.path.abspath(__file__)), "jarvis_diagnostics.pyw")
 VOICE_SCRIPT = os.path.join(ROOT_DIR, "Audio", "jarvis_error_voice.py")
+HARNESS_DISABLE_DIAGNOSTICS = env_flag("JARVIS_HARNESS_DISABLE_DIAGNOSTICS")
+HARNESS_DISABLE_VOICE = env_flag("JARVIS_HARNESS_DISABLE_VOICE")
 
 MAX_RECOVERY_ATTEMPTS = 3
 RECOVERY_COOLDOWN_SECONDS = 1.2
@@ -919,6 +934,11 @@ def crash_log(
 
 
 def launch_diag():
+    if HARNESS_DISABLE_DIAGNOSTICS:
+        runtime("Diagnostics UI launch skipped by harness seam")
+        runtime_event("STATUS", "SKIP", "DIAGNOSTICS_UI", "HARNESS_DISABLED")
+        return None
+
     runtime("Launching diagnostics UI")
     runtime_event("STATUS", "START", "DIAGNOSTICS_UI")
     write_status("TRACE", "Launching diagnostics UI")
@@ -929,6 +949,11 @@ def launch_diag():
 
 
 def speak(spoken_text, display_text=None):
+    if HARNESS_DISABLE_VOICE:
+        runtime(f"VOICE skipped by harness seam: {spoken_text}")
+        runtime_event("VOICE", "SKIP", spoken_text, "HARNESS_DISABLED")
+        return 0
+
     if not os.path.exists(VOICE_SCRIPT):
         runtime(f"Voice script missing: {VOICE_SCRIPT}")
         runtime_event("STATUS", "FAIL", "VOICE_SCRIPT", "MISSING")

--- a/desktop/jarvis_desktop_launcher.pyw
+++ b/desktop/jarvis_desktop_launcher.pyw
@@ -45,6 +45,7 @@ STARTUP_ABORT_CONTROL_FLOW_RESULT = "STARTUP_ABORT"
 CONSECUTIVE_STARTUP_ABORT_THRESHOLD = 2
 CONSECUTIVE_IDENTICAL_CRASH_THRESHOLD = 2
 HISTORY_SCHEMA_VERSION = 1
+HISTORY_STABILITY_WINDOW_SIZE = 5
 
 os.makedirs(LOG_DIR, exist_ok=True)
 
@@ -370,22 +371,22 @@ def count_history_recurrence(records, failure_fingerprint):
 
 
 def characterize_history_stability(records):
-    if not records:
+    recent_records = [
+        record
+        for record in records
+        if recurrence_eligible_history_record(record)
+    ][-HISTORY_STABILITY_WINDOW_SIZE:]
+
+    if not recent_records:
         return "stable"
 
-    recent_records = records[-5:]
-    recent_outcomes = {
-        (record.get("final_outcome") or "").strip()
-        for record in recent_records
-        if (record.get("final_outcome") or "").strip()
-    }
     recent_fingerprints = {
-        (record.get("failure_fingerprint") or "").strip()
+        normalize_failure_fingerprint_text(record.get("failure_fingerprint"))
         for record in recent_records
-        if (record.get("failure_fingerprint") or "").strip()
+        if recurrence_eligible_history_record(record)
     }
 
-    if len(recent_outcomes) <= 1 and len(recent_fingerprints) <= 1:
+    if len(recent_fingerprints) <= 1:
         return "stable"
     return "varied"
 

--- a/desktop/jarvis_desktop_launcher.pyw
+++ b/desktop/jarvis_desktop_launcher.pyw
@@ -83,6 +83,17 @@ def normalize_policy_value(value, prefix=""):
     return " ".join(text.split()).casefold()
 
 
+def format_historical_context_line(message):
+    return f"Historical context (derived from prior finalized recorded history only): {message}"
+
+
+def format_advisory_inference_line(message):
+    return (
+        "Advisory inference (derived from prior finalized history, non-binding, non-authoritative): "
+        f"{message}"
+    )
+
+
 def build_failure_fingerprint_parts(final_classification, failure_cause="", failure_origin=""):
     parts = []
     normalized_classification = normalize_policy_value(final_classification)
@@ -440,14 +451,12 @@ def select_historical_advisory_hint(prior_history_context):
 
     matching_failure_recurrence = int(prior_history_context.get("matching_failure_recurrence", 0) or 0)
     if matching_failure_recurrence > 0:
-        return (
-            "Advisory (historical, non-authoritative): "
+        return format_advisory_inference_line(
             f"this finalized failure fingerprint has appeared in {matching_failure_recurrence} prior finalized failed run(s)."
         )
 
     if (prior_history_context.get("recent_history_stability") or "").strip() == "varied":
-        return (
-            "Advisory (historical, non-authoritative): "
+        return format_advisory_inference_line(
             "recent prior finalized failed runs have been varied, so this run appears within a changing failure history."
         )
 
@@ -1368,11 +1377,15 @@ def main():
         if prior_history_context["matching_failure_recurrence"] > 0:
             write_status(
                 "TRACE",
-                f"Historical context (prior finalized runs only): matching failure fingerprint observed in {prior_history_context['matching_failure_recurrence']} prior run(s).",
+                format_historical_context_line(
+                    f"matching failure fingerprint observed in {prior_history_context['matching_failure_recurrence']} prior run(s)."
+                ),
             )
         write_status(
             "TRACE",
-            f"Historical context (prior finalized runs only): recent recorded failure history stability = {prior_history_context['recent_history_stability']}.",
+            format_historical_context_line(
+                f"recent recorded failure history stability = {prior_history_context['recent_history_stability']}."
+            ),
         )
     historical_advisory_hint = select_historical_advisory_hint(prior_history_context)
     if historical_advisory_hint:

--- a/desktop/jarvis_history_harness_runner.py
+++ b/desktop/jarvis_history_harness_runner.py
@@ -25,6 +25,15 @@ HISTORICAL_ADVISORY_LINE = (
     "Advisory (historical, non-authoritative): "
     "this finalized failure fingerprint has appeared in 1 prior finalized failed run(s)."
 )
+HISTORICAL_CONTEXT_VARIED_LINE = (
+    "Historical context (prior finalized runs only): "
+    "recent recorded failure history stability = varied."
+)
+HISTORICAL_VARIED_ADVISORY_LINE = (
+    "Advisory (historical, non-authoritative): "
+    "recent prior finalized failed runs have been varied, so this run appears within a changing failure history."
+)
+HISTORY_FAILURE_RUNTIME_PREFIX = "Historical recorder failed; continuing without history:"
 
 HEALTHY_RENDERER_SCRIPT = """import sys
 from pathlib import Path
@@ -119,6 +128,10 @@ def write_text(path, text):
     path.write_text(text, encoding="utf-8")
 
 
+def serialize_history_record(record):
+    return json.dumps(record, sort_keys=True)
+
+
 def prepare_workspace(workspace_root, scenario_name):
     scenario_root = workspace_root / scenario_name
     if scenario_root.exists():
@@ -132,8 +145,17 @@ def create_renderer_script(path, script_text):
 
 
 def parse_history_file(path):
-    lines = [line.strip() for line in path.read_text(encoding="utf-8").splitlines() if line.strip()]
-    return lines, [json.loads(line) for line in lines]
+    raw_lines = [line.strip() for line in path.read_text(encoding="utf-8").splitlines() if line.strip()]
+    valid_lines = []
+    records = []
+    for line in raw_lines:
+        try:
+            record = json.loads(line)
+        except Exception:
+            continue
+        valid_lines.append(line)
+        records.append(record)
+    return raw_lines, valid_lines, records
 
 
 def collect_single_file(directory, pattern, required):
@@ -145,11 +167,14 @@ def collect_single_file(directory, pattern, required):
     return matches[0] if matches else None
 
 
-def run_launcher_scenario(scenario_root, renderer_script, seed_history_lines=None):
+def run_launcher_scenario(scenario_root, renderer_script, seed_history_lines=None, precreate_history_directory=False):
     log_root = scenario_root / "logs"
     log_root.mkdir(parents=True, exist_ok=True)
-    if seed_history_lines:
-        write_text(log_root / HISTORY_FILENAME, "\n".join(seed_history_lines) + "\n")
+    history_path = log_root / HISTORY_FILENAME
+    if precreate_history_directory:
+        history_path.mkdir(parents=True, exist_ok=True)
+    elif seed_history_lines:
+        write_text(history_path, "\n".join(seed_history_lines) + "\n")
 
     live_log_snapshot_before = snapshot_live_log_tree()
 
@@ -176,10 +201,13 @@ def run_launcher_scenario(scenario_root, renderer_script, seed_history_lines=Non
     runtime_file = collect_single_file(log_root, "Runtime_*.txt", required=True)
     crash_dir = log_root / "crash"
     crash_file = collect_single_file(crash_dir, "Crash_*.txt", required=False) if crash_dir.exists() else None
-    history_path = log_root / HISTORY_FILENAME
     assert_true(history_path.exists(), f"Missing history file for scenario: {history_path}")
 
-    history_lines, history_records = parse_history_file(history_path)
+    raw_history_lines = []
+    history_lines = []
+    history_records = []
+    if history_path.is_file():
+        raw_history_lines, history_lines, history_records = parse_history_file(history_path)
     runtime_text = runtime_file.read_text(encoding="utf-8")
     crash_text = crash_file.read_text(encoding="utf-8") if crash_file else ""
 
@@ -201,6 +229,8 @@ def run_launcher_scenario(scenario_root, renderer_script, seed_history_lines=Non
         "crash_file": crash_file,
         "crash_text": crash_text,
         "history_path": history_path,
+        "history_is_directory": history_path.is_dir(),
+        "raw_history_lines": raw_history_lines,
         "history_lines": history_lines,
         "history_records": history_records,
         "lingering_paths": lingering_paths,
@@ -266,6 +296,65 @@ def validate_failed_matching_prior(result):
     assert_no_lingering_artifacts(result)
 
 
+def validate_failed_varied_prior(result):
+    assert_true(result["returncode"] == 0, "Varied-prior scenario launcher exit code was not 0.")
+    assert_true(result["crash_file"] is not None, "Varied-prior scenario should produce a crash log.")
+    assert_true(len(result["history_records"]) == 3, "Varied-prior scenario should end with three valid history records.")
+    record = result["history_records"][-1]
+    assert_true(record["final_outcome"] == "FAILURE", "Varied-prior scenario final_outcome must be FAILURE.")
+    assert_true(
+        record["final_classification"] == "CONSECUTIVE_IDENTICAL_CRASH_THRESHOLD_REACHED",
+        "Varied-prior scenario final_classification must reflect the repeated identical crash threshold.",
+    )
+    assert_true(HISTORICAL_CONTEXT_MATCH_LINE not in result["runtime_text"], "Varied-prior scenario should not emit a matching recurrence line.")
+    assert_true(HISTORICAL_CONTEXT_VARIED_LINE in result["runtime_text"], "Varied-prior scenario missing varied historical stability line.")
+    assert_true(HISTORICAL_VARIED_ADVISORY_LINE in result["runtime_text"], "Varied-prior scenario missing varied-history advisory line.")
+    assert_no_historical_output(result["crash_text"])
+    assert_no_lingering_artifacts(result)
+
+
+def validate_failed_success_only_prior(result):
+    assert_true(result["returncode"] == 0, "Success-only-prior scenario launcher exit code was not 0.")
+    assert_true(result["crash_file"] is not None, "Success-only-prior scenario should produce a crash log.")
+    assert_true(len(result["history_records"]) == 2, "Success-only-prior scenario should end with two valid history records.")
+    record = result["history_records"][-1]
+    assert_true(record["final_outcome"] == "FAILURE", "Success-only-prior scenario final_outcome must be FAILURE.")
+    assert_true(
+        record["final_classification"] == "CONSECUTIVE_IDENTICAL_CRASH_THRESHOLD_REACHED",
+        "Success-only-prior scenario final_classification must reflect the repeated identical crash threshold.",
+    )
+    assert_no_historical_output(result["runtime_text"])
+    assert_no_historical_output(result["crash_text"])
+    assert_no_lingering_artifacts(result)
+
+
+def validate_failed_malformed_history(result):
+    assert_true(result["returncode"] == 0, "Malformed-history scenario launcher exit code was not 0.")
+    assert_true(result["crash_file"] is not None, "Malformed-history scenario should produce a crash log.")
+    assert_true(len(result["raw_history_lines"]) > len(result["history_records"]), "Malformed-history scenario should preserve malformed history lines.")
+    assert_true(len(result["history_records"]) == 1, "Malformed-history scenario should end with exactly one valid history record.")
+    record = result["history_records"][-1]
+    assert_true(record["final_outcome"] == "FAILURE", "Malformed-history scenario final_outcome must be FAILURE.")
+    assert_true(
+        record["final_classification"] == "CONSECUTIVE_IDENTICAL_CRASH_THRESHOLD_REACHED",
+        "Malformed-history scenario final_classification must reflect the repeated identical crash threshold.",
+    )
+    assert_no_historical_output(result["runtime_text"])
+    assert_no_historical_output(result["crash_text"])
+    assert_no_lingering_artifacts(result)
+
+
+def validate_failed_hostile_history_storage(result):
+    assert_true(result["returncode"] == 0, "Hostile-history scenario launcher exit code was not 0.")
+    assert_true(result["crash_file"] is not None, "Hostile-history scenario should produce a crash log.")
+    assert_true(result["history_is_directory"], "Hostile-history scenario should leave the history path as a directory.")
+    assert_true(len(result["history_records"]) == 0, "Hostile-history scenario should not produce readable history records.")
+    assert_true(HISTORY_FAILURE_RUNTIME_PREFIX in result["runtime_text"], "Hostile-history scenario missing recorder failure fallback log.")
+    assert_no_historical_output(result["runtime_text"])
+    assert_no_historical_output(result["crash_text"])
+    assert_no_lingering_artifacts(result)
+
+
 def print_result_summary(name, result):
     print(f"{name}: PASS")
     print(f"  workspace: {result['scenario_root']}")
@@ -303,6 +392,77 @@ def main():
     )
     validate_failed_matching_prior(failed_matching_prior_result)
     print_result_summary("failed_matching_prior_history", failed_matching_prior_result)
+
+    base_failure_record = dict(failed_no_history_result["history_records"][0])
+    varied_seed_lines = [
+        serialize_history_record(
+            {
+                **base_failure_record,
+                "run_id": "SEED_VARIED_A",
+                "recorded_at": "2026-03-27T00:00:00Z",
+                "failure_fingerprint": "classification=synthetic-varied-a|cause=synthetic failure a|origin=synthetic/a",
+                "final_classification": "SYNTHETIC_VARIED_A",
+                "end_reason": "SYNTHETIC_VARIED_A",
+            }
+        ),
+        serialize_history_record(
+            {
+                **base_failure_record,
+                "run_id": "SEED_VARIED_B",
+                "recorded_at": "2026-03-27T00:00:01Z",
+                "failure_fingerprint": "classification=synthetic-varied-b|cause=synthetic failure b|origin=synthetic/b",
+                "final_classification": "SYNTHETIC_VARIED_B",
+                "end_reason": "SYNTHETIC_VARIED_B",
+            }
+        ),
+    ]
+
+    failed_varied_prior_root = prepare_workspace(workspace_root, "failed_varied_prior_history")
+    varied_renderer = failed_varied_prior_root / "renderer_failure.py"
+    create_renderer_script(varied_renderer, FAILURE_RENDERER_SCRIPT)
+    failed_varied_prior_result = run_launcher_scenario(
+        failed_varied_prior_root,
+        varied_renderer,
+        seed_history_lines=varied_seed_lines,
+    )
+    validate_failed_varied_prior(failed_varied_prior_result)
+    print_result_summary("failed_varied_prior_history", failed_varied_prior_result)
+
+    failed_success_only_prior_root = prepare_workspace(workspace_root, "failed_success_only_prior_history")
+    success_only_renderer = failed_success_only_prior_root / "renderer_failure.py"
+    create_renderer_script(success_only_renderer, FAILURE_RENDERER_SCRIPT)
+    failed_success_only_prior_result = run_launcher_scenario(
+        failed_success_only_prior_root,
+        success_only_renderer,
+        seed_history_lines=healthy_result["history_lines"],
+    )
+    validate_failed_success_only_prior(failed_success_only_prior_result)
+    print_result_summary("failed_success_only_prior_history", failed_success_only_prior_result)
+
+    failed_malformed_history_root = prepare_workspace(workspace_root, "failed_malformed_history")
+    malformed_renderer = failed_malformed_history_root / "renderer_failure.py"
+    create_renderer_script(malformed_renderer, FAILURE_RENDERER_SCRIPT)
+    failed_malformed_history_result = run_launcher_scenario(
+        failed_malformed_history_root,
+        malformed_renderer,
+        seed_history_lines=[
+            "{not-json",
+            "not a valid json line",
+        ],
+    )
+    validate_failed_malformed_history(failed_malformed_history_result)
+    print_result_summary("failed_malformed_history", failed_malformed_history_result)
+
+    failed_hostile_history_root = prepare_workspace(workspace_root, "failed_hostile_history_storage")
+    hostile_renderer = failed_hostile_history_root / "renderer_failure.py"
+    create_renderer_script(hostile_renderer, FAILURE_RENDERER_SCRIPT)
+    failed_hostile_history_result = run_launcher_scenario(
+        failed_hostile_history_root,
+        hostile_renderer,
+        precreate_history_directory=True,
+    )
+    validate_failed_hostile_history_storage(failed_hostile_history_result)
+    print_result_summary("failed_hostile_history_storage", failed_hostile_history_result)
 
     print(f"Workspace root: {workspace_root}")
     return 0

--- a/desktop/jarvis_history_harness_runner.py
+++ b/desktop/jarvis_history_harness_runner.py
@@ -1,6 +1,7 @@
 import argparse
 import json
 import os
+import runpy
 import shutil
 import subprocess
 import sys
@@ -45,6 +46,11 @@ HISTORICAL_VARIED_ADVISORY_LINE = (
     "recent prior finalized failed runs have been varied, so this run appears within a changing failure history."
 )
 HISTORY_FAILURE_RUNTIME_PREFIX = "Historical recorder failed; continuing without history:"
+FORBIDDEN_CONFIDENCE_SURFACE_TOKENS = (
+    "Confidence:",
+    "direct_evidence",
+    "pattern_evidence",
+)
 
 HEALTHY_RENDERER_SCRIPT = """import sys
 from pathlib import Path
@@ -208,6 +214,33 @@ def resolve_workspace_root(raw_value):
     return workspace_root
 
 
+def load_launcher_probe_namespace(workspace_root):
+    probe_root = workspace_root / "_launcher_confidence_probe"
+    probe_log_root = probe_root / "logs"
+    probe_root.mkdir(parents=True, exist_ok=True)
+
+    env_names = (
+        "JARVIS_HARNESS_LOG_ROOT",
+        "JARVIS_HARNESS_TARGET_SCRIPT",
+        "JARVIS_HARNESS_DISABLE_DIAGNOSTICS",
+        "JARVIS_HARNESS_DISABLE_VOICE",
+    )
+    original_env = {name: os.environ.get(name) for name in env_names}
+    os.environ["JARVIS_HARNESS_LOG_ROOT"] = str(probe_log_root)
+    os.environ["JARVIS_HARNESS_TARGET_SCRIPT"] = str(probe_root / "probe_renderer.py")
+    os.environ["JARVIS_HARNESS_DISABLE_DIAGNOSTICS"] = "1"
+    os.environ["JARVIS_HARNESS_DISABLE_VOICE"] = "1"
+
+    try:
+        return runpy.run_path(str(LAUNCHER_SCRIPT), run_name="jarvis_launcher_probe")
+    finally:
+        for name, value in original_env.items():
+            if value is None:
+                os.environ.pop(name, None)
+            else:
+                os.environ[name] = value
+
+
 def snapshot_live_log_tree():
     if not LIVE_LOG_DIR.exists():
         return {}
@@ -346,6 +379,64 @@ def assert_no_historical_output(text):
     assert_true("Advisory inference (derived from prior finalized history, non-binding, non-authoritative):" not in text, "Unexpected historical advisory output present.")
 
 
+def assert_no_confidence_output(text):
+    for token in FORBIDDEN_CONFIDENCE_SURFACE_TOKENS:
+        assert_true(token not in text, f"Unexpected surfaced confidence output present: {token}")
+
+
+def validate_internal_confidence_contract(workspace_root):
+    namespace = load_launcher_probe_namespace(workspace_root)
+    build_historical_advisory_inference = namespace["build_historical_advisory_inference"]
+    select_historical_advisory_hint = namespace["select_historical_advisory_hint"]
+    direct_confidence = namespace["ADVISORY_CONFIDENCE_DIRECT_EVIDENCE"]
+    pattern_confidence = namespace["ADVISORY_CONFIDENCE_PATTERN_EVIDENCE"]
+
+    direct_context = {
+        "history_loaded": True,
+        "matching_failure_recurrence": 2,
+        "recent_history_stability": "stable",
+    }
+    direct_inference = build_historical_advisory_inference(direct_context)
+    assert_true(direct_inference["confidence"] == direct_confidence, "Exact recurrence advisory should map to direct evidence confidence.")
+    assert_true(
+        select_historical_advisory_hint(direct_context) == historical_advisory_line(2),
+        "Exact recurrence advisory output should remain unchanged while confidence stays internal.",
+    )
+
+    varied_context = {
+        "history_loaded": True,
+        "matching_failure_recurrence": 0,
+        "recent_history_stability": "varied",
+    }
+    varied_inference = build_historical_advisory_inference(varied_context)
+    assert_true(varied_inference["confidence"] == pattern_confidence, "Varied-history advisory should map to pattern evidence confidence.")
+    assert_true(
+        select_historical_advisory_hint(varied_context) == HISTORICAL_VARIED_ADVISORY_LINE,
+        "Varied-history advisory output should remain unchanged while confidence stays internal.",
+    )
+
+    assert_true(
+        build_historical_advisory_inference(
+            {
+                "history_loaded": True,
+                "matching_failure_recurrence": 0,
+                "recent_history_stability": "stable",
+            }
+        ) == {},
+        "Stable no-match history should not produce an advisory inference payload.",
+    )
+    assert_true(
+        build_historical_advisory_inference(
+            {
+                "history_loaded": False,
+                "matching_failure_recurrence": 0,
+                "recent_history_stability": "stable",
+            }
+        ) == {},
+        "History-unloaded context should not produce an advisory inference payload.",
+    )
+
+
 def validate_healthy(result):
     assert_true(result["returncode"] == 0, "Healthy scenario launcher exit code was not 0.")
     assert_true(result["crash_file"] is None, "Healthy scenario should not produce a crash log.")
@@ -357,6 +448,7 @@ def validate_healthy(result):
     assert_failure_fingerprint_contract(record)
     assert_true("STATUS|SUCCESS|LAUNCHER_RUNTIME|NORMAL_EXIT_COMPLETE" in result["runtime_text"], "Healthy scenario missing NORMAL_EXIT_COMPLETE runtime marker.")
     assert_no_historical_output(result["runtime_text"])
+    assert_no_confidence_output(result["runtime_text"])
     assert_no_lingering_artifacts(result)
 
 
@@ -375,6 +467,8 @@ def validate_failed_no_history(result):
     assert_true("STATUS|SUCCESS|LAUNCHER_RUNTIME|FAILURE_FLOW_COMPLETE" in result["runtime_text"], "Failed scenario missing FAILURE_FLOW_COMPLETE marker.")
     assert_no_historical_output(result["runtime_text"])
     assert_no_historical_output(result["crash_text"])
+    assert_no_confidence_output(result["runtime_text"])
+    assert_no_confidence_output(result["crash_text"])
     assert_no_lingering_artifacts(result)
 
 
@@ -395,6 +489,8 @@ def validate_failed_matching_prior(result):
     assert_true(HISTORICAL_CONTEXT_STABILITY_LINE in result["runtime_text"], "Matching-prior scenario missing historical stability context line.")
     assert_true(HISTORICAL_ADVISORY_LINE in result["runtime_text"], "Matching-prior scenario missing historical advisory line.")
     assert_no_historical_output(result["crash_text"])
+    assert_no_confidence_output(result["runtime_text"])
+    assert_no_confidence_output(result["crash_text"])
     assert_no_lingering_artifacts(result)
 
 
@@ -418,6 +514,8 @@ def validate_failed_varied_prior(result):
     assert_true(HISTORICAL_CONTEXT_VARIED_LINE in result["runtime_text"], "Varied-prior scenario missing varied historical stability line.")
     assert_true(HISTORICAL_VARIED_ADVISORY_LINE in result["runtime_text"], "Varied-prior scenario missing varied-history advisory line.")
     assert_no_historical_output(result["crash_text"])
+    assert_no_confidence_output(result["runtime_text"])
+    assert_no_confidence_output(result["crash_text"])
     assert_no_lingering_artifacts(result)
 
 
@@ -435,6 +533,8 @@ def validate_failed_success_only_prior(result):
     assert_failure_fingerprint_contract(record)
     assert_no_historical_output(result["runtime_text"])
     assert_no_historical_output(result["crash_text"])
+    assert_no_confidence_output(result["runtime_text"])
+    assert_no_confidence_output(result["crash_text"])
     assert_no_lingering_artifacts(result)
 
 
@@ -457,6 +557,8 @@ def validate_failed_stable_window_boundary(result):
     assert_true(historical_advisory_line(HISTORY_STABILITY_WINDOW_SIZE) in result["runtime_text"], "Stable-window-boundary scenario missing advisory line for the recent five-record window.")
     assert_true(HISTORICAL_CONTEXT_VARIED_LINE not in result["runtime_text"], "Stable-window-boundary scenario should not emit a varied stability line.")
     assert_no_historical_output(result["crash_text"])
+    assert_no_confidence_output(result["runtime_text"])
+    assert_no_confidence_output(result["crash_text"])
     assert_no_lingering_artifacts(result)
 
 
@@ -475,6 +577,8 @@ def validate_failed_malformed_history(result):
     assert_failure_fingerprint_contract(record)
     assert_no_historical_output(result["runtime_text"])
     assert_no_historical_output(result["crash_text"])
+    assert_no_confidence_output(result["runtime_text"])
+    assert_no_confidence_output(result["crash_text"])
     assert_no_lingering_artifacts(result)
 
 
@@ -486,6 +590,8 @@ def validate_failed_hostile_history_storage(result):
     assert_true(HISTORY_FAILURE_RUNTIME_PREFIX in result["runtime_text"], "Hostile-history scenario missing recorder failure fallback log.")
     assert_no_historical_output(result["runtime_text"])
     assert_no_historical_output(result["crash_text"])
+    assert_no_confidence_output(result["runtime_text"])
+    assert_no_confidence_output(result["crash_text"])
     assert_no_lingering_artifacts(result)
 
 
@@ -501,6 +607,7 @@ def print_result_summary(name, result):
 def main():
     args = parse_args()
     workspace_root = resolve_workspace_root(args.workspace_root)
+    validate_internal_confidence_contract(workspace_root)
 
     healthy_root = prepare_workspace(workspace_root, "healthy_run")
     healthy_renderer = healthy_root / "renderer_ready.py"

--- a/desktop/jarvis_history_harness_runner.py
+++ b/desktop/jarvis_history_harness_runner.py
@@ -12,19 +12,30 @@ ROOT_DIR = Path(__file__).resolve().parents[1]
 LAUNCHER_SCRIPT = Path(__file__).with_name("jarvis_desktop_launcher.pyw")
 LIVE_LOG_DIR = ROOT_DIR / "logs"
 HISTORY_FILENAME = "jarvis_history_v1.jsonl"
+HISTORY_STABILITY_WINDOW_SIZE = 5
 
-HISTORICAL_CONTEXT_MATCH_LINE = (
-    "Historical context (prior finalized runs only): "
-    "matching failure fingerprint observed in 1 prior run(s)."
-)
+def historical_context_match_line(count):
+    return (
+        "Historical context (prior finalized runs only): "
+        f"matching failure fingerprint observed in {count} prior run(s)."
+    )
+
+
 HISTORICAL_CONTEXT_STABILITY_LINE = (
     "Historical context (prior finalized runs only): "
     "recent recorded failure history stability = stable."
 )
-HISTORICAL_ADVISORY_LINE = (
-    "Advisory (historical, non-authoritative): "
-    "this finalized failure fingerprint has appeared in 1 prior finalized failed run(s)."
-)
+
+
+def historical_advisory_line(count):
+    return (
+        "Advisory (historical, non-authoritative): "
+        f"this finalized failure fingerprint has appeared in {count} prior finalized failed run(s)."
+    )
+
+
+HISTORICAL_CONTEXT_MATCH_LINE = historical_context_match_line(1)
+HISTORICAL_ADVISORY_LINE = historical_advisory_line(1)
 HISTORICAL_CONTEXT_VARIED_LINE = (
     "Historical context (prior finalized runs only): "
     "recent recorded failure history stability = varied."
@@ -427,6 +438,28 @@ def validate_failed_success_only_prior(result):
     assert_no_lingering_artifacts(result)
 
 
+def validate_failed_stable_window_boundary(result):
+    assert_true(result["returncode"] == 0, "Stable-window-boundary scenario launcher exit code was not 0.")
+    assert_true(result["crash_file"] is not None, "Stable-window-boundary scenario should produce a crash log.")
+    assert_true(len(result["history_records"]) == 7, "Stable-window-boundary scenario should end with seven valid history records.")
+    record = result["history_records"][-1]
+    assert_true(record["final_outcome"] == "FAILURE", "Stable-window-boundary scenario final_outcome must be FAILURE.")
+    assert_true(
+        record["final_classification"] == "CONSECUTIVE_IDENTICAL_CRASH_THRESHOLD_REACHED",
+        "Stable-window-boundary scenario final_classification must reflect the repeated identical crash threshold.",
+    )
+    assert_failure_fingerprint_contract(record)
+    assert_true(result["history_records"][0]["failure_fingerprint"] != record["failure_fingerprint"], "Oldest seeded failure fingerprint should differ from the final failure fingerprint.")
+    for seeded_record in result["history_records"][1 : HISTORY_STABILITY_WINDOW_SIZE + 1]:
+        assert_true(seeded_record["failure_fingerprint"] == record["failure_fingerprint"], "Most recent seeded failure fingerprints should match the final failure fingerprint.")
+    assert_true(historical_context_match_line(HISTORY_STABILITY_WINDOW_SIZE) in result["runtime_text"], "Stable-window-boundary scenario missing expected recurrence line for the recent five-record window.")
+    assert_true(HISTORICAL_CONTEXT_STABILITY_LINE in result["runtime_text"], "Stable-window-boundary scenario should remain stable across the recent five-record window.")
+    assert_true(historical_advisory_line(HISTORY_STABILITY_WINDOW_SIZE) in result["runtime_text"], "Stable-window-boundary scenario missing advisory line for the recent five-record window.")
+    assert_true(HISTORICAL_CONTEXT_VARIED_LINE not in result["runtime_text"], "Stable-window-boundary scenario should not emit a varied stability line.")
+    assert_no_historical_output(result["crash_text"])
+    assert_no_lingering_artifacts(result)
+
+
 def validate_failed_malformed_history(result):
     assert_true(result["returncode"] == 0, "Malformed-history scenario launcher exit code was not 0.")
     assert_true(result["crash_file"] is not None, "Malformed-history scenario should produce a crash log.")
@@ -541,6 +574,40 @@ def main():
     )
     validate_failed_success_only_prior(failed_success_only_prior_result)
     print_result_summary("failed_success_only_prior_history", failed_success_only_prior_result)
+
+    stable_window_boundary_seed_lines = [
+        serialize_history_record(
+            {
+                **base_failure_record,
+                "run_id": "SEED_WINDOW_OLDEST_DIFFERENT",
+                "recorded_at": "2026-03-27T00:00:02Z",
+                "failure_fingerprint": "classification=synthetic-window-oldest|cause=synthetic oldest failure|origin=synthetic/window-oldest",
+                "final_classification": "SYNTHETIC_WINDOW_OLDEST",
+                "end_reason": "SYNTHETIC_WINDOW_OLDEST",
+            }
+        )
+    ]
+    for index in range(HISTORY_STABILITY_WINDOW_SIZE):
+        stable_window_boundary_seed_lines.append(
+            serialize_history_record(
+                {
+                    **base_failure_record,
+                    "run_id": f"SEED_WINDOW_RECENT_{index + 1}",
+                    "recorded_at": f"2026-03-27T00:00:0{index + 3}Z",
+                }
+            )
+        )
+
+    failed_stable_window_boundary_root = prepare_workspace(workspace_root, "failed_stable_window_boundary")
+    stable_window_renderer = failed_stable_window_boundary_root / "renderer_failure.py"
+    create_renderer_script(stable_window_renderer, FAILURE_RENDERER_SCRIPT)
+    failed_stable_window_boundary_result = run_launcher_scenario(
+        failed_stable_window_boundary_root,
+        stable_window_renderer,
+        seed_history_lines=stable_window_boundary_seed_lines,
+    )
+    validate_failed_stable_window_boundary(failed_stable_window_boundary_result)
+    print_result_summary("failed_stable_window_boundary", failed_stable_window_boundary_result)
 
     failed_malformed_history_root = prepare_workspace(workspace_root, "failed_malformed_history")
     malformed_renderer = failed_malformed_history_root / "renderer_failure.py"

--- a/desktop/jarvis_history_harness_runner.py
+++ b/desktop/jarvis_history_harness_runner.py
@@ -1,0 +1,316 @@
+import argparse
+import json
+import os
+import shutil
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+
+ROOT_DIR = Path(__file__).resolve().parents[1]
+LAUNCHER_SCRIPT = Path(__file__).with_name("jarvis_desktop_launcher.pyw")
+LIVE_LOG_DIR = ROOT_DIR / "logs"
+HISTORY_FILENAME = "jarvis_history_v1.jsonl"
+
+HISTORICAL_CONTEXT_MATCH_LINE = (
+    "Historical context (prior finalized runs only): "
+    "matching failure fingerprint observed in 1 prior run(s)."
+)
+HISTORICAL_CONTEXT_STABILITY_LINE = (
+    "Historical context (prior finalized runs only): "
+    "recent recorded failure history stability = stable."
+)
+HISTORICAL_ADVISORY_LINE = (
+    "Advisory (historical, non-authoritative): "
+    "this finalized failure fingerprint has appeared in 1 prior finalized failed run(s)."
+)
+
+HEALTHY_RENDERER_SCRIPT = """import sys
+from pathlib import Path
+
+runtime_log = ""
+for index, arg in enumerate(sys.argv):
+    if arg == "--runtime-log" and index + 1 < len(sys.argv):
+        runtime_log = sys.argv[index + 1]
+        break
+
+if runtime_log:
+    Path(runtime_log).parent.mkdir(parents=True, exist_ok=True)
+    with open(runtime_log, "a", encoding="utf-8") as handle:
+        handle.write("[00:00:00] RENDERER_MAIN|STARTUP_READY\\n")
+
+raise SystemExit(0)
+"""
+
+FAILURE_RENDERER_SCRIPT = """import sys
+from pathlib import Path
+
+runtime_log = ""
+for index, arg in enumerate(sys.argv):
+    if arg == "--runtime-log" and index + 1 < len(sys.argv):
+        runtime_log = sys.argv[index + 1]
+        break
+
+if runtime_log:
+    Path(runtime_log).parent.mkdir(parents=True, exist_ok=True)
+    with open(runtime_log, "a", encoding="utf-8") as handle:
+        handle.write("[00:00:00] RENDERER_MAIN|STARTUP_READY\\n")
+
+raise RuntimeError("Synthetic renderer failure")
+"""
+
+
+class HarnessAssertionError(RuntimeError):
+    pass
+
+
+def parse_args():
+    parser = argparse.ArgumentParser(description="Contained historical-memory harness runner.")
+    parser.add_argument(
+        "--workspace-root",
+        default="",
+        help="Base directory for contained workspaces. Defaults to a temporary directory outside the live logs tree.",
+    )
+    return parser.parse_args()
+
+
+def is_relative_to(path, parent):
+    try:
+        path.resolve().relative_to(parent.resolve())
+        return True
+    except ValueError:
+        return False
+
+
+def assert_true(condition, message):
+    if not condition:
+        raise HarnessAssertionError(message)
+
+
+def resolve_workspace_root(raw_value):
+    if raw_value:
+        workspace_root = Path(raw_value).resolve()
+        workspace_root.mkdir(parents=True, exist_ok=True)
+    else:
+        workspace_root = Path(tempfile.mkdtemp(prefix="jarvis_fb014_rev1b_")).resolve()
+
+    assert_true(
+        not is_relative_to(workspace_root, LIVE_LOG_DIR),
+        f"Contained workspace root must not be inside the live logs tree: {workspace_root}",
+    )
+    return workspace_root
+
+
+def snapshot_live_log_tree():
+    if not LIVE_LOG_DIR.exists():
+        return {}
+
+    snapshot = {}
+    for path in LIVE_LOG_DIR.rglob("*"):
+        if path.is_file():
+            stat = path.stat()
+            snapshot[str(path.resolve())] = (stat.st_size, stat.st_mtime_ns)
+    return snapshot
+
+
+def write_text(path, text):
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(text, encoding="utf-8")
+
+
+def prepare_workspace(workspace_root, scenario_name):
+    scenario_root = workspace_root / scenario_name
+    if scenario_root.exists():
+        shutil.rmtree(scenario_root)
+    scenario_root.mkdir(parents=True)
+    return scenario_root
+
+
+def create_renderer_script(path, script_text):
+    write_text(path, script_text)
+
+
+def parse_history_file(path):
+    lines = [line.strip() for line in path.read_text(encoding="utf-8").splitlines() if line.strip()]
+    return lines, [json.loads(line) for line in lines]
+
+
+def collect_single_file(directory, pattern, required):
+    matches = sorted(directory.glob(pattern))
+    if required:
+        assert_true(len(matches) == 1, f"Expected exactly one {pattern} in {directory}, found {len(matches)}.")
+        return matches[0]
+    assert_true(len(matches) <= 1, f"Expected at most one {pattern} in {directory}, found {len(matches)}.")
+    return matches[0] if matches else None
+
+
+def run_launcher_scenario(scenario_root, renderer_script, seed_history_lines=None):
+    log_root = scenario_root / "logs"
+    log_root.mkdir(parents=True, exist_ok=True)
+    if seed_history_lines:
+        write_text(log_root / HISTORY_FILENAME, "\n".join(seed_history_lines) + "\n")
+
+    live_log_snapshot_before = snapshot_live_log_tree()
+
+    env = os.environ.copy()
+    env["JARVIS_HARNESS_LOG_ROOT"] = str(log_root)
+    env["JARVIS_HARNESS_TARGET_SCRIPT"] = str(renderer_script)
+    env["JARVIS_HARNESS_DISABLE_DIAGNOSTICS"] = "1"
+    env["JARVIS_HARNESS_DISABLE_VOICE"] = "1"
+
+    result = subprocess.run(
+        [sys.executable, str(LAUNCHER_SCRIPT)],
+        cwd=str(scenario_root),
+        env=env,
+        capture_output=True,
+        text=True,
+    )
+
+    live_log_snapshot_after = snapshot_live_log_tree()
+    assert_true(
+        live_log_snapshot_before == live_log_snapshot_after,
+        "Contained scenario wrote to or modified the live production logs tree.",
+    )
+
+    runtime_file = collect_single_file(log_root, "Runtime_*.txt", required=True)
+    crash_dir = log_root / "crash"
+    crash_file = collect_single_file(crash_dir, "Crash_*.txt", required=False) if crash_dir.exists() else None
+    history_path = log_root / HISTORY_FILENAME
+    assert_true(history_path.exists(), f"Missing history file for scenario: {history_path}")
+
+    history_lines, history_records = parse_history_file(history_path)
+    runtime_text = runtime_file.read_text(encoding="utf-8")
+    crash_text = crash_file.read_text(encoding="utf-8") if crash_file else ""
+
+    lingering_paths = {
+        "diagnostics_status": log_root / "diagnostics_status.txt",
+        "diagnostics_stop": log_root / "diagnostics_stop.signal",
+        "startup_abort": log_root / "renderer_startup_abort.signal",
+    }
+
+    return {
+        "scenario_root": scenario_root,
+        "log_root": log_root,
+        "renderer_script": renderer_script,
+        "returncode": result.returncode,
+        "stdout": result.stdout,
+        "stderr": result.stderr,
+        "runtime_file": runtime_file,
+        "runtime_text": runtime_text,
+        "crash_file": crash_file,
+        "crash_text": crash_text,
+        "history_path": history_path,
+        "history_lines": history_lines,
+        "history_records": history_records,
+        "lingering_paths": lingering_paths,
+    }
+
+
+def assert_no_lingering_artifacts(result):
+    for label, path in result["lingering_paths"].items():
+        assert_true(not path.exists(), f"Lingering {label} artifact detected: {path}")
+
+
+def assert_no_historical_output(text):
+    assert_true("Historical context (prior finalized runs only):" not in text, "Unexpected historical context output present.")
+    assert_true("Advisory (historical, non-authoritative):" not in text, "Unexpected historical advisory output present.")
+
+
+def validate_healthy(result):
+    assert_true(result["returncode"] == 0, "Healthy scenario launcher exit code was not 0.")
+    assert_true(result["crash_file"] is None, "Healthy scenario should not produce a crash log.")
+    assert_true(len(result["history_records"]) == 1, "Healthy scenario should write exactly one history record.")
+    record = result["history_records"][0]
+    assert_true(record["final_outcome"] == "SUCCESS", "Healthy scenario history final_outcome must be SUCCESS.")
+    assert_true(record["final_classification"] == "NORMAL_EXIT_COMPLETE", "Healthy scenario final_classification must be NORMAL_EXIT_COMPLETE.")
+    assert_true(record["attempt_count"] == 1, "Healthy scenario attempt_count must be 1.")
+    assert_true("STATUS|SUCCESS|LAUNCHER_RUNTIME|NORMAL_EXIT_COMPLETE" in result["runtime_text"], "Healthy scenario missing NORMAL_EXIT_COMPLETE runtime marker.")
+    assert_no_historical_output(result["runtime_text"])
+    assert_no_lingering_artifacts(result)
+
+
+def validate_failed_no_history(result):
+    assert_true(result["returncode"] == 0, "Failed scenario launcher exit code was not 0.")
+    assert_true(result["crash_file"] is not None, "Failed scenario should produce a crash log.")
+    assert_true(len(result["history_records"]) == 1, "Failed scenario with no prior history should end with exactly one history record.")
+    record = result["history_records"][0]
+    assert_true(record["final_outcome"] == "FAILURE", "Failed scenario final_outcome must be FAILURE.")
+    assert_true(
+        record["final_classification"] == "CONSECUTIVE_IDENTICAL_CRASH_THRESHOLD_REACHED",
+        "Failed scenario final_classification must reflect the repeated identical crash threshold.",
+    )
+    assert_true(record["attempt_pattern"] == "repeated identical crash", "Failed scenario attempt_pattern drifted from repeated identical crash.")
+    assert_true(bool(record["failure_fingerprint"]), "Failed scenario must record a non-empty failure_fingerprint.")
+    assert_true("STATUS|SUCCESS|LAUNCHER_RUNTIME|FAILURE_FLOW_COMPLETE" in result["runtime_text"], "Failed scenario missing FAILURE_FLOW_COMPLETE marker.")
+    assert_no_historical_output(result["runtime_text"])
+    assert_no_historical_output(result["crash_text"])
+    assert_no_lingering_artifacts(result)
+
+
+def validate_failed_matching_prior(result):
+    assert_true(result["returncode"] == 0, "Matching-prior scenario launcher exit code was not 0.")
+    assert_true(result["crash_file"] is not None, "Matching-prior scenario should produce a crash log.")
+    assert_true(len(result["history_records"]) == 2, "Matching-prior scenario should end with two history records.")
+    record = result["history_records"][-1]
+    assert_true(record["final_outcome"] == "FAILURE", "Matching-prior scenario final_outcome must be FAILURE.")
+    assert_true(
+        record["final_classification"] == "CONSECUTIVE_IDENTICAL_CRASH_THRESHOLD_REACHED",
+        "Matching-prior scenario final_classification must reflect the repeated identical crash threshold.",
+    )
+    assert_true(record["attempt_pattern"] == "repeated identical crash", "Matching-prior scenario attempt_pattern drifted from repeated identical crash.")
+    assert_true(HISTORICAL_CONTEXT_MATCH_LINE in result["runtime_text"], "Matching-prior scenario missing historical recurrence context line.")
+    assert_true(HISTORICAL_CONTEXT_STABILITY_LINE in result["runtime_text"], "Matching-prior scenario missing historical stability context line.")
+    assert_true(HISTORICAL_ADVISORY_LINE in result["runtime_text"], "Matching-prior scenario missing historical advisory line.")
+    assert_no_historical_output(result["crash_text"])
+    assert_no_lingering_artifacts(result)
+
+
+def print_result_summary(name, result):
+    print(f"{name}: PASS")
+    print(f"  workspace: {result['scenario_root']}")
+    print(f"  runtime:   {result['runtime_file']}")
+    if result["crash_file"] is not None:
+        print(f"  crash:     {result['crash_file']}")
+    print(f"  history:   {result['history_path']}")
+
+
+def main():
+    args = parse_args()
+    workspace_root = resolve_workspace_root(args.workspace_root)
+
+    healthy_root = prepare_workspace(workspace_root, "healthy_run")
+    healthy_renderer = healthy_root / "renderer_ready.py"
+    create_renderer_script(healthy_renderer, HEALTHY_RENDERER_SCRIPT)
+    healthy_result = run_launcher_scenario(healthy_root, healthy_renderer)
+    validate_healthy(healthy_result)
+    print_result_summary("healthy_run", healthy_result)
+
+    failed_no_history_root = prepare_workspace(workspace_root, "failed_no_prior_history")
+    failed_renderer = failed_no_history_root / "renderer_failure.py"
+    create_renderer_script(failed_renderer, FAILURE_RENDERER_SCRIPT)
+    failed_no_history_result = run_launcher_scenario(failed_no_history_root, failed_renderer)
+    validate_failed_no_history(failed_no_history_result)
+    print_result_summary("failed_no_prior_history", failed_no_history_result)
+
+    failed_matching_prior_root = prepare_workspace(workspace_root, "failed_matching_prior_history")
+    matching_renderer = failed_matching_prior_root / "renderer_failure.py"
+    create_renderer_script(matching_renderer, FAILURE_RENDERER_SCRIPT)
+    failed_matching_prior_result = run_launcher_scenario(
+        failed_matching_prior_root,
+        matching_renderer,
+        seed_history_lines=failed_no_history_result["history_lines"],
+    )
+    validate_failed_matching_prior(failed_matching_prior_result)
+    print_result_summary("failed_matching_prior_history", failed_matching_prior_result)
+
+    print(f"Workspace root: {workspace_root}")
+    return 0
+
+
+if __name__ == "__main__":
+    try:
+        raise SystemExit(main())
+    except HarnessAssertionError as exc:
+        print(f"FB-014 harness failure: {exc}", file=sys.stderr)
+        raise SystemExit(1)

--- a/desktop/jarvis_history_harness_runner.py
+++ b/desktop/jarvis_history_harness_runner.py
@@ -74,6 +74,92 @@ class HarnessAssertionError(RuntimeError):
     pass
 
 
+def strip_label_prefix(value, prefix):
+    text = (value or "").strip()
+    if text.startswith(prefix):
+        return text[len(prefix):].strip()
+    return text
+
+
+def normalize_policy_value(value, prefix=""):
+    text = strip_label_prefix(value, prefix)
+    return " ".join(text.split()).casefold()
+
+
+def normalize_failure_fingerprint_text(failure_fingerprint):
+    text = (failure_fingerprint or "").strip()
+    if not text:
+        return ""
+
+    normalized_parts = []
+    for raw_part in text.split("|"):
+        part = raw_part.strip()
+        if not part or "=" not in part:
+            return ""
+
+        key, raw_value = part.split("=", 1)
+        normalized_key = " ".join(key.split()).casefold()
+        normalized_value = normalize_policy_value(raw_value)
+        if not normalized_key or not normalized_value:
+            return ""
+
+        normalized_parts.append(f"{normalized_key}={normalized_value}")
+
+    return "|".join(normalized_parts)
+
+
+def parse_failure_fingerprint(failure_fingerprint):
+    components = {}
+    normalized = normalize_failure_fingerprint_text(failure_fingerprint)
+    if not normalized:
+        return components
+
+    for part in normalized.split("|"):
+        key, value = part.split("=", 1)
+        components[key] = value
+    return components
+
+
+def replace_failure_fingerprint_component(failure_fingerprint, key, new_value):
+    components = parse_failure_fingerprint(failure_fingerprint)
+    assert_true(bool(components), f"Cannot replace component in invalid failure fingerprint: {failure_fingerprint}")
+    assert_true(key in components, f"Failure fingerprint missing component {key}: {failure_fingerprint}")
+    components[key] = normalize_policy_value(new_value)
+    ordered_keys = ("classification", "cause", "origin")
+    return "|".join(f"{component_key}={components[component_key]}" for component_key in ordered_keys if component_key in components)
+
+
+def is_contract_valid_history_record(record):
+    if not isinstance(record, dict):
+        return False
+
+    final_outcome = (record.get("final_outcome") or "").strip()
+    failure_fingerprint = record.get("failure_fingerprint")
+    if not isinstance(failure_fingerprint, str):
+        return False
+
+    normalized_failure_fingerprint = normalize_failure_fingerprint_text(failure_fingerprint)
+    if final_outcome == "SUCCESS":
+        return failure_fingerprint == ""
+    if final_outcome == "FAILURE":
+        return bool(normalized_failure_fingerprint) and failure_fingerprint == normalized_failure_fingerprint
+    return False
+
+
+def assert_failure_fingerprint_contract(record):
+    fingerprint = record["failure_fingerprint"]
+    if record["final_outcome"] == "SUCCESS":
+        assert_true(fingerprint == "", "SUCCESS history records must keep an empty failure_fingerprint.")
+        return
+
+    normalized_fingerprint = normalize_failure_fingerprint_text(fingerprint)
+    assert_true(bool(normalized_fingerprint), "FAILURE history records must keep a non-empty normalized failure_fingerprint.")
+    assert_true(fingerprint == normalized_fingerprint, "FAILURE history records must keep a normalized failure_fingerprint.")
+    components = parse_failure_fingerprint(fingerprint)
+    assert_true("classification" in components, "FAILURE history fingerprints must include classification.")
+    assert_true(set(components).issubset({"classification", "cause", "origin"}), "FAILURE history fingerprints contain unsupported components.")
+
+
 def parse_args():
     parser = argparse.ArgumentParser(description="Contained historical-memory harness runner.")
     parser.add_argument(
@@ -152,6 +238,8 @@ def parse_history_file(path):
         try:
             record = json.loads(line)
         except Exception:
+            continue
+        if not is_contract_valid_history_record(record):
             continue
         valid_lines.append(line)
         records.append(record)
@@ -255,6 +343,7 @@ def validate_healthy(result):
     assert_true(record["final_outcome"] == "SUCCESS", "Healthy scenario history final_outcome must be SUCCESS.")
     assert_true(record["final_classification"] == "NORMAL_EXIT_COMPLETE", "Healthy scenario final_classification must be NORMAL_EXIT_COMPLETE.")
     assert_true(record["attempt_count"] == 1, "Healthy scenario attempt_count must be 1.")
+    assert_failure_fingerprint_contract(record)
     assert_true("STATUS|SUCCESS|LAUNCHER_RUNTIME|NORMAL_EXIT_COMPLETE" in result["runtime_text"], "Healthy scenario missing NORMAL_EXIT_COMPLETE runtime marker.")
     assert_no_historical_output(result["runtime_text"])
     assert_no_lingering_artifacts(result)
@@ -271,7 +360,7 @@ def validate_failed_no_history(result):
         "Failed scenario final_classification must reflect the repeated identical crash threshold.",
     )
     assert_true(record["attempt_pattern"] == "repeated identical crash", "Failed scenario attempt_pattern drifted from repeated identical crash.")
-    assert_true(bool(record["failure_fingerprint"]), "Failed scenario must record a non-empty failure_fingerprint.")
+    assert_failure_fingerprint_contract(record)
     assert_true("STATUS|SUCCESS|LAUNCHER_RUNTIME|FAILURE_FLOW_COMPLETE" in result["runtime_text"], "Failed scenario missing FAILURE_FLOW_COMPLETE marker.")
     assert_no_historical_output(result["runtime_text"])
     assert_no_historical_output(result["crash_text"])
@@ -289,6 +378,8 @@ def validate_failed_matching_prior(result):
         "Matching-prior scenario final_classification must reflect the repeated identical crash threshold.",
     )
     assert_true(record["attempt_pattern"] == "repeated identical crash", "Matching-prior scenario attempt_pattern drifted from repeated identical crash.")
+    assert_failure_fingerprint_contract(record)
+    assert_true(result["history_records"][0]["failure_fingerprint"] == record["failure_fingerprint"], "Matching-prior scenario must match on the full normalized fingerprint.")
     assert_true(HISTORICAL_CONTEXT_MATCH_LINE in result["runtime_text"], "Matching-prior scenario missing historical recurrence context line.")
     assert_true(HISTORICAL_CONTEXT_STABILITY_LINE in result["runtime_text"], "Matching-prior scenario missing historical stability context line.")
     assert_true(HISTORICAL_ADVISORY_LINE in result["runtime_text"], "Matching-prior scenario missing historical advisory line.")
@@ -306,6 +397,12 @@ def validate_failed_varied_prior(result):
         record["final_classification"] == "CONSECUTIVE_IDENTICAL_CRASH_THRESHOLD_REACHED",
         "Varied-prior scenario final_classification must reflect the repeated identical crash threshold.",
     )
+    assert_failure_fingerprint_contract(record)
+    first_seed_components = parse_failure_fingerprint(result["history_records"][0]["failure_fingerprint"])
+    record_components = parse_failure_fingerprint(record["failure_fingerprint"])
+    assert_true(first_seed_components.get("classification") == record_components.get("classification"), "Varied-prior scenario should keep classification equal for the near-match seed.")
+    assert_true(first_seed_components.get("cause") == record_components.get("cause"), "Varied-prior scenario should keep cause equal for the near-match seed.")
+    assert_true(first_seed_components.get("origin") != record_components.get("origin"), "Varied-prior scenario should differ only by origin for the near-match seed.")
     assert_true(HISTORICAL_CONTEXT_MATCH_LINE not in result["runtime_text"], "Varied-prior scenario should not emit a matching recurrence line.")
     assert_true(HISTORICAL_CONTEXT_VARIED_LINE in result["runtime_text"], "Varied-prior scenario missing varied historical stability line.")
     assert_true(HISTORICAL_VARIED_ADVISORY_LINE in result["runtime_text"], "Varied-prior scenario missing varied-history advisory line.")
@@ -323,6 +420,8 @@ def validate_failed_success_only_prior(result):
         record["final_classification"] == "CONSECUTIVE_IDENTICAL_CRASH_THRESHOLD_REACHED",
         "Success-only-prior scenario final_classification must reflect the repeated identical crash threshold.",
     )
+    assert_failure_fingerprint_contract(result["history_records"][0])
+    assert_failure_fingerprint_contract(record)
     assert_no_historical_output(result["runtime_text"])
     assert_no_historical_output(result["crash_text"])
     assert_no_lingering_artifacts(result)
@@ -339,6 +438,8 @@ def validate_failed_malformed_history(result):
         record["final_classification"] == "CONSECUTIVE_IDENTICAL_CRASH_THRESHOLD_REACHED",
         "Malformed-history scenario final_classification must reflect the repeated identical crash threshold.",
     )
+    assert_true(any('"failure_fingerprint": ""' in line for line in result["raw_history_lines"]), "Malformed-history scenario should seed an empty-fingerprint failure record.")
+    assert_failure_fingerprint_contract(record)
     assert_no_historical_output(result["runtime_text"])
     assert_no_historical_output(result["crash_text"])
     assert_no_lingering_artifacts(result)
@@ -398,11 +499,13 @@ def main():
         serialize_history_record(
             {
                 **base_failure_record,
-                "run_id": "SEED_VARIED_A",
+                "run_id": "SEED_NEAR_MATCH_ORIGIN_ONLY",
                 "recorded_at": "2026-03-27T00:00:00Z",
-                "failure_fingerprint": "classification=synthetic-varied-a|cause=synthetic failure a|origin=synthetic/a",
-                "final_classification": "SYNTHETIC_VARIED_A",
-                "end_reason": "SYNTHETIC_VARIED_A",
+                "failure_fingerprint": replace_failure_fingerprint_component(
+                    base_failure_record["failure_fingerprint"],
+                    "origin",
+                    "synthetic alternate origin",
+                ),
             }
         ),
         serialize_history_record(
@@ -446,6 +549,14 @@ def main():
         failed_malformed_history_root,
         malformed_renderer,
         seed_history_lines=[
+            serialize_history_record(
+                {
+                    **base_failure_record,
+                    "run_id": "SEED_EMPTY_FINGERPRINT",
+                    "recorded_at": "2026-03-27T00:00:02Z",
+                    "failure_fingerprint": "",
+                }
+            ),
             "{not-json",
             "not a valid json line",
         ],

--- a/desktop/jarvis_history_harness_runner.py
+++ b/desktop/jarvis_history_harness_runner.py
@@ -16,20 +16,20 @@ HISTORY_STABILITY_WINDOW_SIZE = 5
 
 def historical_context_match_line(count):
     return (
-        "Historical context (prior finalized runs only): "
+        "Historical context (derived from prior finalized recorded history only): "
         f"matching failure fingerprint observed in {count} prior run(s)."
     )
 
 
 HISTORICAL_CONTEXT_STABILITY_LINE = (
-    "Historical context (prior finalized runs only): "
+    "Historical context (derived from prior finalized recorded history only): "
     "recent recorded failure history stability = stable."
 )
 
 
 def historical_advisory_line(count):
     return (
-        "Advisory (historical, non-authoritative): "
+        "Advisory inference (derived from prior finalized history, non-binding, non-authoritative): "
         f"this finalized failure fingerprint has appeared in {count} prior finalized failed run(s)."
     )
 
@@ -37,11 +37,11 @@ def historical_advisory_line(count):
 HISTORICAL_CONTEXT_MATCH_LINE = historical_context_match_line(1)
 HISTORICAL_ADVISORY_LINE = historical_advisory_line(1)
 HISTORICAL_CONTEXT_VARIED_LINE = (
-    "Historical context (prior finalized runs only): "
+    "Historical context (derived from prior finalized recorded history only): "
     "recent recorded failure history stability = varied."
 )
 HISTORICAL_VARIED_ADVISORY_LINE = (
-    "Advisory (historical, non-authoritative): "
+    "Advisory inference (derived from prior finalized history, non-binding, non-authoritative): "
     "recent prior finalized failed runs have been varied, so this run appears within a changing failure history."
 )
 HISTORY_FAILURE_RUNTIME_PREFIX = "Historical recorder failed; continuing without history:"
@@ -342,8 +342,8 @@ def assert_no_lingering_artifacts(result):
 
 
 def assert_no_historical_output(text):
-    assert_true("Historical context (prior finalized runs only):" not in text, "Unexpected historical context output present.")
-    assert_true("Advisory (historical, non-authoritative):" not in text, "Unexpected historical advisory output present.")
+    assert_true("Historical context (derived from prior finalized recorded history only):" not in text, "Unexpected historical context output present.")
+    assert_true("Advisory inference (derived from prior finalized history, non-binding, non-authoritative):" not in text, "Unexpected historical advisory output present.")
 
 
 def validate_healthy(result):


### PR DESCRIPTION
## Summary

Jarvis v1.8.0 closes the validation-first cross-run historical intelligence phase.

## What Changed

This release includes:
- FB-014 rev1 validation-first multi-run harness foundation
- FB-012 strict fingerprint contract, strict recurrence grouping, and deterministic recent-history stability model
- FB-013 provenance-first advisory semantics and internal-only confidence semantics

Key guarantees preserved:
- no readback into runtime behavior
- no retry, escalation, threshold, classification, or diagnostics-trigger changes
- no summary or triage-guidance changes
- historical context remains non-authoritative
- advisory output remains non-binding
- no surfaced confidence output

This release finalizes the v1.8.0 trust-and-validation track without reopening the closed v1.6.0 orchestration behavior.

This release includes:
- FB-014 rev1 validation-first multi-run harness foundation
- FB-012 strict fingerprint contract, strict recurrence grouping, and deterministic recent-history stability model
- FB-013 provenance-first advisory semantics and internal-only confidence semantics

Key guarantees preserved:
- no readback into runtime behavior
- no retry, escalation, threshold, classification, or diagnostics-trigger changes
- no summary or triage-guidance changes
- historical context remains non-authoritative
- advisory output remains non-binding
- no surfaced confidence output
