### PR TITLE
release/v2.1.0 planning

### DIFF
--- a/Docs/Main.md
+++ b/Docs/Main.md
@@ -72,6 +72,7 @@ These docs are still valid, but they are not part of the default prompt baseline
 - `docs/v1.8.0_closeout.md`
 - `docs/v1.9.0_closeout.md`
 - `docs/v2.0_closeout.md`
+- `docs/post_v2.0_branch_rebaseline.md`
 
 Use them when the task depends on:
 
@@ -79,6 +80,7 @@ Use them when the task depends on:
 - version closeout facts
 - post-closeout sequencing
 - auditing whether later work reopens closed version behavior
+- implemented post-`v2.0` branch truth before a later version closeout exists
 
 ### Retired / Archive Docs
 
@@ -147,6 +149,7 @@ For the first planning prompt after a version closes, prompts should usually inc
 - `docs/Main.md`
 - `docs/codex_modes.md`
 - the latest relevant closeout doc
+- the latest relevant interim rebaseline doc if one exists for the active post-closeout branch
 - the directly relevant canonical planning doc or docs for the next version lane
 
 That first prompt should explicitly answer:

--- a/Docs/boot_access_design.md
+++ b/Docs/boot_access_design.md
@@ -737,12 +737,30 @@ It should not be treated as:
 Consumer setup should stay short, legible, and consumer-friendly.
 Its purpose is to establish initial fit and comfort, not to front-load every future choice.
 
+## Minimum Consumer-Setup First Slice
+
+At planning level, the smallest coherent first consumer-setup slice should include only the minimum broad posture choices needed to avoid an obviously wrong first-run experience:
+
+- an initial presence-posture baseline
+- an initial guidance-posture baseline
+- an initial interaction-posture baseline that keeps typing sufficient and voice optional
+
+This first slice may be satisfied by explicit user choice or by accepting a coherent default posture for those same categories.
+
+This first slice should not require:
+
+- deeper pacing or atmosphere refinement
+- detailed per-surface preference tuning
+- non-essential resident presence refinement for later ordinary use
+- any choice that would force the user to understand trust restoration, recovery posture, or later post-login ownership lanes
+
 ## Consumer Setup Completion And Handoff Contract
 
 At planning level, consumer setup should count as complete once:
 
 - Jarvis has established a coherent initial posture for ordinary use
 - the user has made only the minimum early choices needed for that posture
+- the minimum first-slice posture bundle has been either explicitly chosen or coherently accepted by default
 - the user understands that later preference adjustment remains possible
 - the system can hand off into normal Jarvis use without continuing to behave like an installer or onboarding wizard
 
@@ -758,6 +776,12 @@ The handoff after setup should feel like:
 - Jarvis is now ready for everyday use
 - the user is no longer inside a special onboarding state
 - future adjustment can happen later without replaying the entire setup lane
+
+At planning level, that first handoff into ordinary use includes:
+
+- the chosen initial posture becoming the active everyday starting posture
+- ordinary Jarvis use beginning without reopening setup as an access gate
+- later refinement remaining available only as a future adjacent lane rather than as part of first-slice completion
 
 ## Consumer Setup Relationship To Trust And Recovery Lanes
 

--- a/Docs/boot_access_design.md
+++ b/Docs/boot_access_design.md
@@ -378,6 +378,28 @@ Acceptable routine friction is limited to:
 
 If normal daily use starts to feel like a ritual, the routine path has become too heavy.
 
+## Routine-To-Stronger Trust Boundary
+
+At planning level, Jarvis should stop treating access as routine when doing so would incorrectly frame the current trust posture as ordinary daily continuity.
+
+Routine access remains sufficient when:
+
+- the user is completing ordinary daily entry and Jarvis trust continuity is still normal enough to be treated as routine
+- the trust moment is still just one ordinary daily confirmation rather than trust restoration or recovery-oriented confirmation
+- a future optional routine-path shortcut such as Windows Hello is unavailable, unset, declined, or fails, but the ordinary typed routine path still applies
+
+The stronger path becomes justified when:
+
+- Jarvis should no longer pretend the current trust posture is ordinary daily continuity
+- the trust moment now carries restoration, recovery-oriented confirmation, or clearly non-routine confirmation meaning
+- trust continuity is meaningfully different from normal daily entry even before any future additive stronger-path hardening factor is considered
+
+This boundary clarification does not mean:
+
+- the stronger path becomes the new default daily path
+- routine access should be escalated just because optional routine-path convenience is unavailable
+- the stronger path is defined by future TOTP mechanics rather than by the underlying non-routine trust posture
+
 ## Stronger Path
 
 The stronger path is not for routine daily use.

--- a/Docs/feature_backlog.md
+++ b/Docs/feature_backlog.md
@@ -763,7 +763,7 @@ Rev1 and rev2 are now implemented in code. The current repo truth uses lane-loca
 
 ### [ID: FB-021] Dev-only Boot Jarvis test lane
 
-Status: Deferred (initial launcher and Phase 1 seams implemented; later helper slices remain)  
+Status: Implemented (v2.1.0 rev1)  
 Priority: High  
 Suggested Version: v2.1.0  
 Suggested Revision: rev1  
@@ -775,7 +775,10 @@ Why it matters:
 Boot and transition testing is currently much slower than desktop-path testing unless the repo keeps a narrow internal harness model for `main.py`.
 
 Proposed Change:
-Continue boot-harness work only through narrow dev-only slices such as dedicated boot test launchers, contained repeatability helpers, and an optional monitor-topology preflight helper only if existing runtime evidence remains too ambiguous.
+Implemented model:
+- `main.py` now includes Phase 1 boot-harness seams for boot profile, audio mode, dedicated `dev/logs` runtime roots, structured `BOOT_MAIN|...` milestones, and auto-handoff skip-import support
+- dev-only hidden-window boot launchers now exist under `dev/launchers/` for manual versus auto-handoff and quiet versus voice
+- Boot Jarvis transition work stayed inside the dev-only harness and did not turn `main.py` into a normal product entrypoint
 
 Likely Files Affected:
 - C:/Jarvis/main.py
@@ -785,7 +788,7 @@ Scope:
 - dev-only boot/login harness support
 - faster contained boot-to-desktop repro
 - dedicated dev launchers for the existing boot prompt chain
-- optional later monitor-topology helper only if evidence still proves ambiguous
+- contained boot transition behavior and evidence inside the dev-only harness
 
 Out of Scope:
 - making `main.py` a user-facing launcher
@@ -795,18 +798,20 @@ Out of Scope:
 - Dev Toolkit surfacing in the same slice
 
 Notes:
-Current repo truth already includes:
+This item is now implemented as a reusable dev-only boot test lane.
+Current repo truth also includes later helper follow-through such as:
 
-- a dev-only hidden-window launcher for `main.py` under `dev/launchers/`
-- `main.py` Phase 1 seam support for boot profile, audio mode, dedicated `dev/logs` runtime roots, structured `BOOT_MAIN` markers, and auto-handoff skip-import
+- monitor preflight
+- boot-to-desktop handoff verification
+- transition capture
 
-Later work should stay strictly dev-only and must not blur the line between the boot harness and the normal desktop launch path.
+Those later helper surfaces remain dev-only and still must not blur the line between the boot harness and the normal desktop launch path.
 
 ---
 
 ### [ID: FB-022] Boot & Transition Checks Dev Toolkit surfacing
 
-Status: Deferred  
+Status: Implemented (v2.1.0 rev2)  
 Priority: Medium  
 Suggested Version: v2.1.0  
 Suggested Revision: rev2  
@@ -818,7 +823,16 @@ Why it matters:
 The Dev Toolkit should eventually expose repeatable boot and transition checks without requiring direct file launches, but it should only surface stable helpers rather than inventing them inside the toolkit UI.
 
 Proposed Change:
-Add a new toolkit purpose group plus the first narrow boot lanes such as `Boot Jarvis Manual Flow` and `Boot Jarvis Auto Handoff (Skip Import)`, reusing the existing quiet/voice mode model and lane-local `dev/logs` evidence roots.
+Implemented model:
+- the Dev Toolkit now includes a dedicated `Boot & Transition Checks` purpose group
+- it reuses the existing quiet/voice launch-mode model rather than inventing a separate boot audio system
+- the current surfaced lanes are:
+  - `Boot Jarvis Manual Flow`
+  - `Boot Jarvis Auto Handoff (Skip Import)`
+  - `Boot To Desktop Handoff Verification`
+  - `Boot Transition Capture`
+  - `Boot Monitor Preflight`
+  - `Boot Helper Toolkit Validation`
 
 Likely Files Affected:
 - C:/Jarvis/dev/launchers/jarvis_dev_launcher.pyw
@@ -837,13 +851,21 @@ Out of Scope:
 - desktop launcher policy changes
 
 Notes:
-This should remain sequenced behind `FB-021`. The toolkit should expose stable boot helpers only after the contained boot-harness lane is trustworthy enough to treat as a reusable internal test surface.
+This item is now implemented.
+Later Dev Toolkit follow-through in the same branch also added:
+
+- Toolkit session runtime logging
+- top-level smoke validation in a separate purpose group
+- live background status/progress
+- latest-artifact convenience utilities
+
+Those later QoL additions build on this surfacing rather than changing its core ownership model.
 
 ---
 
 ### [ID: FB-023] Desktop renderer observability gap closure
 
-Status: Deferred  
+Status: Implemented (v2.1.0 rev3)  
 Priority: High  
 Suggested Version: v2.1.0  
 Suggested Revision: rev3  
@@ -855,7 +877,14 @@ Why it matters:
 Current desktop logs cover startup well but remain thinner on page-load failure, desktop-mode attach results, and renderer-side shutdown milestones.
 
 Proposed Change:
-Add a narrow desktop observability patch centered on `desktop/desktop_renderer.py`, with only directly supportive touches in `desktop/jarvis_desktop_main.py` if needed, to emit markers such as visual-page ready versus load failed, desktop-mode enable begin, desktop attach result, and renderer shutdown begin.
+Implemented model:
+- `desktop/desktop_renderer.py` now emits the first narrow renderer-side observability markers for:
+  - visual page ready versus load failed
+  - desktop mode enable begin
+  - desktop attach result
+  - renderer shutdown begin
+- directly supportive WorkerW host-discovery probe evidence then landed to explain a real attach-path blind spot
+- a guarded `Progman` fallback followed as machine-specific host-selection follow-through after the new markers surfaced the failed next-WorkerW assumption
 
 Likely Files Affected:
 - C:/Jarvis/desktop/desktop_renderer.py
@@ -874,7 +903,7 @@ Out of Scope:
 - UI redesign
 
 Notes:
-Current analysis shows this is the highest-value next observability patch because the controlled live desktop path still has larger debugging blind spots than the now-improved boot happy path.
+This item is now implemented as the first coherent desktop renderer observability slice, with directly supportive attach-path follow-through after the newly surfaced evidence showed the old WorkerW selection assumption was wrong on this machine.
 
 ---
 
@@ -910,7 +939,18 @@ Out of Scope:
 - trust or auth behavior changes
 
 Notes:
-This should remain sequenced after `FB-023` unless fresh evidence shows the current boot edge-path gaps are blocking active debugging sooner than the desktop renderer gaps.
+The remaining scope for this item is now narrower than the original wording may imply.
+Current repo truth already includes:
+
+- Phase 1 boot-harness seams in `main.py`
+- structured `BOOT_MAIN|...` milestones across the happy path
+- quiet and auto-handoff skip-import support
+- dev-only boot launchers
+- a more continuous boot-to-desktop handoff
+- helper follow-through such as monitor preflight, handoff verification, transition capture, and boot-helper Toolkit validation
+
+The remaining work is specifically about unhappy-path and edge-path evidence such as invalid prompt loops, rejected yes/no responses, interrupted handoff, and other non-happy-path marker gaps.
+This should remain sequenced after `FB-023` unless fresh evidence shows those remaining edge-path gaps are now blocking debugging sooner than any later desktop follow-through.
 
 ---
 
@@ -946,7 +986,8 @@ Out of Scope:
 - behavior changes
 
 Notes:
-This should wait until later. It is not the highest-value first observability move and should not displace the smaller failure-path marker work in `FB-023` and `FB-024`.
+This remains deferred.
+Current repo truth now already includes first-class `BOOT_MAIN|...` and `RENDERER_MAIN|...` milestone families, so this item is now only about later naming-shape cleanup and cross-lane readability rather than filling missing core marker coverage.
 
 ---
 
@@ -983,7 +1024,15 @@ Out of Scope:
 - automatic issue submission redesign
 
 Notes:
-This should be handled as its own focused Toolkit UX slice rather than being bolted into the current status/progress pass. The existing support-bundle triage helper remains the current route for bundle analysis until this dedicated intake surface is designed cleanly.
+This remains deferred.
+Current repo truth already includes:
+
+- the existing support-bundle triage helper and its Toolkit surfacing
+- Toolkit session logging
+- live status/progress for background lanes
+- latest-artifact convenience utilities
+
+The remaining work is the dedicated lower intake surface itself, not the broader Toolkit foundation around it.
 
 ---
 

--- a/Docs/feature_backlog.md
+++ b/Docs/feature_backlog.md
@@ -908,8 +908,8 @@ This item is now implemented as the first coherent desktop renderer observabilit
 ---
 
 ### [ID: FB-024] Boot harness edge-path observability refinement
-
-Status: Deferred  
+  
+Status: Implemented (v2.1.0 rev4)  
 Priority: Medium  
 Suggested Version: v2.1.0  
 Suggested Revision: rev4  
@@ -921,7 +921,14 @@ Why it matters:
 The current boot harness now records the main happy path well, but unrecognized command loops, invalid import responses, and interrupted shutdown/handoff paths still leave evidence gaps.
 
 Proposed Change:
-Add the smallest boot-harness marker refinement pass in `main.py` for unrecognized commands, invalid yes/no answers, retry loops, handoff signal emission, and boot-side shutdown or exit completion without redesigning the prompt flow.
+Implemented model:
+- `main.py` now emits the remaining narrow boot edge-path markers for:
+  - rejected first-command input
+  - rejected import yes/no input
+  - typed shutdown accepted at command stage 1 or 2
+  - hotkey-triggered shutdown
+  - handoff signal emitted versus dropped
+- the marker pass stayed inside the existing boot harness and did not redesign prompt flow or alter boot behavior
 
 Likely Files Affected:
 - C:/Jarvis/main.py
@@ -939,18 +946,17 @@ Out of Scope:
 - trust or auth behavior changes
 
 Notes:
-The remaining scope for this item is now narrower than the original wording may imply.
-Current repo truth already includes:
-
+ Current repo truth for this item includes:
+  
 - Phase 1 boot-harness seams in `main.py`
 - structured `BOOT_MAIN|...` milestones across the happy path
 - quiet and auto-handoff skip-import support
 - dev-only boot launchers
 - a more continuous boot-to-desktop handoff
 - helper follow-through such as monitor preflight, handoff verification, transition capture, and boot-helper Toolkit validation
+- landed edge-path markers for rejected input, shutdown source, and handoff signal outcome
 
-The remaining work is specifically about unhappy-path and edge-path evidence such as invalid prompt loops, rejected yes/no responses, interrupted handoff, and other non-happy-path marker gaps.
-This should remain sequenced after `FB-023` unless fresh evidence shows those remaining edge-path gaps are now blocking debugging sooner than any later desktop follow-through.
+Later naming cleanup remains deferred under `FB-025`.
 
 ---
 

--- a/Docs/feature_backlog.md
+++ b/Docs/feature_backlog.md
@@ -761,6 +761,195 @@ Rev1 and rev2 are now implemented in code. The current repo truth uses lane-loca
 
 ---
 
+### [ID: FB-021] Dev-only Boot Jarvis test lane
+
+Status: Deferred (initial launcher and Phase 1 seams implemented; later helper slices remain)  
+Priority: High  
+Suggested Version: v2.1.0  
+Suggested Revision: rev1  
+
+Description:
+Build out the dev-only Boot Jarvis test lane around `main.py` so boot/login behavior and the boot-to-desktop transition are faster to reproduce without turning `main.py` into the normal product entrypoint.
+
+Why it matters:
+Boot and transition testing is currently much slower than desktop-path testing unless the repo keeps a narrow internal harness model for `main.py`.
+
+Proposed Change:
+Continue boot-harness work only through narrow dev-only slices such as dedicated boot test launchers, contained repeatability helpers, and an optional monitor-topology preflight helper only if existing runtime evidence remains too ambiguous.
+
+Likely Files Affected:
+- C:/Jarvis/main.py
+- C:/Jarvis/dev/launchers/launch_jarvis_main_*.vbs
+
+Scope:
+- dev-only boot/login harness support
+- faster contained boot-to-desktop repro
+- dedicated dev launchers for the existing boot prompt chain
+- optional later monitor-topology helper only if evidence still proves ambiguous
+
+Out of Scope:
+- making `main.py` a user-facing launcher
+- changing `launch_jarvis_desktop.vbs`
+- trust or auth behavior changes
+- full boot orchestrator implementation
+- Dev Toolkit surfacing in the same slice
+
+Notes:
+Current repo truth already includes:
+
+- a dev-only hidden-window launcher for `main.py` under `dev/launchers/`
+- `main.py` Phase 1 seam support for boot profile, audio mode, dedicated `dev/logs` runtime roots, structured `BOOT_MAIN` markers, and auto-handoff skip-import
+
+Later work should stay strictly dev-only and must not blur the line between the boot harness and the normal desktop launch path.
+
+---
+
+### [ID: FB-022] Boot & Transition Checks Dev Toolkit surfacing
+
+Status: Deferred  
+Priority: Medium  
+Suggested Version: v2.1.0  
+Suggested Revision: rev2  
+
+Description:
+Add a dedicated `Boot & Transition Checks` purpose group to the Dev Toolkit once the boot helper seams and launchers are stable enough to surface safely.
+
+Why it matters:
+The Dev Toolkit should eventually expose repeatable boot and transition checks without requiring direct file launches, but it should only surface stable helpers rather than inventing them inside the toolkit UI.
+
+Proposed Change:
+Add a new toolkit purpose group plus the first narrow boot lanes such as `Boot Jarvis Manual Flow` and `Boot Jarvis Auto Handoff (Skip Import)`, reusing the existing quiet/voice mode model and lane-local `dev/logs` evidence roots.
+
+Likely Files Affected:
+- C:/Jarvis/dev/launchers/jarvis_dev_launcher.pyw
+- C:/Jarvis/dev/launchers/launch_jarvis_main_manual_test*.vbs
+- C:/Jarvis/dev/launchers/launch_jarvis_main_auto_handoff_skip_import*.vbs
+
+Scope:
+- Dev Toolkit purpose grouping for boot checks
+- boot-specific lane surfacing after helper stability
+- reuse of existing quiet versus voice launch-mode patterns
+
+Out of Scope:
+- inventing new boot helper seams inside the toolkit
+- user-facing boot launchers
+- trust or product behavior changes
+- desktop launcher policy changes
+
+Notes:
+This should remain sequenced behind `FB-021`. The toolkit should expose stable boot helpers only after the contained boot-harness lane is trustworthy enough to treat as a reusable internal test surface.
+
+---
+
+### [ID: FB-023] Desktop renderer observability gap closure
+
+Status: Deferred  
+Priority: High  
+Suggested Version: v2.1.0  
+Suggested Revision: rev3  
+
+Description:
+Add the smallest missing renderer-side runtime markers for the controlled desktop path so renderer failures and shutdown behavior are easier to diagnose from logs.
+
+Why it matters:
+Current desktop logs cover startup well but remain thinner on page-load failure, desktop-mode attach results, and renderer-side shutdown milestones.
+
+Proposed Change:
+Add a narrow desktop observability patch centered on `desktop/desktop_renderer.py`, with only directly supportive touches in `desktop/jarvis_desktop_main.py` if needed, to emit markers such as visual-page ready versus load failed, desktop-mode enable begin, desktop attach result, and renderer shutdown begin.
+
+Likely Files Affected:
+- C:/Jarvis/desktop/desktop_renderer.py
+- C:/Jarvis/desktop/jarvis_desktop_main.py
+
+Scope:
+- desktop renderer observability only
+- missing failure-path and shutdown markers
+- improved outcome clarity for the controlled desktop lane
+
+Out of Scope:
+- launcher policy changes
+- boot-harness changes
+- Dev Toolkit work
+- raw verbosity increases
+- UI redesign
+
+Notes:
+Current analysis shows this is the highest-value next observability patch because the controlled live desktop path still has larger debugging blind spots than the now-improved boot happy path.
+
+---
+
+### [ID: FB-024] Boot harness edge-path observability refinement
+
+Status: Deferred  
+Priority: Medium  
+Suggested Version: v2.1.0  
+Suggested Revision: rev4  
+
+Description:
+Fill in the remaining Boot Jarvis edge-path runtime markers so invalid prompt loops and interrupted handoff paths can be diagnosed without inferring behavior from missing happy-path milestones.
+
+Why it matters:
+The current boot harness now records the main happy path well, but unrecognized command loops, invalid import responses, and interrupted shutdown/handoff paths still leave evidence gaps.
+
+Proposed Change:
+Add the smallest boot-harness marker refinement pass in `main.py` for unrecognized commands, invalid yes/no answers, retry loops, handoff signal emission, and boot-side shutdown or exit completion without redesigning the prompt flow.
+
+Likely Files Affected:
+- C:/Jarvis/main.py
+
+Scope:
+- boot-harness milestone refinement only
+- prompt edge-path evidence
+- abnormal exit and interrupted handoff evidence
+
+Out of Scope:
+- prompt copy rewrite
+- monitor preflight helper implementation
+- desktop renderer changes
+- Dev Toolkit surfacing
+- trust or auth behavior changes
+
+Notes:
+This should remain sequenced after `FB-023` unless fresh evidence shows the current boot edge-path gaps are blocking active debugging sooner than the desktop renderer gaps.
+
+---
+
+### [ID: FB-025] Boot and desktop milestone taxonomy clarification
+
+Status: Deferred  
+Priority: Low  
+Suggested Version: v2.1.0  
+Suggested Revision: rev5  
+
+Description:
+Clarify the shared naming shape between `BOOT_MAIN|...` and `RENDERER_MAIN|...` milestone families once both lanes have enough core markers to make cross-lane evidence easier to compare.
+
+Why it matters:
+Boot and desktop ownership should stay separate, but a small later taxonomy pass could make mixed evidence easier to read without collapsing the two lanes into a single logging system.
+
+Proposed Change:
+Do a tiny naming and taxonomy clarification pass only after the core boot and desktop observability gaps are closed, preserving separate lane ownership while aligning milestone shape where that improves diagnostics.
+
+Likely Files Affected:
+- C:/Jarvis/main.py
+- C:/Jarvis/desktop/jarvis_desktop_main.py
+- C:/Jarvis/desktop/desktop_renderer.py
+
+Scope:
+- naming and taxonomy clarification only
+- cross-lane diagnostic readability
+
+Out of Scope:
+- full shared logging contract implementation
+- launcher policy changes
+- raw verbosity increases
+- behavior changes
+
+Notes:
+This should wait until later. It is not the highest-value first observability move and should not displace the smaller failure-path marker work in `FB-023` and `FB-024`.
+
+---
+
 ## Completed Items
 
 Move completed backlog items here for history tracking.

--- a/Docs/feature_backlog.md
+++ b/Docs/feature_backlog.md
@@ -950,6 +950,43 @@ This should wait until later. It is not the highest-value first observability mo
 
 ---
 
+### [ID: FB-026] Dev Toolkit uploaded-bundle intake surface
+
+Status: Deferred  
+Priority: Medium  
+Suggested Version: v2.1.0  
+Suggested Revision: rev6  
+
+Description:
+Add a dedicated bottom-of-toolkit intake surface for user-submitted debug bundles so engineers can pick a zip or extracted folder, see what was received, and route it into the right internal helper without leaving the Dev Toolkit.
+
+Why it matters:
+The current toolkit already has support-bundle triage coverage, but intake still feels fragmented. A small, explicit uploaded-bundle area would make the toolkit feel like a one-stop internal debugging surface instead of a set of separate helper entrypoints.
+
+Proposed Change:
+Add a dedicated `Uploads` or similarly named lower-section panel in the Dev Toolkit that accepts a user-submitted zip or extracted bundle folder, shows the current selected source, and routes that source into the existing support-bundle triage helper or later bundle-specific follow-up helpers.
+
+Likely Files Affected:
+- C:/Jarvis/dev/launchers/jarvis_dev_launcher.pyw
+- C:/Jarvis/dev/jarvis_support_bundle_triage.py
+- directly supportive VBS/helper launcher surfaces only if needed
+
+Scope:
+- dev-only uploaded-bundle intake UI
+- zip and extracted-folder picking
+- clearer one-stop routing into existing bundle-debug helpers
+
+Out of Scope:
+- silent uploads
+- cloud transfer or remote storage
+- product-facing upload UI
+- automatic issue submission redesign
+
+Notes:
+This should be handled as its own focused Toolkit UX slice rather than being bolted into the current status/progress pass. The existing support-bundle triage helper remains the current route for bundle analysis until this dedicated intake surface is designed cleanly.
+
+---
+
 ## Completed Items
 
 Move completed backlog items here for history tracking.

--- a/Docs/post_v2.0_branch_rebaseline.md
+++ b/Docs/post_v2.0_branch_rebaseline.md
@@ -19,7 +19,7 @@ Current branch truth for this rebaseline:
 
 - branch: `feature/v2.1.0-planning`
 - boundary start: `10cd024`
-- current `HEAD`: `b954af7`
+- current `HEAD`: `e14cd53`
 
 When this document conflicts with stale backlog wording from the same workstream, actual code plus commit history is the higher-priority truth.
 
@@ -52,6 +52,14 @@ The branch also added dev-only hidden-window boot launchers under `dev/launchers
 - auto-handoff skip-import voice
 
 Boot-to-desktop handoff behavior was then tightened inside `main.py` so the current transition reads as one continuous Jarvis-controlled flow rather than a visible overlap or a distinct fade-out/fade-in swap.
+
+The later `FB-024` follow-through then closed the remaining narrow boot unhappy-path blind spots in `main.py` by adding explicit markers for:
+
+- rejected first-command input
+- rejected import yes/no input
+- typed shutdown accepted from command stage 1 or 2
+- hotkey-triggered shutdown
+- handoff signal emitted versus dropped
 
 ### Desktop Renderer Observability And Attach Follow-Through
 
@@ -137,21 +145,12 @@ This branch does not close out all later work.
 The following remain deferred:
 
 - broader boot-orchestrator implementation beyond the dev-only harness
-- remaining boot edge-path observability refinement
 - later boot/desktop milestone taxonomy clarification
 - a dedicated Dev Toolkit uploaded-bundle intake surface
 - any full `v2.1` closeout-style version document
 
 ## Doc Sync Implication
 
-The primary doc-sync consequence of this branch is that several backlog items now need implemented-state updates instead of continued deferred wording.
-
-The first sync targets are:
-
-- `FB-021`
-- `FB-022`
-- `FB-023`
-- `FB-024`
-- light truth checks for `FB-025` and `FB-026`
+The current doc-sync consequence of this branch is that backlog truth should now show `FB-021` through `FB-024` as implemented while keeping `FB-025` and `FB-026` deferred.
 
 This rebaseline doc should be used when a task depends on implemented post-`v2.0` branch truth before any later version closeout exists.

--- a/Docs/post_v2.0_branch_rebaseline.md
+++ b/Docs/post_v2.0_branch_rebaseline.md
@@ -1,0 +1,157 @@
+# Jarvis Post-v2.0 Branch Rebaseline
+
+## Purpose
+
+This document records the implemented branch truth for the current post-`v2.0` workstream without treating that work as a version closeout.
+
+It exists to:
+
+- capture the implemented reality of the active `feature/v2.1.0-planning` branch
+- keep future prompts from relying on stale backlog wording alone
+- preserve the historical accuracy of `docs/v2.0_closeout.md`
+- separate implemented branch truth from still-deferred follow-up work
+
+This is an interim rebaseline doc, not a closeout doc.
+
+## Branch Context
+
+Current branch truth for this rebaseline:
+
+- branch: `feature/v2.1.0-planning`
+- boundary start: `10cd024`
+- current `HEAD`: `b954af7`
+
+When this document conflicts with stale backlog wording from the same workstream, actual code plus commit history is the higher-priority truth.
+
+The current architectural boundaries still in force are:
+
+- `main.py` remains the dev-only Boot Jarvis harness
+- `launch_jarvis_desktop.vbs` remains the normal manual user launch
+- the controlled desktop path remains:
+  - `desktop/jarvis_desktop_launcher.pyw`
+  - `desktop/jarvis_desktop_main.py`
+
+## Implemented Workstream Truth
+
+### Boot Harness And Transition Surfaces
+
+The dev-only Boot Jarvis harness now includes a real Phase 1 seam layer in `main.py`:
+
+- `--boot-profile manual|auto_handoff_skip_import`
+- `--audio-mode voice|quiet`
+- dedicated boot evidence roots under `dev/logs`
+- structured `BOOT_MAIN|...` milestones
+- quiet/no-audio behavior inside `main.py`
+- auto-drive for the existing `engage hud -> no` prompt chain
+
+The branch also added dev-only hidden-window boot launchers under `dev/launchers` for:
+
+- manual quiet
+- manual voice
+- auto-handoff skip-import quiet
+- auto-handoff skip-import voice
+
+Boot-to-desktop handoff behavior was then tightened inside `main.py` so the current transition reads as one continuous Jarvis-controlled flow rather than a visible overlap or a distinct fade-out/fade-in swap.
+
+### Desktop Renderer Observability And Attach Follow-Through
+
+The controlled desktop path now has renderer-side runtime evidence for:
+
+- visual page ready versus load failed
+- desktop mode enable begin
+- desktop attach result
+- renderer shutdown begin
+
+Those markers exposed a real desktop attach problem on this machine.
+The branch then added:
+
+- WorkerW discovery probe evidence
+- a guarded `Progman` fallback when the confirmed shell shape is:
+  - `Progman`
+  - direct `SHELLDLL_DefView`
+  - no next WorkerW sibling
+
+That means the current desktop attach path is no longer failing only because the old WorkerW host-selection assumption was wrong on this machine.
+
+### Single-Instance Relaunch Model
+
+Single-instance behavior is now a cooperative relaunch flow rather than a dead-end block.
+
+That flow now includes:
+
+- relaunch-request signaling between instances
+- clean shutdown handling in Boot Jarvis, Desktop Jarvis, and the Dev Toolkit
+- a Jarvis-owned relaunch prompt
+- topmost/focus-stealing prompt behavior
+- surface-specific prompt copy for Boot Jarvis, Desktop Jarvis, and the Dev Toolkit
+- decision-level logging for accept, decline, signal-sent, and wait outcomes
+
+### Dev Toolkit Expansion
+
+The Dev Toolkit is now a materially broader internal validation surface than the one described in `v2.0_closeout.md`.
+
+Implemented additions in this branch include:
+
+- `Boot & Transition Checks` Toolkit surfacing
+- Dev Toolkit session runtime logging under `dev/logs/dev_toolkit_session`
+- boot monitor preflight
+- boot-to-desktop handoff verification
+- boot transition capture
+- boot-helper Toolkit validation
+- desktop-helper Toolkit validation
+- top-level Dev Toolkit smoke validation
+- live background-lane status and progress reporting
+- latest smoke-report and latest transition-capture utilities
+
+These additions build on the delivered `v2.0` Toolkit foundation rather than replacing its split-utility and per-run-history model.
+
+## Current Evidence Roots Added Or Expanded
+
+Key branch-era dev evidence roots now include:
+
+- `dev/logs/boot_manual_flow`
+- `dev/logs/boot_auto_handoff_skip_import`
+- `dev/logs/boot_monitor_preflight`
+- `dev/logs/boot_transition_verification`
+- `dev/logs/boot_transition_capture`
+- `dev/logs/boot_toolkit_validation`
+- `dev/logs/desktop_toolkit_validation`
+- `dev/logs/dev_toolkit_session`
+- `dev/logs/dev_toolkit_smoke_validation`
+
+## Current Guarantees
+
+The following truths remain in force after this branch work:
+
+- `main.py` remains dev-only and root-owned
+- `launch_jarvis_desktop.vbs` remains the normal manual user launch path
+- the controlled desktop path is still launcher-owned through `desktop/jarvis_desktop_launcher.pyw` and `desktop/jarvis_desktop_main.py`
+- `docs/v2.0_closeout.md` remains historical closeout truth for `v2.0`
+- `docs/boot_access_design.md` remains the active boot-planning canon
+- `docs/workspace_layout_plan.md` remains the active workspace-planning canon
+
+## Still Deferred After This Rebaseline
+
+This branch does not close out all later work.
+
+The following remain deferred:
+
+- broader boot-orchestrator implementation beyond the dev-only harness
+- remaining boot edge-path observability refinement
+- later boot/desktop milestone taxonomy clarification
+- a dedicated Dev Toolkit uploaded-bundle intake surface
+- any full `v2.1` closeout-style version document
+
+## Doc Sync Implication
+
+The primary doc-sync consequence of this branch is that several backlog items now need implemented-state updates instead of continued deferred wording.
+
+The first sync targets are:
+
+- `FB-021`
+- `FB-022`
+- `FB-023`
+- `FB-024`
+- light truth checks for `FB-025` and `FB-026`
+
+This rebaseline doc should be used when a task depends on implemented post-`v2.0` branch truth before any later version closeout exists.

--- a/desktop/desktop_renderer.py
+++ b/desktop/desktop_renderer.py
@@ -101,9 +101,11 @@ class DesktopJarvisWindow(QWidget):
 
     def _on_load_finished(self, ok):
         if not ok:
+            self._log_event("RENDERER_MAIN|VISUAL_PAGE_LOAD_FAILED")
             return
 
         self._page_ready = True
+        self._log_event("RENDERER_MAIN|VISUAL_PAGE_READY")
         self._apply_pending_visual_state()
         self._apply_pending_voice_level()
 
@@ -132,6 +134,7 @@ class DesktopJarvisWindow(QWidget):
         if self.desktop_mode or self._is_shutting_down:
             return
 
+        self._log_event("RENDERER_MAIN|DESKTOP_MODE_ENABLE_BEGIN")
         self.desktop_mode = True
 
         self.setAttribute(Qt.WA_TransparentForMouseEvents, True)
@@ -141,8 +144,11 @@ class DesktopJarvisWindow(QWidget):
 
         hwnd = int(self.winId())
 
-        attach_window_to_desktop(hwnd)
+        attached = attach_window_to_desktop(hwnd)
         make_window_noninteractive(hwnd)
+        self._log_event(
+            f"RENDERER_MAIN|DESKTOP_ATTACH_RESULT|success={'true' if attached else 'false'}"
+        )
 
         self.lower()
 
@@ -150,6 +156,7 @@ class DesktopJarvisWindow(QWidget):
         if self._is_shutting_down:
             return
 
+        self._log_event("RENDERER_MAIN|RENDERER_SHUTDOWN_BEGIN")
         self._is_shutting_down = True
 
         self.webview.stop()

--- a/desktop/desktop_renderer.py
+++ b/desktop/desktop_renderer.py
@@ -13,14 +13,18 @@ HTTRANSPARENT = -1
 
 
 class DesktopJarvisWindow(QWidget):
-    def __init__(self, screen, visual_html_path: str):
+    def __init__(self, screen, visual_html_path: str, event_logger=None):
         super().__init__()
 
         self.screen_ref = screen
         self.visual_html_path = os.path.abspath(visual_html_path)
+        self.event_logger = event_logger
 
         self.desktop_mode = False
         self._is_shutting_down = False
+        self._page_ready = False
+        self._pending_visual_state = None
+        self._pending_voice_level = None
 
         # Window configuration (Concept 2 test)
         self.setWindowFlags(Qt.FramelessWindowHint | Qt.Tool | Qt.WindowDoesNotAcceptFocus)
@@ -42,6 +46,7 @@ class DesktopJarvisWindow(QWidget):
         self.webview.setFocusPolicy(Qt.NoFocus)
 
         self.webview.page().setBackgroundColor(QColor(0, 0, 0, 0))
+        self.webview.loadFinished.connect(self._on_load_finished)
         self.webview.load(QUrl.fromLocalFile(self.visual_html_path))
 
         root.addWidget(self.webview)
@@ -62,6 +67,57 @@ class DesktopJarvisWindow(QWidget):
 
         if not self.desktop_mode:
             QTimer.singleShot(50, self.enable_desktop_mode)
+
+    def _log_event(self, event):
+        if callable(self.event_logger):
+            try:
+                self.event_logger(event)
+            except Exception:
+                pass
+
+    def _run_javascript(self, script):
+        page = self.webview.page()
+        if page is not None:
+            page.runJavaScript(script)
+
+    def _apply_pending_visual_state(self):
+        if not self._page_ready or self._pending_visual_state is None:
+            return
+
+        state_name = self._pending_visual_state
+        js = f"window.setJarvisState && window.setJarvisState('{state_name}');"
+        self._run_javascript(js)
+        self._log_event(f"RENDERER_MAIN|VISUAL_STATE_APPLIED|state={state_name}")
+        self._pending_visual_state = None
+
+    def _apply_pending_voice_level(self):
+        if not self._page_ready or self._pending_voice_level is None:
+            return
+
+        level = self._pending_voice_level
+        js = f"window.setJarvisVoiceLevel && window.setJarvisVoiceLevel({level:.4f});"
+        self._run_javascript(js)
+        self._pending_voice_level = None
+
+    def _on_load_finished(self, ok):
+        if not ok:
+            return
+
+        self._page_ready = True
+        self._apply_pending_visual_state()
+        self._apply_pending_voice_level()
+
+    def set_visual_state(self, state_name):
+        self._pending_visual_state = state_name
+
+        if self._page_ready:
+            self._apply_pending_visual_state()
+
+    def set_voice_level(self, level):
+        self._pending_voice_level = max(0.0, min(1.0, float(level)))
+
+        if self._page_ready:
+            self._apply_pending_voice_level()
 
     def nativeEvent(self, eventType, message):
         if self.desktop_mode:

--- a/desktop/desktop_renderer.py
+++ b/desktop/desktop_renderer.py
@@ -6,7 +6,11 @@ from PySide6.QtCore import Qt, QTimer, QUrl, QRect
 from PySide6.QtGui import QColor
 from PySide6.QtWebEngineWidgets import QWebEngineView
 
-from .workerw_utils import attach_window_to_desktop, make_window_noninteractive
+from .workerw_utils import (
+    attach_window_to_desktop,
+    get_last_workerw_probe_events,
+    make_window_noninteractive,
+)
 
 WM_NCHITTEST = 0x0084
 HTTRANSPARENT = -1
@@ -149,6 +153,8 @@ class DesktopJarvisWindow(QWidget):
         self._log_event(
             f"RENDERER_MAIN|DESKTOP_ATTACH_RESULT|success={'true' if attached else 'false'}"
         )
+        for probe_event in get_last_workerw_probe_events():
+            self._log_event(f"RENDERER_MAIN|{probe_event}")
 
         self.lower()
 

--- a/desktop/jarvis_desktop_launcher.pyw
+++ b/desktop/jarvis_desktop_launcher.pyw
@@ -10,6 +10,8 @@ import datetime
 import platform
 import secrets
 
+from single_instance import NamedSignal, SingleInstanceGuard, acquire_or_prompt_replace
+
 
 def env_flag(name):
     value = (os.environ.get(name) or "").strip().casefold()
@@ -34,6 +36,10 @@ DIAGNOSTICS_SCRIPT = os.path.join(os.path.dirname(os.path.abspath(__file__)), "j
 VOICE_SCRIPT = os.path.join(ROOT_DIR, "Audio", "jarvis_error_voice.py")
 HARNESS_DISABLE_DIAGNOSTICS = env_flag("JARVIS_HARNESS_DISABLE_DIAGNOSTICS")
 HARNESS_DISABLE_VOICE = env_flag("JARVIS_HARNESS_DISABLE_VOICE")
+RUNTIME_INSTANCE_MUTEX = r"Local\JarvisRuntimeSingletonV1"
+RUNTIME_RELAUNCH_EVENT = r"Local\JarvisRuntimeRelaunchRequestV1"
+runtime_instance_guard = SingleInstanceGuard(RUNTIME_INSTANCE_MUTEX)
+runtime_relaunch_signal = NamedSignal(RUNTIME_RELAUNCH_EVENT)
 
 MAX_RECOVERY_ATTEMPTS = 3
 RECOVERY_COOLDOWN_SECONDS = 1.2
@@ -1179,6 +1185,16 @@ def finalize_failure(
 
 def main():
     run_id = create_run_id()
+    if not acquire_or_prompt_replace(
+        runtime_instance_guard,
+        runtime_relaunch_signal,
+        "Jarvis Already Running",
+        "Jarvis is already running.\n\nDo you want to close the current instance and open a new one?",
+    ):
+        runtime("Launcher start blocked: Jarvis is already running")
+        runtime_event("STATUS", "SKIP", "LAUNCHER_RUNTIME", "ALREADY_RUNNING")
+        return 0
+
     ensure_crash_dir("launcher startup")
     reset_status()
 
@@ -1210,7 +1226,24 @@ def main():
     mixed_failure_pattern_logged = False
     recovery_pipeline_end_reason = "MAX_ATTEMPTS_EXHAUSTED"
 
+    def exit_if_relaunch_requested(phase_label=""):
+        if not runtime_relaunch_signal.consume():
+            return False
+
+        runtime("Launcher relaunch request received")
+        if phase_label:
+            runtime_event("STATUS", "WARNING", "LAUNCHER_RUNTIME", "RELAUNCH_REQUEST_RECEIVED", f"PHASE={phase_label}")
+        else:
+            runtime_event("STATUS", "WARNING", "LAUNCHER_RUNTIME", "RELAUNCH_REQUEST_RECEIVED")
+        delete_file(STOP_SIGNAL_FILE, "launcher relaunch")
+        delete_file(STARTUP_ABORT_SIGNAL_FILE, "launcher relaunch")
+        delete_file(STATUS_FILE, "launcher relaunch")
+        return True
+
     for attempt in range(1, MAX_RECOVERY_ATTEMPTS + 1):
+        if exit_if_relaunch_requested("before_renderer_attempt"):
+            return 0
+
         runtime(f"Renderer launch attempt {attempt}/{MAX_RECOVERY_ATTEMPTS}")
         runtime_event("STATUS", "START", "RECOVERY_ATTEMPT", f"INDEX={attempt}", f"MAX={MAX_RECOVERY_ATTEMPTS}")
         write_status("TRACE", f"Renderer launch attempt {attempt}/{MAX_RECOVERY_ATTEMPTS}")
@@ -1367,6 +1400,9 @@ def main():
 
             time.sleep(RECOVERY_COOLDOWN_SECONDS)
             runtime_event("STATUS", "SUCCESS", "RECOVERY_COOLDOWN", f"INDEX={attempt}")
+
+    if exit_if_relaunch_requested("before_failure_finalization"):
+        return 0
 
     failure_stability = select_failure_stability(
         mixed_failure_pattern_logged,

--- a/desktop/jarvis_desktop_launcher.pyw
+++ b/desktop/jarvis_desktop_launcher.pyw
@@ -617,6 +617,20 @@ def pythonw():
     return alt if os.path.exists(alt) else exe
 
 
+def hidden_window_kwargs():
+    if os.name != "nt":
+        return {}
+
+    startupinfo = subprocess.STARTUPINFO()
+    startupinfo.dwFlags |= subprocess.STARTF_USESHOWWINDOW
+    startupinfo.wShowWindow = 0
+
+    return {
+        "startupinfo": startupinfo,
+        "creationflags": getattr(subprocess, "CREATE_NO_WINDOW", 0),
+    }
+
+
 def runtime(msg):
     ts = datetime.datetime.now().strftime("%H:%M:%S")
     with open(RUNTIME_FILE, "a", encoding="utf-8") as f:
@@ -1032,7 +1046,10 @@ def launch_diag():
     runtime("Launching diagnostics UI")
     runtime_event("STATUS", "START", "DIAGNOSTICS_UI")
     write_status("TRACE", "Launching diagnostics UI")
-    proc = subprocess.Popen([pythonw(), DIAGNOSTICS_SCRIPT, "--runtime-log", RUNTIME_FILE])
+    proc = subprocess.Popen(
+        [pythonw(), DIAGNOSTICS_SCRIPT, "--runtime-log", RUNTIME_FILE],
+        **hidden_window_kwargs(),
+    )
     runtime(f"Diagnostics PID: {proc.pid}")
     runtime_event("STATUS", "SUCCESS", "DIAGNOSTICS_UI", f"PID={proc.pid}")
     return proc
@@ -1063,7 +1080,7 @@ def speak(spoken_text, display_text=None):
         "--stop-signal", STOP_SIGNAL_FILE,
     ]
     runtime(f"VOICE CMD: {' '.join(cmd[2:])}")
-    result = subprocess.run(cmd)
+    result = subprocess.run(cmd, **hidden_window_kwargs())
     runtime(f"VOICE EXIT CODE: {result.returncode} :: {spoken_text}")
     runtime_event("VOICE", "END", spoken_text, f"EXIT={result.returncode}")
     return result.returncode
@@ -1085,6 +1102,7 @@ def run_renderer():
         text=True,
         encoding="utf-8",
         errors="replace",
+        **hidden_window_kwargs(),
     )
     runtime(f"Renderer PID: {proc.pid}")
     runtime_event("STATUS", "SUCCESS", "RENDERER_PROCESS_SPAWN", f"PID={proc.pid}")

--- a/desktop/jarvis_desktop_launcher.pyw
+++ b/desktop/jarvis_desktop_launcher.pyw
@@ -1193,8 +1193,11 @@ def main():
     if not acquire_or_prompt_replace(
         runtime_instance_guard,
         runtime_relaunch_signal,
-        "Jarvis Already Running",
-        "Jarvis is already running.\n\nDo you want to close the current instance and open a new one?",
+        "Jarvis Session Active",
+        "Jarvis is already active on this computer.\n\nDo you want to close the current Jarvis session and relaunch Desktop Jarvis now?",
+        eyebrow_text="DESKTOP JARVIS",
+        primary_button_text="Relaunch Desktop Jarvis",
+        secondary_button_text="Keep Current Session",
         event_logger=log_single_instance_event,
     ):
         runtime("Launcher start blocked: Jarvis is already running")

--- a/desktop/jarvis_desktop_launcher.pyw
+++ b/desktop/jarvis_desktop_launcher.pyw
@@ -1185,11 +1185,17 @@ def finalize_failure(
 
 def main():
     run_id = create_run_id()
+
+    def log_single_instance_event(event):
+        runtime(f"Single-instance flow: {event}")
+        runtime_event("STATUS", "TRACE", "LAUNCHER_RUNTIME", event)
+
     if not acquire_or_prompt_replace(
         runtime_instance_guard,
         runtime_relaunch_signal,
         "Jarvis Already Running",
         "Jarvis is already running.\n\nDo you want to close the current instance and open a new one?",
+        event_logger=log_single_instance_event,
     ):
         runtime("Launcher start blocked: Jarvis is already running")
         runtime_event("STATUS", "SKIP", "LAUNCHER_RUNTIME", "ALREADY_RUNNING")

--- a/desktop/jarvis_desktop_main.py
+++ b/desktop/jarvis_desktop_main.py
@@ -82,7 +82,7 @@ def main():
         return 0
 
     screen = app.primaryScreen()
-    window = DesktopJarvisWindow(screen, visual_html_path)
+    window = DesktopJarvisWindow(screen, visual_html_path, event_logger=runtime_milestone)
     runtime_milestone("RENDERER_MAIN|WINDOW_CONSTRUCTED")
     if exit_if_startup_abort_requested():
         return 0
@@ -113,11 +113,19 @@ def main():
     if exit_if_startup_abort_requested(hotkeys):
         return 0
 
+    def settle_passive_default_handoff():
+        if exit_if_startup_abort_requested(hotkeys):
+            app.quit()
+            return
+        window.set_visual_state("dormant")
+        runtime_milestone("RENDERER_MAIN|PASSIVE_DEFAULT_HANDOFF_REQUESTED|state=dormant")
+
     def mark_startup_ready():
         if exit_if_startup_abort_requested(hotkeys):
             app.quit()
             return
         runtime_milestone("RENDERER_MAIN|STARTUP_READY")
+        settle_passive_default_handoff()
 
     QTimer.singleShot(0, mark_startup_ready)
 

--- a/desktop/jarvis_desktop_main.py
+++ b/desktop/jarvis_desktop_main.py
@@ -13,9 +13,11 @@ from PySide6.QtCore import QTimer
 
 from desktop.desktop_renderer import DesktopJarvisWindow
 from desktop.hotkeys import ShutdownBus, GlobalHotkeyManager
+from desktop.single_instance import NamedSignal
 
 RUNTIME_LOG_FILE = ""
 STARTUP_ABORT_SIGNAL_FILE = ""
+RUNTIME_RELAUNCH_EVENT = r"Local\JarvisRuntimeRelaunchRequestV1"
 
 
 def parse_runtime_log_arg(argv):
@@ -90,14 +92,25 @@ def main():
     bus = ShutdownBus()
     runtime_milestone("RENDERER_MAIN|SHUTDOWN_BUS_READY")
     hotkeys = GlobalHotkeyManager(bus)
+    relaunch_signal = NamedSignal(RUNTIME_RELAUNCH_EVENT)
+    shutdown_started = False
     if exit_if_startup_abort_requested():
         return 0
 
     def do_shutdown():
+        nonlocal shutdown_started
+        if shutdown_started:
+            return
+        shutdown_started = True
         runtime_milestone("RENDERER_MAIN|SHUTDOWN_REQUESTED")
         hotkeys.stop()
         window.request_shutdown()
         QTimer.singleShot(1200, hotkeys.force_kill)
+
+    def poll_relaunch_request():
+        if relaunch_signal.consume():
+            runtime_milestone("RENDERER_MAIN|RELAUNCH_REQUEST_RECEIVED")
+            do_shutdown()
 
     bus.shutdown_requested.connect(do_shutdown)
     hotkeys.start()
@@ -127,9 +140,14 @@ def main():
         runtime_milestone("RENDERER_MAIN|STARTUP_READY")
         settle_passive_default_handoff()
 
+    relaunch_timer = QTimer()
+    relaunch_timer.timeout.connect(poll_relaunch_request)
+    relaunch_timer.start(200)
     QTimer.singleShot(0, mark_startup_ready)
 
     exit_code = app.exec()
+    relaunch_timer.stop()
+    relaunch_signal.close()
     hotkeys.stop()
     runtime_milestone(f"RENDERER_MAIN|EVENT_LOOP_EXIT|code={exit_code}")
     return exit_code

--- a/desktop/single_instance.py
+++ b/desktop/single_instance.py
@@ -1,0 +1,161 @@
+import atexit
+import ctypes
+import time
+from ctypes import wintypes
+
+
+kernel32 = ctypes.windll.kernel32
+user32 = ctypes.windll.user32
+
+CreateMutexW = kernel32.CreateMutexW
+CreateMutexW.argtypes = [wintypes.LPVOID, wintypes.BOOL, wintypes.LPCWSTR]
+CreateMutexW.restype = wintypes.HANDLE
+
+CloseHandle = kernel32.CloseHandle
+CloseHandle.argtypes = [wintypes.HANDLE]
+CloseHandle.restype = wintypes.BOOL
+
+GetLastError = kernel32.GetLastError
+GetLastError.argtypes = []
+GetLastError.restype = wintypes.DWORD
+
+CreateEventW = kernel32.CreateEventW
+CreateEventW.argtypes = [wintypes.LPVOID, wintypes.BOOL, wintypes.BOOL, wintypes.LPCWSTR]
+CreateEventW.restype = wintypes.HANDLE
+
+SetEvent = kernel32.SetEvent
+SetEvent.argtypes = [wintypes.HANDLE]
+SetEvent.restype = wintypes.BOOL
+
+ResetEvent = kernel32.ResetEvent
+ResetEvent.argtypes = [wintypes.HANDLE]
+ResetEvent.restype = wintypes.BOOL
+
+WaitForSingleObject = kernel32.WaitForSingleObject
+WaitForSingleObject.argtypes = [wintypes.HANDLE, wintypes.DWORD]
+WaitForSingleObject.restype = wintypes.DWORD
+
+MessageBoxW = user32.MessageBoxW
+MessageBoxW.argtypes = [wintypes.HWND, wintypes.LPCWSTR, wintypes.LPCWSTR, wintypes.UINT]
+MessageBoxW.restype = ctypes.c_int
+
+ERROR_ALREADY_EXISTS = 183
+MB_OK = 0x00000000
+MB_YESNO = 0x00000004
+MB_ICONINFORMATION = 0x00000040
+MB_ICONQUESTION = 0x00000020
+IDYES = 6
+WAIT_OBJECT_0 = 0
+WAIT_TIMEOUT = 258
+
+
+class SingleInstanceGuard:
+    def __init__(self, mutex_name: str):
+        self.mutex_name = mutex_name
+        self.handle = None
+
+    def acquire(self) -> bool:
+        if self.handle:
+            return True
+
+        handle = CreateMutexW(None, False, self.mutex_name)
+        if not handle:
+            return False
+
+        if GetLastError() == ERROR_ALREADY_EXISTS:
+            CloseHandle(handle)
+            return False
+
+        self.handle = handle
+        atexit.register(self.release)
+        return True
+
+    def release(self) -> None:
+        if self.handle:
+            CloseHandle(self.handle)
+            self.handle = None
+
+
+def show_already_running_dialog(title: str, message: str) -> None:
+    try:
+        MessageBoxW(None, message, title, MB_OK | MB_ICONINFORMATION)
+    except Exception:
+        pass
+
+
+def show_replace_running_dialog(title: str, message: str) -> bool:
+    try:
+        result = MessageBoxW(None, message, title, MB_YESNO | MB_ICONQUESTION)
+        return result == IDYES
+    except Exception:
+        return False
+
+
+class NamedSignal:
+    def __init__(self, signal_name: str):
+        self.signal_name = signal_name
+        self.handle = CreateEventW(None, True, False, self.signal_name)
+        if self.handle:
+            atexit.register(self.close)
+
+    def signal(self) -> bool:
+        if not self.handle:
+            return False
+        return bool(SetEvent(self.handle))
+
+    def clear(self) -> bool:
+        if not self.handle:
+            return False
+        return bool(ResetEvent(self.handle))
+
+    def consume(self) -> bool:
+        if not self.handle:
+            return False
+
+        wait_result = WaitForSingleObject(self.handle, 0)
+        if wait_result != WAIT_OBJECT_0:
+            return False
+
+        ResetEvent(self.handle)
+        return True
+
+    def close(self) -> None:
+        if self.handle:
+            CloseHandle(self.handle)
+            self.handle = None
+
+
+def acquire_or_prompt_replace(
+    guard: SingleInstanceGuard,
+    relaunch_signal: NamedSignal,
+    title: str,
+    message: str,
+    wait_seconds: float = 8.0,
+    poll_interval_seconds: float = 0.1,
+) -> bool:
+    if guard.acquire():
+        relaunch_signal.clear()
+        return True
+
+    if not show_replace_running_dialog(title, message):
+        return False
+
+    if not relaunch_signal.signal():
+        show_already_running_dialog(
+            title,
+            "Jarvis could not signal the current instance to close. Please close it manually and try again.",
+        )
+        return False
+
+    deadline = time.time() + max(0.5, wait_seconds)
+    while time.time() < deadline:
+        if guard.acquire():
+            relaunch_signal.clear()
+            return True
+        time.sleep(max(0.05, poll_interval_seconds))
+
+    show_already_running_dialog(
+        title,
+        "Jarvis is still closing. Please wait a moment and try again.",
+    )
+    return False

--- a/desktop/single_instance.py
+++ b/desktop/single_instance.py
@@ -84,6 +84,8 @@ class SingleInstanceGuard:
 
 
 def show_already_running_dialog(title: str, message: str) -> None:
+    if _show_qt_dialog(title, message, confirm=False) is not None:
+        return
     try:
         MessageBoxW(None, message, title, MB_OK | MB_ICONINFORMATION | FOREGROUND_DIALOG_FLAGS)
     except Exception:
@@ -91,11 +93,197 @@ def show_already_running_dialog(title: str, message: str) -> None:
 
 
 def show_replace_running_dialog(title: str, message: str) -> bool:
+    qt_result = _show_qt_dialog(title, message, confirm=True)
+    if qt_result is not None:
+        return qt_result
     try:
         result = MessageBoxW(None, message, title, MB_YESNO | MB_ICONQUESTION | FOREGROUND_DIALOG_FLAGS)
         return result == IDYES
     except Exception:
         return False
+
+
+def _show_qt_dialog(title: str, message: str, confirm: bool):
+    try:
+        from PySide6.QtCore import QTimer, Qt
+        from PySide6.QtGui import QFont, QGuiApplication
+        from PySide6.QtWidgets import (
+            QApplication,
+            QDialog,
+            QFrame,
+            QHBoxLayout,
+            QLabel,
+            QPushButton,
+            QVBoxLayout,
+        )
+    except Exception:
+        return None
+
+    class JarvisPromptDialog(QDialog):
+        def __init__(self):
+            super().__init__()
+            self.choice = False
+
+            self.setWindowTitle(title)
+            self.setModal(True)
+            self.setWindowFlags(
+                Qt.Dialog
+                | Qt.FramelessWindowHint
+                | Qt.WindowStaysOnTopHint
+                | Qt.CustomizeWindowHint
+            )
+            self.setAttribute(Qt.WA_DeleteOnClose, True)
+            self.setMinimumWidth(540)
+
+            self.setStyleSheet(
+                """
+                QDialog {
+                    background: #04080d;
+                    color: #8df3ff;
+                    border: 1px solid #0fe1ff;
+                }
+                QFrame#shell {
+                    background: #07131b;
+                    border: 1px solid #0fe1ff;
+                }
+                QLabel#eyebrow {
+                    color: #00d8ff;
+                    font-size: 13px;
+                    font-weight: 700;
+                    letter-spacing: 1px;
+                    border: none;
+                }
+                QLabel#heading {
+                    color: #e8fdff;
+                    font-size: 28px;
+                    font-weight: 700;
+                    border: none;
+                }
+                QLabel#detail {
+                    color: #8dd9e6;
+                    font-size: 15px;
+                    line-height: 1.35em;
+                    border: none;
+                }
+                QPushButton {
+                    min-height: 42px;
+                    padding: 0 18px;
+                    border-radius: 0;
+                    font-size: 14px;
+                    font-weight: 700;
+                }
+                QPushButton#secondary {
+                    color: #8df3ff;
+                    background: #0a1b26;
+                    border: 1px solid #0fe1ff;
+                }
+                QPushButton#secondary:hover {
+                    background: #12303e;
+                }
+                QPushButton#primary {
+                    color: #041017;
+                    background: #0fe1ff;
+                    border: 1px solid #6ff6ff;
+                }
+                QPushButton#primary:hover {
+                    background: #6ff6ff;
+                }
+                """
+            )
+
+            root = QVBoxLayout(self)
+            root.setContentsMargins(18, 18, 18, 18)
+
+            shell = QFrame()
+            shell.setObjectName("shell")
+            shell_layout = QVBoxLayout(shell)
+            shell_layout.setContentsMargins(22, 20, 22, 20)
+            shell_layout.setSpacing(14)
+
+            eyebrow = QLabel("JARVIS")
+            eyebrow.setObjectName("eyebrow")
+
+            heading = QLabel(title)
+            heading.setObjectName("heading")
+            heading.setWordWrap(True)
+
+            detail = QLabel(message.replace("\n", "<br>"))
+            detail.setObjectName("detail")
+            detail.setWordWrap(True)
+            detail.setTextFormat(Qt.RichText)
+
+            shell_layout.addWidget(eyebrow)
+            shell_layout.addWidget(heading)
+            shell_layout.addWidget(detail)
+
+            actions = QHBoxLayout()
+            actions.setContentsMargins(0, 8, 0, 0)
+            actions.setSpacing(10)
+            actions.addStretch()
+
+            if confirm:
+                keep_button = QPushButton("Keep Current")
+                keep_button.setObjectName("secondary")
+                keep_button.clicked.connect(self.reject_dialog)
+                actions.addWidget(keep_button)
+
+                replace_button = QPushButton("Close Current And Relaunch")
+                replace_button.setObjectName("primary")
+                replace_button.clicked.connect(self.accept_dialog)
+                actions.addWidget(replace_button)
+            else:
+                close_button = QPushButton("Close")
+                close_button.setObjectName("primary")
+                close_button.clicked.connect(self.accept_dialog)
+                actions.addWidget(close_button)
+
+            shell_layout.addLayout(actions)
+            root.addWidget(shell)
+
+        def showEvent(self, event):
+            super().showEvent(event)
+            self.raise_()
+            self.activateWindow()
+            try:
+                user32.SetForegroundWindow(int(self.winId()))
+            except Exception:
+                pass
+
+        def center_on_primary(self):
+            screen = QGuiApplication.primaryScreen()
+            if not screen:
+                return
+            geometry = screen.availableGeometry()
+            self.adjustSize()
+            x = geometry.x() + (geometry.width() - self.width()) // 2
+            y = geometry.y() + (geometry.height() - self.height()) // 2
+            self.move(x, y)
+
+        def accept_dialog(self):
+            self.choice = True
+            self.accept()
+
+        def reject_dialog(self):
+            self.choice = False
+            self.reject()
+
+    app = QApplication.instance()
+    owns_app = app is None
+    if owns_app:
+        app = QApplication([])
+        app.setFont(QFont("Segoe UI", 10))
+
+    dialog = JarvisPromptDialog()
+    dialog.center_on_primary()
+    QTimer.singleShot(0, dialog.raise_)
+    QTimer.singleShot(0, dialog.activateWindow)
+    dialog.exec()
+    result = dialog.choice if confirm else True
+
+    if owns_app:
+        app.quit()
+
+    return result
 
 
 class NamedSignal:

--- a/desktop/single_instance.py
+++ b/desktop/single_instance.py
@@ -42,11 +42,17 @@ MessageBoxW.restype = ctypes.c_int
 ERROR_ALREADY_EXISTS = 183
 MB_OK = 0x00000000
 MB_YESNO = 0x00000004
+MB_SYSTEMMODAL = 0x00001000
+MB_SETFOREGROUND = 0x00010000
+MB_TOPMOST = 0x00040000
 MB_ICONINFORMATION = 0x00000040
 MB_ICONQUESTION = 0x00000020
 IDYES = 6
 WAIT_OBJECT_0 = 0
 WAIT_TIMEOUT = 258
+
+
+FOREGROUND_DIALOG_FLAGS = MB_SYSTEMMODAL | MB_SETFOREGROUND | MB_TOPMOST
 
 
 class SingleInstanceGuard:
@@ -78,14 +84,14 @@ class SingleInstanceGuard:
 
 def show_already_running_dialog(title: str, message: str) -> None:
     try:
-        MessageBoxW(None, message, title, MB_OK | MB_ICONINFORMATION)
+        MessageBoxW(None, message, title, MB_OK | MB_ICONINFORMATION | FOREGROUND_DIALOG_FLAGS)
     except Exception:
         pass
 
 
 def show_replace_running_dialog(title: str, message: str) -> bool:
     try:
-        result = MessageBoxW(None, message, title, MB_YESNO | MB_ICONQUESTION)
+        result = MessageBoxW(None, message, title, MB_YESNO | MB_ICONQUESTION | FOREGROUND_DIALOG_FLAGS)
         return result == IDYES
     except Exception:
         return False

--- a/desktop/single_instance.py
+++ b/desktop/single_instance.py
@@ -54,6 +54,7 @@ WAIT_TIMEOUT = 258
 
 
 FOREGROUND_DIALOG_FLAGS = MB_SYSTEMMODAL | MB_SETFOREGROUND | MB_TOPMOST
+_qt_dialog_app = None
 
 
 class SingleInstanceGuard:
@@ -83,8 +84,19 @@ class SingleInstanceGuard:
             self.handle = None
 
 
-def show_already_running_dialog(title: str, message: str) -> None:
-    if _show_qt_dialog(title, message, confirm=False) is not None:
+def show_already_running_dialog(
+    title: str,
+    message: str,
+    eyebrow_text: str = "JARVIS",
+    primary_button_text: str = "Close",
+) -> None:
+    if _show_qt_dialog(
+        title,
+        message,
+        confirm=False,
+        eyebrow_text=eyebrow_text,
+        primary_button_text=primary_button_text,
+    ) is not None:
         return
     try:
         MessageBoxW(None, message, title, MB_OK | MB_ICONINFORMATION | FOREGROUND_DIALOG_FLAGS)
@@ -92,8 +104,21 @@ def show_already_running_dialog(title: str, message: str) -> None:
         pass
 
 
-def show_replace_running_dialog(title: str, message: str) -> bool:
-    qt_result = _show_qt_dialog(title, message, confirm=True)
+def show_replace_running_dialog(
+    title: str,
+    message: str,
+    eyebrow_text: str = "JARVIS",
+    primary_button_text: str = "Close Current And Relaunch",
+    secondary_button_text: str = "Keep Current",
+) -> bool:
+    qt_result = _show_qt_dialog(
+        title,
+        message,
+        confirm=True,
+        eyebrow_text=eyebrow_text,
+        primary_button_text=primary_button_text,
+        secondary_button_text=secondary_button_text,
+    )
     if qt_result is not None:
         return qt_result
     try:
@@ -103,7 +128,14 @@ def show_replace_running_dialog(title: str, message: str) -> bool:
         return False
 
 
-def _show_qt_dialog(title: str, message: str, confirm: bool):
+def _show_qt_dialog(
+    title: str,
+    message: str,
+    confirm: bool,
+    eyebrow_text: str = "JARVIS",
+    primary_button_text: str = "Close Current And Relaunch",
+    secondary_button_text: str = "Keep Current",
+):
     try:
         from PySide6.QtCore import QTimer, Qt
         from PySide6.QtGui import QFont, QGuiApplication
@@ -118,6 +150,8 @@ def _show_qt_dialog(title: str, message: str, confirm: bool):
         )
     except Exception:
         return None
+
+    global _qt_dialog_app
 
     class JarvisPromptDialog(QDialog):
         def __init__(self):
@@ -200,7 +234,7 @@ def _show_qt_dialog(title: str, message: str, confirm: bool):
             shell_layout.setContentsMargins(22, 20, 22, 20)
             shell_layout.setSpacing(14)
 
-            eyebrow = QLabel("JARVIS")
+            eyebrow = QLabel(eyebrow_text)
             eyebrow.setObjectName("eyebrow")
 
             heading = QLabel(title)
@@ -222,17 +256,17 @@ def _show_qt_dialog(title: str, message: str, confirm: bool):
             actions.addStretch()
 
             if confirm:
-                keep_button = QPushButton("Keep Current")
+                keep_button = QPushButton(secondary_button_text)
                 keep_button.setObjectName("secondary")
                 keep_button.clicked.connect(self.reject_dialog)
                 actions.addWidget(keep_button)
 
-                replace_button = QPushButton("Close Current And Relaunch")
+                replace_button = QPushButton(primary_button_text)
                 replace_button.setObjectName("primary")
                 replace_button.clicked.connect(self.accept_dialog)
                 actions.addWidget(replace_button)
             else:
-                close_button = QPushButton("Close")
+                close_button = QPushButton(primary_button_text)
                 close_button.setObjectName("primary")
                 close_button.clicked.connect(self.accept_dialog)
                 actions.addWidget(close_button)
@@ -268,10 +302,11 @@ def _show_qt_dialog(title: str, message: str, confirm: bool):
             self.reject()
 
     app = QApplication.instance()
-    owns_app = app is None
-    if owns_app:
-        app = QApplication([])
-        app.setFont(QFont("Segoe UI", 10))
+    if app is None:
+        if _qt_dialog_app is None:
+            _qt_dialog_app = QApplication([])
+            _qt_dialog_app.setFont(QFont("Segoe UI", 10))
+        app = _qt_dialog_app
 
     dialog = JarvisPromptDialog()
     dialog.center_on_primary()
@@ -279,9 +314,6 @@ def _show_qt_dialog(title: str, message: str, confirm: bool):
     QTimer.singleShot(0, dialog.activateWindow)
     dialog.exec()
     result = dialog.choice if confirm else True
-
-    if owns_app:
-        app.quit()
 
     return result
 
@@ -328,6 +360,9 @@ def acquire_or_prompt_replace(
     wait_seconds: float = 8.0,
     poll_interval_seconds: float = 0.1,
     event_logger: Callable[[str], None] | None = None,
+    eyebrow_text: str = "JARVIS",
+    primary_button_text: str = "Close Current And Relaunch",
+    secondary_button_text: str = "Keep Current",
 ) -> bool:
     def log_event(event: str) -> None:
         if not callable(event_logger):
@@ -344,7 +379,13 @@ def acquire_or_prompt_replace(
 
     log_event("SINGLE_INSTANCE_CONFLICT_DETECTED")
 
-    if not show_replace_running_dialog(title, message):
+    if not show_replace_running_dialog(
+        title,
+        message,
+        eyebrow_text=eyebrow_text,
+        primary_button_text=primary_button_text,
+        secondary_button_text=secondary_button_text,
+    ):
         log_event("REPLACE_PROMPT_DECLINED")
         return False
 
@@ -355,6 +396,8 @@ def acquire_or_prompt_replace(
         show_already_running_dialog(
             title,
             "Jarvis could not signal the current instance to close. Please close it manually and try again.",
+            eyebrow_text=eyebrow_text,
+            primary_button_text="Close",
         )
         return False
 
@@ -372,5 +415,7 @@ def acquire_or_prompt_replace(
     show_already_running_dialog(
         title,
         "Jarvis is still closing. Please wait a moment and try again.",
+        eyebrow_text=eyebrow_text,
+        primary_button_text="Close",
     )
     return False

--- a/desktop/single_instance.py
+++ b/desktop/single_instance.py
@@ -2,6 +2,7 @@ import atexit
 import ctypes
 import time
 from ctypes import wintypes
+from typing import Callable
 
 
 kernel32 = ctypes.windll.kernel32
@@ -138,28 +139,48 @@ def acquire_or_prompt_replace(
     message: str,
     wait_seconds: float = 8.0,
     poll_interval_seconds: float = 0.1,
+    event_logger: Callable[[str], None] | None = None,
 ) -> bool:
+    def log_event(event: str) -> None:
+        if not callable(event_logger):
+            return
+        try:
+            event_logger(event)
+        except Exception:
+            pass
+
     if guard.acquire():
         relaunch_signal.clear()
+        log_event("SINGLE_INSTANCE_ACQUIRED")
         return True
 
+    log_event("SINGLE_INSTANCE_CONFLICT_DETECTED")
+
     if not show_replace_running_dialog(title, message):
+        log_event("REPLACE_PROMPT_DECLINED")
         return False
 
+    log_event("REPLACE_PROMPT_ACCEPTED")
+
     if not relaunch_signal.signal():
+        log_event("RELAUNCH_SIGNAL_FAILED")
         show_already_running_dialog(
             title,
             "Jarvis could not signal the current instance to close. Please close it manually and try again.",
         )
         return False
 
+    log_event("RELAUNCH_SIGNAL_SENT")
+
     deadline = time.time() + max(0.5, wait_seconds)
     while time.time() < deadline:
         if guard.acquire():
             relaunch_signal.clear()
+            log_event("RELAUNCH_ACQUIRED_AFTER_WAIT")
             return True
         time.sleep(max(0.05, poll_interval_seconds))
 
+    log_event("RELAUNCH_WAIT_TIMEOUT")
     show_already_running_dialog(
         title,
         "Jarvis is still closing. Please wait a moment and try again.",

--- a/desktop/workerw_utils.py
+++ b/desktop/workerw_utils.py
@@ -13,6 +13,7 @@ ShowWindow = user32.ShowWindow
 SetWindowPos = user32.SetWindowPos
 GetWindowLongPtrW = user32.GetWindowLongPtrW
 SetWindowLongPtrW = user32.SetWindowLongPtrW
+GetClassNameW = user32.GetClassNameW
 
 LONG_PTR = ctypes.c_ssize_t
 ULONG_PTR = ctypes.c_size_t
@@ -50,6 +51,9 @@ GetWindowLongPtrW.restype = LONG_PTR
 SetWindowLongPtrW.argtypes = [wintypes.HWND, ctypes.c_int, LONG_PTR]
 SetWindowLongPtrW.restype = LONG_PTR
 
+GetClassNameW.argtypes = [wintypes.HWND, wintypes.LPWSTR, ctypes.c_int]
+GetClassNameW.restype = ctypes.c_int
+
 # --- Constants ---
 SMTO_NORMAL = 0x0000
 SW_SHOW = 5
@@ -83,6 +87,8 @@ WS_EX_NOACTIVATE = 0x08000000
 WS_EX_APPWINDOW = 0x00040000
 
 WNDENUMPROC = ctypes.WINFUNCTYPE(ctypes.c_bool, wintypes.HWND, wintypes.LPARAM)
+PROBE_SAMPLE_LIMIT = 4
+_LAST_WORKERW_PROBE = {}
 
 
 def _to_signed_long_ptr(value: int) -> int:
@@ -100,11 +106,78 @@ def _set_window_long_ptr(hwnd: int, index: int, value: int) -> int:
     return SetWindowLongPtrW(hwnd, index, _to_signed_long_ptr(value))
 
 
+def _hwnd_token(hwnd) -> str:
+    if isinstance(hwnd, str):
+        return hwnd or "none"
+    return hex(int(hwnd)) if hwnd else "none"
+
+
+def _window_class(hwnd) -> str:
+    if not hwnd:
+        return "none"
+
+    buf = ctypes.create_unicode_buffer(256)
+    if GetClassNameW(hwnd, buf, len(buf)) <= 0:
+        return "unknown"
+    return buf.value or "unknown"
+
+
+def _sample_tokens(values, limit=PROBE_SAMPLE_LIMIT):
+    if not values:
+        return "none"
+
+    tokens = [_hwnd_token(value) for value in values[:limit]]
+    remaining = len(values) - len(tokens)
+    if remaining > 0:
+        tokens.append(f"+{remaining}_more")
+    return ",".join(tokens)
+
+
+def get_last_workerw_probe_events():
+    probe = _LAST_WORKERW_PROBE
+    if not probe:
+        return []
+
+    shell_hosts = probe.get("shell_hosts", [])
+    host_tokens = []
+    for host in shell_hosts[:2]:
+        host_tokens.append(
+            f"{host['class']}@{host['hwnd']}(defview={host['defview']},next={host['next_workerw']})"
+        )
+    remaining_hosts = len(shell_hosts) - len(host_tokens)
+    if remaining_hosts > 0:
+        host_tokens.append(f"+{remaining_hosts}_more")
+
+    return [
+        (
+            "WORKERW_PROBE|"
+            f"progman={probe.get('progman', 'none')}|"
+            f"progman_class={probe.get('progman_class', 'none')}|"
+            f"progman_message_sent={probe.get('progman_message_sent', 'false')}|"
+            f"progman_message_result={probe.get('progman_message_result', 'none')}|"
+            f"top_level_window_count={probe.get('top_level_window_count', 0)}"
+        ),
+        (
+            "WORKERW_HOSTS|"
+            f"shell_host_count={len(shell_hosts)}|"
+            f"shell_hosts={','.join(host_tokens) if host_tokens else 'none'}|"
+            f"selected_workerw={probe.get('selected_workerw', 'none')}"
+        ),
+        (
+            "WORKERW_CANDIDATES|"
+            f"workerw_count={len(probe.get('workerw_candidates', []))}|"
+            f"workerw_sample={_sample_tokens(probe.get('workerw_candidates', []))}"
+        ),
+    ]
+
+
 def get_workerw():
     progman = FindWindowW("Progman", None)
+    progman_message_sent = False
+    progman_message_result = "none"
     if progman:
         result = wintypes.DWORD()
-        SendMessageTimeoutW(
+        send_result = SendMessageTimeoutW(
             progman,
             0x052C,
             0,
@@ -113,21 +186,51 @@ def get_workerw():
             1000,
             ctypes.byref(result),
         )
+        progman_message_sent = bool(send_result)
+        progman_message_result = str(int(result.value))
 
     workerw = None
+    windows = []
 
     @WNDENUMPROC
     def enum_windows_proc(hwnd, lparam):
-        nonlocal workerw
-        shell_def_view = FindWindowExW(hwnd, None, "SHELLDLL_DefView", None)
-        if shell_def_view:
-            possible = FindWindowExW(None, hwnd, "WorkerW", None)
-            if possible:
-                workerw = possible
-                return False
+        windows.append(hwnd)
         return True
 
     EnumWindows(enum_windows_proc, 0)
+
+    workerw_candidates = []
+    shell_hosts = []
+
+    for hwnd in windows:
+        if _window_class(hwnd) == "WorkerW":
+            workerw_candidates.append(hwnd)
+
+        shell_def_view = FindWindowExW(hwnd, None, "SHELLDLL_DefView", None)
+        if shell_def_view:
+            possible = FindWindowExW(None, hwnd, "WorkerW", None)
+            shell_hosts.append(
+                {
+                    "hwnd": _hwnd_token(hwnd),
+                    "class": _window_class(hwnd),
+                    "defview": _hwnd_token(shell_def_view),
+                    "next_workerw": _hwnd_token(possible),
+                }
+            )
+            if workerw is None and possible:
+                workerw = possible
+
+    global _LAST_WORKERW_PROBE
+    _LAST_WORKERW_PROBE = {
+        "progman": _hwnd_token(progman),
+        "progman_class": _window_class(progman),
+        "progman_message_sent": "true" if progman_message_sent else "false",
+        "progman_message_result": progman_message_result,
+        "top_level_window_count": len(windows),
+        "shell_hosts": shell_hosts,
+        "workerw_candidates": [_hwnd_token(hwnd) for hwnd in workerw_candidates],
+        "selected_workerw": _hwnd_token(workerw),
+    }
     return workerw
 
 

--- a/desktop/workerw_utils.py
+++ b/desktop/workerw_utils.py
@@ -161,7 +161,8 @@ def get_last_workerw_probe_events():
             "WORKERW_HOSTS|"
             f"shell_host_count={len(shell_hosts)}|"
             f"shell_hosts={','.join(host_tokens) if host_tokens else 'none'}|"
-            f"selected_workerw={probe.get('selected_workerw', 'none')}"
+            f"selected_workerw={probe.get('selected_workerw', 'none')}|"
+            f"selection_reason={probe.get('selection_reason', 'none')}"
         ),
         (
             "WORKERW_CANDIDATES|"
@@ -175,6 +176,7 @@ def get_workerw():
     progman = FindWindowW("Progman", None)
     progman_message_sent = False
     progman_message_result = "none"
+    selection_reason = "none"
     if progman:
         result = wintypes.DWORD()
         send_result = SendMessageTimeoutW(
@@ -203,7 +205,9 @@ def get_workerw():
     shell_hosts = []
 
     for hwnd in windows:
-        if _window_class(hwnd) == "WorkerW":
+        window_class = _window_class(hwnd)
+
+        if window_class == "WorkerW":
             workerw_candidates.append(hwnd)
 
         shell_def_view = FindWindowExW(hwnd, None, "SHELLDLL_DefView", None)
@@ -212,13 +216,23 @@ def get_workerw():
             shell_hosts.append(
                 {
                     "hwnd": _hwnd_token(hwnd),
-                    "class": _window_class(hwnd),
+                    "class": window_class,
                     "defview": _hwnd_token(shell_def_view),
                     "next_workerw": _hwnd_token(possible),
                 }
             )
             if workerw is None and possible:
                 workerw = possible
+                selection_reason = "next_workerw"
+            elif (
+                workerw is None
+                and not possible
+                and progman
+                and hwnd == progman
+                and window_class == "Progman"
+            ):
+                workerw = hwnd
+                selection_reason = "progman_fallback"
 
     global _LAST_WORKERW_PROBE
     _LAST_WORKERW_PROBE = {
@@ -230,6 +244,7 @@ def get_workerw():
         "shell_hosts": shell_hosts,
         "workerw_candidates": [_hwnd_token(hwnd) for hwnd in workerw_candidates],
         "selected_workerw": _hwnd_token(workerw),
+        "selection_reason": selection_reason,
     }
     return workerw
 

--- a/dev/jarvis_boot_monitor_preflight.py
+++ b/dev/jarvis_boot_monitor_preflight.py
@@ -1,0 +1,149 @@
+import datetime
+import json
+import os
+import sys
+
+from PySide6.QtGui import QGuiApplication
+
+
+ROOT_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+DEV_LOGS_DIR = os.path.join(ROOT_DIR, "dev", "logs")
+BASE_LOG_ROOT = os.path.join(DEV_LOGS_DIR, "boot_monitor_preflight")
+REPORTS_DIR = os.path.join(BASE_LOG_ROOT, "reports")
+
+
+def ensure_dir(path):
+    os.makedirs(path, exist_ok=True)
+
+
+def line_status(ok, detail):
+    return {"ok": bool(ok), "detail": detail}
+
+
+def detect_branch_state():
+    head_path = os.path.join(ROOT_DIR, ".git", "HEAD")
+    try:
+        with open(head_path, "r", encoding="utf-8") as f:
+            return f.read().strip()
+    except Exception:
+        return "unavailable"
+
+
+def screen_marker(screen):
+    geometry = screen.geometry()
+    return (
+        f"{screen.name()}@x{geometry.x()}_y{geometry.y()}_w{geometry.width()}_h{geometry.height()}"
+    )
+
+
+def resolve_boot_screens(screens, primary_screen):
+    center_screen = primary_screen
+    other_screens = [screen for screen in screens if screen != center_screen]
+    if len(other_screens) < 2:
+        screens_sorted = sorted(screens, key=lambda screen: screen.geometry().x())
+        return screens_sorted[0], screens_sorted[1], screens_sorted[2]
+    other_sorted = sorted(other_screens, key=lambda screen: screen.geometry().x())
+    return other_sorted[0], center_screen, other_sorted[1]
+
+
+def run_preflight():
+    ensure_dir(BASE_LOG_ROOT)
+    ensure_dir(REPORTS_DIR)
+
+    app = QGuiApplication(sys.argv)
+    screens = QGuiApplication.screens()
+    primary_screen = QGuiApplication.primaryScreen()
+
+    checks = {
+        "screen_count_at_least_three": line_status(len(screens) >= 3, f"screen_count={len(screens)}"),
+        "primary_screen_present": line_status(primary_screen is not None, primary_screen.name() if primary_screen else "missing"),
+    }
+
+    left_screen = None
+    center_screen = None
+    right_screen = None
+
+    if len(screens) >= 3 and primary_screen is not None:
+        try:
+            left_screen, center_screen, right_screen = resolve_boot_screens(screens, primary_screen)
+        except Exception as exc:
+            checks["boot_screen_resolution"] = line_status(False, f"resolution error: {type(exc).__name__}: {exc}")
+        else:
+            checks["boot_screen_resolution"] = line_status(
+                True,
+                f"left={screen_marker(left_screen)} | center={screen_marker(center_screen)} | right={screen_marker(right_screen)}",
+            )
+
+            left_x = left_screen.geometry().x()
+            center_x = center_screen.geometry().x()
+            right_x = right_screen.geometry().x()
+            checks["left_center_right_order_valid"] = line_status(
+                left_x < center_x < right_x,
+                f"left_x={left_x} center_x={center_x} right_x={right_x}",
+            )
+            checks["center_matches_primary_screen"] = line_status(
+                center_screen == primary_screen,
+                f"center={center_screen.name()} primary={primary_screen.name()}",
+            )
+
+    checks["screen_markers_captured"] = line_status(
+        bool(screens),
+        " | ".join(screen_marker(screen) for screen in screens) if screens else "no screens reported",
+    )
+
+    app.quit()
+
+    return {
+        "branch_state": detect_branch_state(),
+        "checks": checks,
+    }
+
+
+def build_report_text(report_path, result, overall_ok):
+    lines = [
+        "BOOT MONITOR PREFLIGHT",
+        f"Report: {report_path}",
+        f"Branch: {result['branch_state']}",
+        f"Overall Result: {'PASS' if overall_ok else 'FAIL'}",
+        "",
+        "Checks:",
+    ]
+
+    for key, value in result["checks"].items():
+        lines.append(f"  {'PASS' if value['ok'] else 'FAIL'} :: {key} :: {value['detail']}")
+
+    return "\n".join(lines) + "\n"
+
+
+def main(argv):
+    open_report = "--open-report" in argv
+
+    result = run_preflight()
+    failures = [key for key, value in result["checks"].items() if not value["ok"]]
+    overall_ok = not failures
+
+    stamp = datetime.datetime.now().strftime("%Y%m%d_%H%M%S")
+    report_path = os.path.join(REPORTS_DIR, f"BootMonitorPreflightReport_{stamp}.txt")
+    json_path = os.path.join(REPORTS_DIR, f"BootMonitorPreflightReport_{stamp}.json")
+
+    report_text = build_report_text(report_path, result, overall_ok)
+
+    with open(report_path, "w", encoding="utf-8") as f:
+        f.write(report_text)
+
+    with open(json_path, "w", encoding="utf-8") as f:
+        json.dump(result, f, indent=2)
+
+    print(report_text)
+
+    if open_report:
+        try:
+            os.startfile(report_path)
+        except Exception:
+            pass
+
+    return 0 if overall_ok else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))

--- a/dev/jarvis_boot_toolkit_validation.py
+++ b/dev/jarvis_boot_toolkit_validation.py
@@ -1,0 +1,439 @@
+import datetime
+import importlib.machinery
+import importlib.util
+import json
+import os
+import subprocess
+import sys
+import time
+
+os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+
+from PySide6.QtCore import Qt
+from PySide6.QtTest import QTest
+
+
+ROOT_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+DEV_LOGS_DIR = os.path.join(ROOT_DIR, "dev", "logs")
+BASE_LOG_ROOT = os.path.join(DEV_LOGS_DIR, "boot_toolkit_validation")
+REPORTS_DIR = os.path.join(BASE_LOG_ROOT, "reports")
+
+DEV_LAUNCHER_SCRIPT = os.path.join(ROOT_DIR, "dev", "launchers", "jarvis_dev_launcher.pyw")
+DEV_LAUNCHERS_DIR = os.path.join(ROOT_DIR, "dev", "launchers")
+
+REPORT_PREFIX = "BootToolkitValidationReport_"
+
+BOOT_CASES = (
+    {
+        "name": "Toolkit Boot Helper: Monitor Preflight",
+        "lane_key": "bootMonitorPreflight",
+        "lane_label": "Boot Monitor Preflight",
+        "expected_launcher": "launch_jarvis_boot_monitor_preflight.vbs",
+        "report_root": os.path.join(DEV_LOGS_DIR, "boot_monitor_preflight", "reports"),
+        "report_prefix": "BootMonitorPreflightReport_",
+        "timeout_seconds": 45,
+    },
+    {
+        "name": "Toolkit Boot Helper: Transition Verification",
+        "lane_key": "bootTransitionVerification",
+        "lane_label": "Boot To Desktop Handoff Verification",
+        "expected_launcher": "launch_jarvis_boot_transition_verification.vbs",
+        "report_root": os.path.join(DEV_LOGS_DIR, "boot_transition_verification", "reports"),
+        "report_prefix": "BootTransitionVerificationReport_",
+        "timeout_seconds": 150,
+    },
+)
+
+
+def hidden_subprocess_kwargs():
+    kwargs = {
+        "stdout": subprocess.PIPE,
+        "stderr": subprocess.PIPE,
+        "text": True,
+        "encoding": "utf-8",
+        "errors": "replace",
+    }
+
+    if os.name == "nt":
+        startupinfo = subprocess.STARTUPINFO()
+        startupinfo.dwFlags |= subprocess.STARTF_USESHOWWINDOW
+        startupinfo.wShowWindow = 0
+        kwargs["startupinfo"] = startupinfo
+        kwargs["creationflags"] = getattr(subprocess, "CREATE_NO_WINDOW", 0)
+
+    return kwargs
+
+
+def ensure_dir(path):
+    os.makedirs(path, exist_ok=True)
+
+
+def reset_dir(path):
+    if not os.path.isdir(path):
+        os.makedirs(path, exist_ok=True)
+        return
+
+    for name in os.listdir(path):
+        child = os.path.join(path, name)
+        try:
+            if os.path.isdir(child):
+                for root, dirs, files in os.walk(child, topdown=False):
+                    for file_name in files:
+                        os.remove(os.path.join(root, file_name))
+                    for dir_name in dirs:
+                        os.rmdir(os.path.join(root, dir_name))
+                os.rmdir(child)
+            else:
+                os.remove(child)
+        except Exception:
+            pass
+
+
+def detect_branch_state():
+    head_path = os.path.join(ROOT_DIR, ".git", "HEAD")
+    try:
+        with open(head_path, "r", encoding="utf-8") as handle:
+            return handle.read().strip()
+    except Exception:
+        return "unavailable"
+
+
+def latest_file_matching(folder_path, prefix, suffix=""):
+    if not os.path.isdir(folder_path):
+        return ""
+
+    best_path = ""
+    best_mtime = -1.0
+    for name in os.listdir(folder_path):
+        if not name.lower().startswith(prefix.lower()):
+            continue
+        if suffix and not name.lower().endswith(suffix.lower()):
+            continue
+        path = os.path.join(folder_path, name)
+        if not os.path.isfile(path):
+            continue
+        try:
+            mtime = os.path.getmtime(path)
+        except OSError:
+            continue
+        if mtime >= best_mtime:
+            best_mtime = mtime
+            best_path = path
+    return best_path
+
+
+def matching_files(folder_path, prefix, suffix):
+    if not os.path.isdir(folder_path):
+        return set()
+
+    matches = set()
+    for name in os.listdir(folder_path):
+        if not name.lower().startswith(prefix.lower()):
+            continue
+        if suffix and not name.lower().endswith(suffix.lower()):
+            continue
+        path = os.path.join(folder_path, name)
+        if os.path.isfile(path):
+            matches.add(os.path.abspath(path))
+    return matches
+
+
+def read_text(path):
+    if not path or not os.path.isfile(path):
+        return ""
+    with open(path, "r", encoding="utf-8", errors="ignore") as handle:
+        return handle.read()
+
+
+def line_status(ok, detail):
+    return {"ok": bool(ok), "detail": detail}
+
+
+def load_module_from_path(module_name, module_path):
+    loader = importlib.machinery.SourceFileLoader(module_name, module_path)
+    spec = importlib.util.spec_from_loader(module_name, loader)
+    module = importlib.util.module_from_spec(spec)
+    loader.exec_module(module)
+    return module
+
+
+def wait_for_new_report(report_root, report_prefix, before_reports, timeout_seconds, app):
+    deadline = time.time() + max(5, timeout_seconds)
+    latest = ""
+    while time.time() < deadline:
+        current_reports = matching_files(report_root, report_prefix, ".txt")
+        new_reports = current_reports - before_reports
+        if len(new_reports) == 1:
+            return sorted(new_reports)[0]
+        if new_reports:
+            latest = latest_file_matching(report_root, report_prefix, ".txt")
+            if latest:
+                return latest
+        app.processEvents()
+        time.sleep(0.2)
+    return latest
+
+
+def run_toolkit_case(dev_launcher_module, window, app, case):
+    before_reports = matching_files(case["report_root"], case["report_prefix"], ".txt")
+    launch_records = []
+    opened_paths = []
+    toolkit_events = []
+
+    original_popen = subprocess.Popen
+    original_open_path = window.open_path
+    original_runtime_logger = window.runtime_logger
+
+    def runtime_logger(event):
+        toolkit_events.append(event)
+        if callable(original_runtime_logger):
+            original_runtime_logger(event)
+
+    def fake_open_path(path, success_message):
+        opened_paths.append({"path": os.path.abspath(path), "message": success_message})
+        window.set_status(success_message)
+
+    def recording_popen(args, cwd=None, **kwargs):
+        launch_records.append(
+            {
+                "args": list(args),
+                "cwd": os.path.abspath(cwd or ROOT_DIR),
+            }
+        )
+        launch_env = os.environ.copy()
+        launch_env.pop("QT_QPA_PLATFORM", None)
+        kwargs["env"] = launch_env
+        return original_popen(args, cwd=cwd, **kwargs)
+
+    window.runtime_logger = runtime_logger
+    window.open_path = fake_open_path
+    subprocess.Popen = recording_popen
+
+    launch_status = ""
+    complete_status = ""
+    open_status = ""
+    new_report_path = ""
+    try:
+        window.select_lane(case["lane_key"])
+        app.processEvents()
+        window.delay_combo.setCurrentIndex(1)
+        app.processEvents()
+
+        QTest.mouseClick(window.launch_btn, Qt.LeftButton)
+        app.processEvents()
+        launch_status = window.status_label.text()
+
+        new_report_path = wait_for_new_report(
+            case["report_root"],
+            case["report_prefix"],
+            before_reports,
+            case["timeout_seconds"],
+            app,
+        )
+
+        window.refresh_background_run_status()
+        app.processEvents()
+        complete_status = window.status_label.text()
+
+        window.open_latest_report()
+        app.processEvents()
+        open_status = window.status_label.text()
+    finally:
+        subprocess.Popen = original_popen
+        window.open_path = original_open_path
+        window.runtime_logger = original_runtime_logger
+
+    latest_opened_path = opened_paths[-1]["path"] if opened_paths else ""
+    report_text = read_text(new_report_path)
+    launch_record = launch_records[0] if launch_records else {}
+    expected_launcher_path = os.path.join(DEV_LAUNCHERS_DIR, case["expected_launcher"])
+    expected_launch_marker = (
+        f"TOOLKIT_MAIN|LANE_LAUNCHED|lane={case['lane_key']}|mode=quiet|label={case['lane_label']}"
+    )
+
+    checks = {
+        "selected_lane_expected": line_status(
+            window.current_lane_key() == case["lane_key"],
+            window.current_lane_key(),
+        ),
+        "launch_mode_quiet": line_status(
+            window.current_launch_mode_key() == "quiet",
+            window.current_launch_mode_key(),
+        ),
+        "launcher_process_invoked_once": line_status(
+            len(launch_records) == 1,
+            f"launch records={len(launch_records)}",
+        ),
+        "launcher_host_is_wscript": line_status(
+            bool(launch_record)
+            and len(launch_record["args"]) >= 2
+            and os.path.basename(launch_record["args"][0]).lower() == "wscript.exe",
+            launch_record.get("args", ["missing"])[0] if launch_record else "missing launch",
+        ),
+        "launcher_path_expected": line_status(
+            bool(launch_record)
+            and len(launch_record["args"]) >= 2
+            and os.path.normcase(os.path.abspath(launch_record["args"][1]))
+            == os.path.normcase(os.path.abspath(expected_launcher_path)),
+            launch_record.get("args", ["", "missing"])[1] if launch_record else "missing launch",
+        ),
+        "launcher_cwd_expected": line_status(
+            bool(launch_record)
+            and os.path.normcase(os.path.abspath(launch_record.get("cwd", "")))
+            == os.path.normcase(os.path.abspath(DEV_LAUNCHERS_DIR)),
+            launch_record.get("cwd", "missing cwd") if launch_record else "missing launch",
+        ),
+        "launch_marker_emitted": line_status(
+            expected_launch_marker in toolkit_events,
+            expected_launch_marker,
+        ),
+        "launch_status_expected": line_status(
+            launch_status.startswith(f"Test in progress: {case['lane_label']}"),
+            launch_status or "missing launch status",
+        ),
+        "new_report_created": line_status(
+            bool(new_report_path) and os.path.isfile(new_report_path),
+            new_report_path or "missing new report",
+        ),
+        "report_overall_pass": line_status(
+            "Overall Result: PASS" in report_text,
+            new_report_path or "missing report",
+        ),
+        "complete_status_expected": line_status(
+            complete_status == f"Test complete: {case['lane_label']}",
+            complete_status or "missing completion status",
+        ),
+        "latest_report_opened": line_status(
+            bool(latest_opened_path),
+            latest_opened_path or "no opened report path captured",
+        ),
+        "opened_report_matches_new_report": line_status(
+            bool(new_report_path)
+            and bool(latest_opened_path)
+            and os.path.normcase(os.path.abspath(latest_opened_path))
+            == os.path.normcase(os.path.abspath(new_report_path)),
+            latest_opened_path or "no opened report path captured",
+        ),
+        "open_status_expected": line_status(
+            open_status.startswith("Opened latest report: "),
+            open_status or "missing open status",
+        ),
+    }
+
+    return {
+        "name": case["name"],
+        "lane_label": case["lane_label"],
+        "report_path": new_report_path,
+        "opened_report_path": latest_opened_path,
+        "launch_status": launch_status,
+        "complete_status": complete_status,
+        "open_status": open_status,
+        "launch_record": launch_record,
+        "checks": checks,
+    }
+
+
+def collect_failures(section):
+    failures = []
+    for key, value in section["checks"].items():
+        if not value["ok"]:
+            failures.append(f"{section['name']} :: {key}: {value['detail']}")
+    return failures
+
+
+def build_report_text(branch_state, report_path, sections, overall_ok):
+    lines = [
+        "JARVIS BOOT TOOLKIT VALIDATION",
+        f"Report: {report_path}",
+        f"Branch: {branch_state}",
+        f"Overall Result: {'PASS' if overall_ok else 'FAIL'}",
+        "",
+    ]
+
+    for section in sections:
+        lines.append(f"{section['name']}:")
+        lines.append(f"  lane: {section['lane_label']}")
+        if section.get("report_path"):
+            lines.append(f"  report: {section['report_path']}")
+        if section.get("opened_report_path"):
+            lines.append(f"  opened report: {section['opened_report_path']}")
+        if section.get("launch_status"):
+            lines.append(f"  launch status: {section['launch_status']}")
+        if section.get("complete_status"):
+            lines.append(f"  completion status: {section['complete_status']}")
+        if section.get("open_status"):
+            lines.append(f"  open status: {section['open_status']}")
+        for key, value in section["checks"].items():
+            lines.append(f"  {'PASS' if value['ok'] else 'FAIL'} :: {key} :: {value['detail']}")
+        lines.append("")
+
+    return "\n".join(lines) + "\n"
+
+
+def main(argv):
+    open_report = "--open-report" in argv
+
+    reset_dir(BASE_LOG_ROOT)
+    ensure_dir(REPORTS_DIR)
+
+    os.environ["QT_QPA_PLATFORM"] = "offscreen"
+
+    dev_launcher_module = load_module_from_path(
+        "jarvis_dev_launcher_boot_toolkit_validation_module",
+        DEV_LAUNCHER_SCRIPT,
+    )
+
+    app = dev_launcher_module.QApplication.instance() or dev_launcher_module.QApplication([])
+    window = dev_launcher_module.DevLauncherWindow()
+    window.show()
+    app.processEvents()
+
+    try:
+        sections = [
+            run_toolkit_case(dev_launcher_module, window, app, case)
+            for case in BOOT_CASES
+        ]
+    finally:
+        window.close()
+        app.quit()
+
+    failures = []
+    for section in sections:
+        failures.extend(collect_failures(section))
+
+    overall_ok = not failures
+    branch_state = detect_branch_state()
+    stamp = datetime.datetime.now().strftime("%Y%m%d_%H%M%S")
+    report_path = os.path.join(REPORTS_DIR, f"{REPORT_PREFIX}{stamp}.txt")
+    json_path = os.path.join(REPORTS_DIR, f"{REPORT_PREFIX}{stamp}.json")
+    report_text = build_report_text(branch_state, report_path, sections, overall_ok)
+
+    with open(report_path, "w", encoding="utf-8") as handle:
+        handle.write(report_text)
+
+    with open(json_path, "w", encoding="utf-8") as handle:
+        json.dump(
+            {
+                "branch_state": branch_state,
+                "overall_ok": overall_ok,
+                "sections": sections,
+                "failures": failures,
+                "report_path": report_path,
+            },
+            handle,
+            indent=2,
+            sort_keys=True,
+        )
+
+    if open_report and os.name == "nt":
+        try:
+            os.startfile(report_path)
+        except Exception:
+            pass
+
+    print(report_text)
+    return 0 if overall_ok else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))

--- a/dev/jarvis_boot_transition_capture.py
+++ b/dev/jarvis_boot_transition_capture.py
@@ -1,0 +1,353 @@
+import datetime
+import json
+import os
+import subprocess
+import sys
+import time
+
+from PySide6.QtGui import QGuiApplication
+
+
+ROOT_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+if ROOT_DIR not in sys.path:
+    sys.path.insert(0, ROOT_DIR)
+
+from desktop.single_instance import NamedSignal  # noqa: E402
+
+
+DEV_LOGS_DIR = os.path.join(ROOT_DIR, "dev", "logs")
+BASE_LOG_ROOT = os.path.join(DEV_LOGS_DIR, "boot_transition_capture")
+REPORTS_DIR = os.path.join(BASE_LOG_ROOT, "reports")
+CAPTURES_DIR = os.path.join(BASE_LOG_ROOT, "captures")
+BOOT_RUNTIME_ROOT = os.path.join(DEV_LOGS_DIR, "boot_auto_handoff_skip_import")
+MAIN_SCRIPT = os.path.join(ROOT_DIR, "main.py")
+RUNTIME_RELAUNCH_EVENT = "Local\\JarvisRuntimeRelaunchRequestV1"
+
+REPORT_PREFIX = "BootTransitionCaptureReport_"
+CAPTURE_MARKERS = (
+    ("01_command_accepted", "BOOT_MAIN|FIRST_COMMAND_ACCEPTED|command=engage_hud"),
+    ("02_transition_begin", "BOOT_MAIN|TRANSITION_BEGIN|import_home=false"),
+    ("03_desktop_shown", "BOOT_MAIN|DESKTOP_SHOWN"),
+    ("04_boot_hidden", "BOOT_MAIN|BOOT_WINDOWS_HIDDEN"),
+    ("05_desktop_visible", "BOOT_MAIN|DESKTOP_VISIBLE"),
+    ("06_desktop_committed", "BOOT_MAIN|DESKTOP_STATE_COMMITTED|state=dormant"),
+    ("07_desktop_settled", "BOOT_MAIN|DESKTOP_SETTLED|state=dormant"),
+)
+
+
+def ensure_dir(path):
+    os.makedirs(path, exist_ok=True)
+
+
+def detect_branch_state():
+    head_path = os.path.join(ROOT_DIR, ".git", "HEAD")
+    try:
+        with open(head_path, "r", encoding="utf-8") as handle:
+            return handle.read().strip()
+    except Exception:
+        return "unavailable"
+
+
+def latest_file_matching(folder_path, prefix, suffix=""):
+    if not os.path.isdir(folder_path):
+        return ""
+
+    best_path = ""
+    best_mtime = -1.0
+    for name in os.listdir(folder_path):
+        if not name.lower().startswith(prefix.lower()):
+            continue
+        if suffix and not name.lower().endswith(suffix.lower()):
+            continue
+        path = os.path.join(folder_path, name)
+        if not os.path.isfile(path):
+            continue
+        try:
+            mtime = os.path.getmtime(path)
+        except OSError:
+            continue
+        if mtime >= best_mtime:
+            best_mtime = mtime
+            best_path = path
+    return best_path
+
+
+def matching_files(folder_path, prefix, suffix):
+    if not os.path.isdir(folder_path):
+        return set()
+
+    matches = set()
+    for name in os.listdir(folder_path):
+        if not name.lower().startswith(prefix.lower()):
+            continue
+        if suffix and not name.lower().endswith(suffix.lower()):
+            continue
+        path = os.path.join(folder_path, name)
+        if os.path.isfile(path):
+            matches.add(os.path.abspath(path))
+    return matches
+
+
+def read_text(path):
+    if not path or not os.path.isfile(path):
+        return ""
+    with open(path, "r", encoding="utf-8", errors="ignore") as handle:
+        return handle.read()
+
+
+def line_status(ok, detail):
+    return {"ok": bool(ok), "detail": detail}
+
+
+def hidden_subprocess_kwargs():
+    kwargs = {
+        "stdout": subprocess.PIPE,
+        "stderr": subprocess.PIPE,
+        "text": True,
+        "encoding": "utf-8",
+        "errors": "replace",
+    }
+
+    if os.name == "nt":
+        startupinfo = subprocess.STARTUPINFO()
+        startupinfo.dwFlags |= subprocess.STARTF_USESHOWWINDOW
+        startupinfo.wShowWindow = 0
+        kwargs["startupinfo"] = startupinfo
+        kwargs["creationflags"] = getattr(subprocess, "CREATE_NO_WINDOW", 0)
+
+    return kwargs
+
+
+def resolve_python_gui_executable():
+    current = os.path.abspath(sys.executable)
+    folder = os.path.dirname(current)
+    if os.path.basename(current).lower() == "pythonw.exe":
+        return current
+    candidate = os.path.join(folder, "pythonw.exe")
+    if os.path.isfile(candidate):
+        return candidate
+    return current
+
+
+def wait_for_runtime_log(before_logs, timeout_seconds=20):
+    deadline = time.time() + max(5, timeout_seconds)
+    latest = ""
+    while time.time() < deadline:
+        current_logs = matching_files(BOOT_RUNTIME_ROOT, "Runtime_", ".txt")
+        new_logs = current_logs - before_logs
+        if len(new_logs) == 1:
+            return sorted(new_logs)[0]
+        if new_logs:
+            latest = latest_file_matching(BOOT_RUNTIME_ROOT, "Runtime_", ".txt")
+            if latest:
+                return latest
+        time.sleep(0.2)
+    return latest
+
+
+def capture_primary_screen(screen, capture_path):
+    pixmap = screen.grabWindow(0, 0, 0, screen.geometry().width(), screen.geometry().height())
+    return bool(pixmap.save(capture_path, "PNG"))
+
+
+def build_report_text(branch_state, report_path, runtime_log_path, capture_dir, captures, checks, stdout_text, stderr_text):
+    lines = [
+        "BOOT TRANSITION CAPTURE",
+        f"Report: {report_path}",
+        f"Branch: {branch_state}",
+        f"Overall Result: {'PASS' if all(item['ok'] for item in checks.values()) else 'FAIL'}",
+        "",
+        f"Boot runtime log: {runtime_log_path}",
+        f"Capture directory: {capture_dir}",
+        "",
+        "Checks:",
+    ]
+
+    for key, value in checks.items():
+        lines.append(f"  {'PASS' if value['ok'] else 'FAIL'} :: {key} :: {value['detail']}")
+
+    lines.append("")
+    lines.append("Captures:")
+    if captures:
+        for capture in captures:
+            lines.append(
+                f"  {capture['label']} :: {capture['marker']} :: {capture['path']} :: saved={capture['saved']}"
+            )
+    else:
+        lines.append("  none")
+
+    if stdout_text:
+        lines.append("")
+        lines.append("stdout:")
+        lines.append(stdout_text)
+
+    if stderr_text:
+        lines.append("")
+        lines.append("stderr:")
+        lines.append(stderr_text)
+
+    return "\n".join(lines) + "\n"
+
+
+def main(argv):
+    open_report = "--open-report" in argv
+
+    ensure_dir(REPORTS_DIR)
+    ensure_dir(CAPTURES_DIR)
+
+    app = QGuiApplication.instance() or QGuiApplication([])
+    screen = app.primaryScreen()
+    stamp = datetime.datetime.now().strftime("%Y%m%d_%H%M%S")
+    capture_dir = os.path.join(CAPTURES_DIR, stamp)
+    ensure_dir(capture_dir)
+
+    before_logs = matching_files(BOOT_RUNTIME_ROOT, "Runtime_", ".txt")
+    runtime_process = None
+    signal = NamedSignal(RUNTIME_RELAUNCH_EVENT)
+    runtime_log_path = ""
+    captures = []
+    stdout_text = ""
+    stderr_text = ""
+    signal_sent = False
+
+    try:
+        python_executable = resolve_python_gui_executable()
+        runtime_process = subprocess.Popen(
+            [
+                python_executable,
+                MAIN_SCRIPT,
+                "--boot-profile",
+                "auto_handoff_skip_import",
+                "--audio-mode",
+                "quiet",
+            ],
+            cwd=ROOT_DIR,
+            **hidden_subprocess_kwargs(),
+        )
+
+        runtime_log_path = wait_for_runtime_log(before_logs, timeout_seconds=20)
+        captured_labels = set()
+        deadline = time.time() + 60
+
+        while time.time() < deadline and len(captured_labels) < len(CAPTURE_MARKERS):
+            app.processEvents()
+            log_text = read_text(runtime_log_path)
+            for label, marker in CAPTURE_MARKERS:
+                if label in captured_labels or marker not in log_text:
+                    continue
+                capture_path = os.path.join(capture_dir, f"{label}.png")
+                saved = bool(screen and capture_primary_screen(screen, capture_path))
+                captures.append(
+                    {
+                        "label": label,
+                        "marker": marker,
+                        "path": capture_path,
+                        "saved": saved,
+                    }
+                )
+                captured_labels.add(label)
+            if "BOOT_MAIN|DESKTOP_SETTLED|state=dormant" in log_text and len(captured_labels) >= 5:
+                break
+            time.sleep(0.2)
+
+        time.sleep(0.5)
+        signal_sent = signal.signal()
+
+        if runtime_process is not None:
+            try:
+                stdout_text, stderr_text = runtime_process.communicate(timeout=20)
+            except subprocess.TimeoutExpired:
+                runtime_process.kill()
+                stdout_text, stderr_text = runtime_process.communicate(timeout=5)
+    finally:
+        if runtime_process is not None and runtime_process.poll() is None:
+            try:
+                runtime_process.kill()
+            except Exception:
+                pass
+        app.processEvents()
+
+    runtime_text = read_text(runtime_log_path)
+    capture_saved_count = sum(1 for capture in captures if capture["saved"])
+
+    checks = {
+        "primary_screen_present": line_status(
+            screen is not None,
+            screen.name() if screen else "missing primary screen",
+        ),
+        "runtime_log_created": line_status(
+            bool(runtime_log_path) and os.path.isfile(runtime_log_path),
+            runtime_log_path or "missing runtime log",
+        ),
+        "expected_sequence_reached": line_status(
+            all(marker in runtime_text for _, marker in CAPTURE_MARKERS),
+            "all capture markers observed" if runtime_text else "capture markers missing",
+        ),
+        "captures_saved": line_status(
+            capture_saved_count == len(CAPTURE_MARKERS),
+            f"saved {capture_saved_count} of {len(CAPTURE_MARKERS)} capture(s)",
+        ),
+        "cleanup_signal_sent": line_status(
+            signal_sent,
+            RUNTIME_RELAUNCH_EVENT if signal_sent else "signal failed",
+        ),
+        "cleanup_markers_present": line_status(
+            "BOOT_MAIN|RELAUNCH_REQUEST_RECEIVED" in runtime_text
+            and "BOOT_MAIN|SHUTDOWN_REQUESTED" in runtime_text
+            and "BOOT_MAIN|EVENT_LOOP_EXIT|code=0" in runtime_text,
+            "cleanup markers observed" if runtime_text else "cleanup markers missing",
+        ),
+        "process_exit_zero": line_status(
+            runtime_process is not None and runtime_process.returncode == 0,
+            f"exit={runtime_process.returncode if runtime_process is not None else 'missing'}",
+        ),
+        "traceback_absent": line_status(
+            "Traceback" not in stdout_text and "Traceback" not in stderr_text and "Traceback" not in runtime_text,
+            "no traceback in runtime/stdout/stderr" if runtime_text or stdout_text or stderr_text else "traceback check unavailable",
+        ),
+    }
+
+    branch_state = detect_branch_state()
+    report_path = os.path.join(REPORTS_DIR, f"{REPORT_PREFIX}{stamp}.txt")
+    json_path = os.path.join(REPORTS_DIR, f"{REPORT_PREFIX}{stamp}.json")
+    report_text = build_report_text(
+        branch_state,
+        report_path,
+        runtime_log_path,
+        capture_dir,
+        captures,
+        checks,
+        stdout_text.strip(),
+        stderr_text.strip(),
+    )
+
+    with open(report_path, "w", encoding="utf-8") as handle:
+        handle.write(report_text)
+
+    with open(json_path, "w", encoding="utf-8") as handle:
+        json.dump(
+            {
+                "branch_state": branch_state,
+                "runtime_log_path": runtime_log_path,
+                "capture_dir": capture_dir,
+                "captures": captures,
+                "checks": checks,
+                "report_path": report_path,
+            },
+            handle,
+            indent=2,
+            sort_keys=True,
+        )
+
+    if open_report and os.name == "nt":
+        try:
+            os.startfile(report_path)
+        except Exception:
+            pass
+
+    print(report_text)
+    return 0 if all(item["ok"] for item in checks.values()) else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))

--- a/dev/jarvis_boot_transition_verification.py
+++ b/dev/jarvis_boot_transition_verification.py
@@ -1,0 +1,287 @@
+import datetime
+import json
+import os
+import subprocess
+import sys
+import time
+
+
+ROOT_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+if ROOT_DIR not in sys.path:
+    sys.path.insert(0, ROOT_DIR)
+
+DEV_LOGS_DIR = os.path.join(ROOT_DIR, "dev", "logs")
+BASE_LOG_ROOT = os.path.join(DEV_LOGS_DIR, "boot_transition_verification")
+REPORTS_DIR = os.path.join(BASE_LOG_ROOT, "reports")
+BOOT_RUNTIME_ROOT = os.path.join(DEV_LOGS_DIR, "boot_auto_handoff_skip_import")
+MAIN_SCRIPT = os.path.join(ROOT_DIR, "main.py")
+RUNTIME_RELAUNCH_EVENT = r"Local\JarvisRuntimeRelaunchRequestV1"
+
+EXPECTED_SEQUENCE = [
+    "BOOT_MAIN|START|profile=auto_handoff_skip_import|audio=quiet",
+    "BOOT_MAIN|BOOT_SEQUENCE_START",
+    "BOOT_MAIN|FIRST_COMMAND_ACCEPTED|command=engage_hud",
+    "BOOT_MAIN|IMPORT_CHOICE_RESOLVED|choice=skip",
+    "BOOT_MAIN|TRANSITION_BEGIN|import_home=false",
+    "BOOT_MAIN|DESKTOP_SHOWN",
+    "BOOT_MAIN|BOOT_WINDOWS_HIDDEN",
+    "BOOT_MAIN|DESKTOP_VISIBLE",
+    "BOOT_MAIN|DESKTOP_STATE_COMMITTED|state=dormant",
+    "BOOT_MAIN|DESKTOP_SETTLED|state=dormant",
+]
+
+CLEAN_EXIT_MARKERS = [
+    "BOOT_MAIN|RELAUNCH_REQUEST_RECEIVED",
+    "BOOT_MAIN|SHUTDOWN_REQUESTED",
+    "BOOT_MAIN|EVENT_LOOP_EXIT|code=0",
+]
+
+
+def hidden_subprocess_kwargs():
+    kwargs = {
+        "stdout": subprocess.PIPE,
+        "stderr": subprocess.PIPE,
+        "text": True,
+        "encoding": "utf-8",
+        "errors": "replace",
+    }
+
+    if os.name == "nt":
+        startupinfo = subprocess.STARTUPINFO()
+        startupinfo.dwFlags |= subprocess.STARTF_USESHOWWINDOW
+        startupinfo.wShowWindow = 0
+        kwargs["startupinfo"] = startupinfo
+        kwargs["creationflags"] = getattr(subprocess, "CREATE_NO_WINDOW", 0)
+
+    return kwargs
+
+
+def ensure_dir(path):
+    os.makedirs(path, exist_ok=True)
+
+
+def read_lines(path):
+    if not os.path.exists(path):
+        return []
+    with open(path, "r", encoding="utf-8", errors="ignore") as f:
+        return [line.rstrip("\r\n") for line in f]
+
+
+def latest_file_matching(folder_path, prefix):
+    if not os.path.isdir(folder_path):
+        return ""
+
+    best_path = ""
+    best_mtime = -1.0
+    for name in os.listdir(folder_path):
+        if not name.lower().startswith(prefix.lower()):
+            continue
+        path = os.path.join(folder_path, name)
+        if not os.path.isfile(path):
+            continue
+        try:
+            mtime = os.path.getmtime(path)
+        except OSError:
+            continue
+        if mtime >= best_mtime:
+            best_mtime = mtime
+            best_path = path
+    return best_path
+
+
+def line_status(ok, detail):
+    return {"ok": bool(ok), "detail": detail}
+
+
+def detect_branch_state():
+    head_path = os.path.join(ROOT_DIR, ".git", "HEAD")
+    try:
+        with open(head_path, "r", encoding="utf-8") as f:
+            return f.read().strip()
+    except Exception:
+        return "unavailable"
+
+
+def find_new_runtime_file(before_set, timeout_seconds=25.0):
+    deadline = time.time() + timeout_seconds
+    while time.time() < deadline:
+        current_files = {
+            name for name in os.listdir(BOOT_RUNTIME_ROOT)
+            if name.lower().startswith("runtime_") and name.lower().endswith("_quiet.txt")
+        } if os.path.isdir(BOOT_RUNTIME_ROOT) else set()
+        new_files = sorted(current_files - before_set)
+        if new_files:
+            return os.path.join(BOOT_RUNTIME_ROOT, new_files[-1])
+        time.sleep(0.1)
+    return ""
+
+
+def wait_for_markers(runtime_log, expected_markers, timeout_seconds=45.0):
+    deadline = time.time() + timeout_seconds
+    runtime_lines = []
+    while time.time() < deadline:
+        runtime_lines = read_lines(runtime_log)
+        if all(any(marker in line for line in runtime_lines) for marker in expected_markers):
+            return runtime_lines, True
+        time.sleep(0.2)
+    return runtime_lines, False
+
+
+def marker_line_indexes(runtime_lines, markers):
+    indexes = {}
+    for marker in markers:
+        indexes[marker] = -1
+        for index, line in enumerate(runtime_lines):
+            if marker in line:
+                indexes[marker] = index
+                break
+    return indexes
+
+
+def send_runtime_relaunch_signal():
+    from desktop.single_instance import NamedSignal
+
+    signal = NamedSignal(RUNTIME_RELAUNCH_EVENT)
+    try:
+        return bool(signal.signal())
+    finally:
+        signal.close()
+
+
+def run_verification():
+    ensure_dir(BASE_LOG_ROOT)
+    ensure_dir(REPORTS_DIR)
+
+    before_files = {
+        name for name in os.listdir(BOOT_RUNTIME_ROOT)
+        if name.lower().startswith("runtime_") and name.lower().endswith("_quiet.txt")
+    } if os.path.isdir(BOOT_RUNTIME_ROOT) else set()
+
+    proc = subprocess.Popen(
+        [
+            sys.executable,
+            MAIN_SCRIPT,
+            "--boot-profile",
+            "auto_handoff_skip_import",
+            "--audio-mode",
+            "quiet",
+        ],
+        cwd=ROOT_DIR,
+        **hidden_subprocess_kwargs(),
+    )
+
+    runtime_log = find_new_runtime_file(before_files)
+    runtime_lines = []
+    reached_expected_sequence = False
+    signal_sent = False
+
+    try:
+        if runtime_log:
+            runtime_lines, reached_expected_sequence = wait_for_markers(runtime_log, EXPECTED_SEQUENCE)
+    finally:
+        signal_sent = send_runtime_relaunch_signal()
+        try:
+            proc.wait(timeout=15)
+        except subprocess.TimeoutExpired:
+            proc.kill()
+            proc.wait(timeout=5)
+
+    stdout_text, stderr_text = proc.communicate()
+    runtime_lines = read_lines(runtime_log) if runtime_log else []
+    marker_indexes = marker_line_indexes(runtime_lines, EXPECTED_SEQUENCE)
+    ordered = all(
+        marker_indexes[EXPECTED_SEQUENCE[index]] >= 0
+        and marker_indexes[EXPECTED_SEQUENCE[index + 1]] >= 0
+        and marker_indexes[EXPECTED_SEQUENCE[index]] < marker_indexes[EXPECTED_SEQUENCE[index + 1]]
+        for index in range(len(EXPECTED_SEQUENCE) - 1)
+    )
+
+    checks = {
+        "runtime_log_created": line_status(bool(runtime_log and os.path.exists(runtime_log)), runtime_log or "missing"),
+        "expected_sequence_reached": line_status(reached_expected_sequence, "all expected handoff markers observed"),
+        "handoff_marker_order_valid": line_status(ordered, json.dumps(marker_indexes, indent=2)),
+        "runtime_cleanup_signal_sent": line_status(signal_sent, RUNTIME_RELAUNCH_EVENT),
+    }
+
+    for marker in EXPECTED_SEQUENCE:
+        checks[f"marker::{marker}"] = line_status(
+            any(marker in line for line in runtime_lines),
+            marker,
+        )
+
+    for marker in CLEAN_EXIT_MARKERS:
+        checks[f"cleanup::{marker}"] = line_status(
+            any(marker in line for line in runtime_lines),
+            marker,
+        )
+
+    checks["process_exit_zero"] = line_status(proc.returncode == 0, f"exit={proc.returncode}")
+    checks["traceback_absent"] = line_status(
+        "Traceback" not in stdout_text and "Traceback" not in stderr_text,
+        (stderr_text or stdout_text or "no traceback in stdout/stderr").strip(),
+    )
+
+    return {
+        "branch_state": detect_branch_state(),
+        "runtime_log": runtime_log,
+        "checks": checks,
+        "stdout": stdout_text.strip(),
+        "stderr": stderr_text.strip(),
+    }
+
+
+def build_report_text(report_path, result, overall_ok):
+    lines = [
+        "BOOT TO DESKTOP HANDOFF VERIFICATION",
+        f"Report: {report_path}",
+        f"Branch: {result['branch_state']}",
+        f"Overall Result: {'PASS' if overall_ok else 'FAIL'}",
+        "",
+        f"Boot runtime log: {result['runtime_log'] or 'missing'}",
+        "",
+        "Checks:",
+    ]
+
+    for key, value in result["checks"].items():
+        lines.append(f"  {'PASS' if value['ok'] else 'FAIL'} :: {key} :: {value['detail']}")
+
+    if result["stdout"]:
+        lines.extend(["", "stdout:", result["stdout"]])
+    if result["stderr"]:
+        lines.extend(["", "stderr:", result["stderr"]])
+
+    return "\n".join(lines) + "\n"
+
+
+def main(argv):
+    open_report = "--open-report" in argv
+
+    result = run_verification()
+    failures = [key for key, value in result["checks"].items() if not value["ok"]]
+    overall_ok = not failures
+
+    stamp = datetime.datetime.now().strftime("%Y%m%d_%H%M%S")
+    report_path = os.path.join(REPORTS_DIR, f"BootTransitionVerificationReport_{stamp}.txt")
+    json_path = os.path.join(REPORTS_DIR, f"BootTransitionVerificationReport_{stamp}.json")
+
+    report_text = build_report_text(report_path, result, overall_ok)
+
+    with open(report_path, "w", encoding="utf-8") as f:
+        f.write(report_text)
+
+    with open(json_path, "w", encoding="utf-8") as f:
+        json.dump(result, f, indent=2)
+
+    print(report_text)
+
+    if open_report:
+        try:
+            os.startfile(report_path)
+        except Exception:
+            pass
+
+    return 0 if overall_ok else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))

--- a/dev/jarvis_desktop_toolkit_validation.py
+++ b/dev/jarvis_desktop_toolkit_validation.py
@@ -1,0 +1,418 @@
+import datetime
+import importlib.machinery
+import importlib.util
+import json
+import os
+import subprocess
+import sys
+import time
+
+os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+
+from PySide6.QtCore import Qt
+from PySide6.QtTest import QTest
+
+
+ROOT_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+DEV_LOGS_DIR = os.path.join(ROOT_DIR, "dev", "logs")
+BASE_LOG_ROOT = os.path.join(DEV_LOGS_DIR, "desktop_toolkit_validation")
+REPORTS_DIR = os.path.join(BASE_LOG_ROOT, "reports")
+
+DEV_LAUNCHER_SCRIPT = os.path.join(ROOT_DIR, "dev", "launchers", "jarvis_dev_launcher.pyw")
+DEV_LAUNCHERS_DIR = os.path.join(ROOT_DIR, "dev", "launchers")
+
+REPORT_PREFIX = "DesktopToolkitValidationReport_"
+
+DESKTOP_CASES = (
+    {
+        "name": "Toolkit Desktop Helper: Healthy Desktop Validation",
+        "lane_key": "desktopHealthy",
+        "lane_label": "Healthy Desktop Launch Validation",
+        "expected_launcher": "launch_jarvis_desktop_entrypoint_validation.vbs",
+        "report_root": os.path.join(DEV_LOGS_DIR, "desktop_entrypoint_validation", "reports"),
+        "report_prefix": "DesktopEntrypointValidationReport_",
+        "timeout_seconds": 60,
+    },
+    {
+        "name": "Toolkit Desktop Helper: Healthy Launcher Validation",
+        "lane_key": "launcherHealthy",
+        "lane_label": "Healthy Launcher Path Validation",
+        "expected_launcher": "launch_jarvis_desktop_launcher_healthy_validation.vbs",
+        "report_root": os.path.join(DEV_LOGS_DIR, "desktop_launcher_healthy_validation", "reports"),
+        "report_prefix": "DesktopLauncherHealthyValidationReport_",
+        "timeout_seconds": 90,
+    },
+)
+
+
+def ensure_dir(path):
+    os.makedirs(path, exist_ok=True)
+
+
+def reset_dir(path):
+    if not os.path.isdir(path):
+        os.makedirs(path, exist_ok=True)
+        return
+
+    for name in os.listdir(path):
+        child = os.path.join(path, name)
+        try:
+            if os.path.isdir(child):
+                for root, dirs, files in os.walk(child, topdown=False):
+                    for file_name in files:
+                        os.remove(os.path.join(root, file_name))
+                    for dir_name in dirs:
+                        os.rmdir(os.path.join(root, dir_name))
+                os.rmdir(child)
+            else:
+                os.remove(child)
+        except Exception:
+            pass
+
+
+def detect_branch_state():
+    head_path = os.path.join(ROOT_DIR, ".git", "HEAD")
+    try:
+        with open(head_path, "r", encoding="utf-8") as handle:
+            return handle.read().strip()
+    except Exception:
+        return "unavailable"
+
+
+def latest_file_matching(folder_path, prefix, suffix=""):
+    if not os.path.isdir(folder_path):
+        return ""
+
+    best_path = ""
+    best_mtime = -1.0
+    for name in os.listdir(folder_path):
+        if not name.lower().startswith(prefix.lower()):
+            continue
+        if suffix and not name.lower().endswith(suffix.lower()):
+            continue
+        path = os.path.join(folder_path, name)
+        if not os.path.isfile(path):
+            continue
+        try:
+            mtime = os.path.getmtime(path)
+        except OSError:
+            continue
+        if mtime >= best_mtime:
+            best_mtime = mtime
+            best_path = path
+    return best_path
+
+
+def matching_files(folder_path, prefix, suffix):
+    if not os.path.isdir(folder_path):
+        return set()
+
+    matches = set()
+    for name in os.listdir(folder_path):
+        if not name.lower().startswith(prefix.lower()):
+            continue
+        if suffix and not name.lower().endswith(suffix.lower()):
+            continue
+        path = os.path.join(folder_path, name)
+        if os.path.isfile(path):
+            matches.add(os.path.abspath(path))
+    return matches
+
+
+def read_text(path):
+    if not path or not os.path.isfile(path):
+        return ""
+    with open(path, "r", encoding="utf-8", errors="ignore") as handle:
+        return handle.read()
+
+
+def line_status(ok, detail):
+    return {"ok": bool(ok), "detail": detail}
+
+
+def load_module_from_path(module_name, module_path):
+    loader = importlib.machinery.SourceFileLoader(module_name, module_path)
+    spec = importlib.util.spec_from_loader(module_name, loader)
+    module = importlib.util.module_from_spec(spec)
+    loader.exec_module(module)
+    return module
+
+
+def wait_for_new_report(report_root, report_prefix, before_reports, timeout_seconds, app):
+    deadline = time.time() + max(5, timeout_seconds)
+    latest = ""
+    while time.time() < deadline:
+        current_reports = matching_files(report_root, report_prefix, ".txt")
+        new_reports = current_reports - before_reports
+        if len(new_reports) == 1:
+            return sorted(new_reports)[0]
+        if new_reports:
+            latest = latest_file_matching(report_root, report_prefix, ".txt")
+            if latest:
+                return latest
+        app.processEvents()
+        time.sleep(0.2)
+    return latest
+
+
+def run_toolkit_case(dev_launcher_module, window, app, case):
+    before_reports = matching_files(case["report_root"], case["report_prefix"], ".txt")
+    launch_records = []
+    opened_paths = []
+    toolkit_events = []
+
+    original_popen = subprocess.Popen
+    original_open_path = window.open_path
+    original_runtime_logger = window.runtime_logger
+
+    def runtime_logger(event):
+        toolkit_events.append(event)
+        if callable(original_runtime_logger):
+            original_runtime_logger(event)
+
+    def fake_open_path(path, success_message):
+        opened_paths.append({"path": os.path.abspath(path), "message": success_message})
+        window.set_status(success_message)
+
+    def recording_popen(args, cwd=None, **kwargs):
+        launch_records.append(
+            {
+                "args": list(args),
+                "cwd": os.path.abspath(cwd or ROOT_DIR),
+            }
+        )
+        launch_env = os.environ.copy()
+        launch_env.pop("QT_QPA_PLATFORM", None)
+        kwargs["env"] = launch_env
+        return original_popen(args, cwd=cwd, **kwargs)
+
+    window.runtime_logger = runtime_logger
+    window.open_path = fake_open_path
+    subprocess.Popen = recording_popen
+
+    launch_status = ""
+    complete_status = ""
+    open_status = ""
+    new_report_path = ""
+    try:
+        window.select_lane(case["lane_key"])
+        app.processEvents()
+        window.delay_combo.setCurrentIndex(1)
+        app.processEvents()
+
+        QTest.mouseClick(window.launch_btn, Qt.LeftButton)
+        app.processEvents()
+        launch_status = window.status_label.text()
+
+        new_report_path = wait_for_new_report(
+            case["report_root"],
+            case["report_prefix"],
+            before_reports,
+            case["timeout_seconds"],
+            app,
+        )
+
+        window.refresh_background_run_status()
+        app.processEvents()
+        complete_status = window.status_label.text()
+
+        window.open_latest_report()
+        app.processEvents()
+        open_status = window.status_label.text()
+    finally:
+        subprocess.Popen = original_popen
+        window.open_path = original_open_path
+        window.runtime_logger = original_runtime_logger
+
+    latest_opened_path = opened_paths[-1]["path"] if opened_paths else ""
+    report_text = read_text(new_report_path)
+    launch_record = launch_records[0] if launch_records else {}
+    expected_launcher_path = os.path.join(DEV_LAUNCHERS_DIR, case["expected_launcher"])
+    expected_launch_marker = (
+        f"TOOLKIT_MAIN|LANE_LAUNCHED|lane={case['lane_key']}|mode=quiet|label={case['lane_label']}"
+    )
+
+    checks = {
+        "selected_lane_expected": line_status(
+            window.current_lane_key() == case["lane_key"],
+            window.current_lane_key(),
+        ),
+        "launch_mode_quiet": line_status(
+            window.current_launch_mode_key() == "quiet",
+            window.current_launch_mode_key(),
+        ),
+        "launcher_process_invoked_once": line_status(
+            len(launch_records) == 1,
+            f"launch records={len(launch_records)}",
+        ),
+        "launcher_host_is_wscript": line_status(
+            bool(launch_record)
+            and len(launch_record["args"]) >= 2
+            and os.path.basename(launch_record["args"][0]).lower() == "wscript.exe",
+            launch_record.get("args", ["missing"])[0] if launch_record else "missing launch",
+        ),
+        "launcher_path_expected": line_status(
+            bool(launch_record)
+            and len(launch_record["args"]) >= 2
+            and os.path.normcase(os.path.abspath(launch_record["args"][1]))
+            == os.path.normcase(os.path.abspath(expected_launcher_path)),
+            launch_record.get("args", ["", "missing"])[1] if launch_record else "missing launch",
+        ),
+        "launcher_cwd_expected": line_status(
+            bool(launch_record)
+            and os.path.normcase(os.path.abspath(launch_record.get("cwd", "")))
+            == os.path.normcase(os.path.abspath(DEV_LAUNCHERS_DIR)),
+            launch_record.get("cwd", "missing cwd") if launch_record else "missing launch",
+        ),
+        "launch_marker_emitted": line_status(
+            expected_launch_marker in toolkit_events,
+            expected_launch_marker,
+        ),
+        "launch_status_expected": line_status(
+            launch_status.startswith(f"Test in progress: {case['lane_label']}"),
+            launch_status or "missing launch status",
+        ),
+        "new_report_created": line_status(
+            bool(new_report_path) and os.path.isfile(new_report_path),
+            new_report_path or "missing new report",
+        ),
+        "report_overall_pass": line_status(
+            "Overall Result: PASS" in report_text,
+            new_report_path or "missing report",
+        ),
+        "complete_status_expected": line_status(
+            complete_status == f"Test complete: {case['lane_label']}",
+            complete_status or "missing completion status",
+        ),
+        "latest_report_opened": line_status(
+            bool(latest_opened_path),
+            latest_opened_path or "no opened report path captured",
+        ),
+        "opened_report_matches_new_report": line_status(
+            bool(new_report_path)
+            and bool(latest_opened_path)
+            and os.path.normcase(os.path.abspath(latest_opened_path))
+            == os.path.normcase(os.path.abspath(new_report_path)),
+            latest_opened_path or "no opened report path captured",
+        ),
+        "open_status_expected": line_status(
+            open_status.startswith("Opened latest report: "),
+            open_status or "missing open status",
+        ),
+    }
+
+    return {
+        "name": case["name"],
+        "lane_label": case["lane_label"],
+        "report_path": new_report_path,
+        "opened_report_path": latest_opened_path,
+        "launch_status": launch_status,
+        "complete_status": complete_status,
+        "open_status": open_status,
+        "launch_record": launch_record,
+        "checks": checks,
+    }
+
+
+def collect_failures(section):
+    failures = []
+    for key, value in section["checks"].items():
+        if not value["ok"]:
+            failures.append(f"{section['name']} :: {key}: {value['detail']}")
+    return failures
+
+
+def build_report_text(branch_state, report_path, sections, overall_ok):
+    lines = [
+        "JARVIS DESKTOP TOOLKIT VALIDATION",
+        f"Report: {report_path}",
+        f"Branch: {branch_state}",
+        f"Overall Result: {'PASS' if overall_ok else 'FAIL'}",
+        "",
+    ]
+
+    for section in sections:
+        lines.append(f"{section['name']}:")
+        lines.append(f"  lane: {section['lane_label']}")
+        if section.get("report_path"):
+            lines.append(f"  report: {section['report_path']}")
+        if section.get("opened_report_path"):
+            lines.append(f"  opened report: {section['opened_report_path']}")
+        if section.get("launch_status"):
+            lines.append(f"  launch status: {section['launch_status']}")
+        if section.get("complete_status"):
+            lines.append(f"  completion status: {section['complete_status']}")
+        if section.get("open_status"):
+            lines.append(f"  open status: {section['open_status']}")
+        for key, value in section["checks"].items():
+            lines.append(f"  {'PASS' if value['ok'] else 'FAIL'} :: {key} :: {value['detail']}")
+        lines.append("")
+
+    return "\n".join(lines) + "\n"
+
+
+def main(argv):
+    open_report = "--open-report" in argv
+
+    reset_dir(BASE_LOG_ROOT)
+    ensure_dir(REPORTS_DIR)
+
+    dev_launcher_module = load_module_from_path(
+        "jarvis_dev_launcher_desktop_toolkit_validation_module",
+        DEV_LAUNCHER_SCRIPT,
+    )
+
+    app = dev_launcher_module.QApplication.instance() or dev_launcher_module.QApplication([])
+    window = dev_launcher_module.DevLauncherWindow()
+    window.show()
+    app.processEvents()
+
+    try:
+        sections = [
+            run_toolkit_case(dev_launcher_module, window, app, case)
+            for case in DESKTOP_CASES
+        ]
+    finally:
+        window.close()
+        app.quit()
+
+    failures = []
+    for section in sections:
+        failures.extend(collect_failures(section))
+
+    overall_ok = not failures
+    branch_state = detect_branch_state()
+    stamp = datetime.datetime.now().strftime("%Y%m%d_%H%M%S")
+    report_path = os.path.join(REPORTS_DIR, f"{REPORT_PREFIX}{stamp}.txt")
+    json_path = os.path.join(REPORTS_DIR, f"{REPORT_PREFIX}{stamp}.json")
+    report_text = build_report_text(branch_state, report_path, sections, overall_ok)
+
+    with open(report_path, "w", encoding="utf-8") as handle:
+        handle.write(report_text)
+
+    with open(json_path, "w", encoding="utf-8") as handle:
+        json.dump(
+            {
+                "branch_state": branch_state,
+                "overall_ok": overall_ok,
+                "sections": sections,
+                "failures": failures,
+                "report_path": report_path,
+            },
+            handle,
+            indent=2,
+            sort_keys=True,
+        )
+
+    if open_report and os.name == "nt":
+        try:
+            os.startfile(report_path)
+        except Exception:
+            pass
+
+    print(report_text)
+    return 0 if overall_ok else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))

--- a/dev/jarvis_dev_toolkit_smoke_validation.py
+++ b/dev/jarvis_dev_toolkit_smoke_validation.py
@@ -1,0 +1,271 @@
+import datetime
+import json
+import os
+import subprocess
+import sys
+
+
+ROOT_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+DEV_LOGS_DIR = os.path.join(ROOT_DIR, "dev", "logs")
+BASE_LOG_ROOT = os.path.join(DEV_LOGS_DIR, "dev_toolkit_smoke_validation")
+REPORTS_DIR = os.path.join(BASE_LOG_ROOT, "reports")
+
+BOOT_TOOLKIT_VALIDATION_SCRIPT = os.path.join(ROOT_DIR, "dev", "jarvis_boot_toolkit_validation.py")
+DESKTOP_TOOLKIT_VALIDATION_SCRIPT = os.path.join(ROOT_DIR, "dev", "jarvis_desktop_toolkit_validation.py")
+
+BOOT_TOOLKIT_REPORTS_DIR = os.path.join(DEV_LOGS_DIR, "boot_toolkit_validation", "reports")
+DESKTOP_TOOLKIT_REPORTS_DIR = os.path.join(DEV_LOGS_DIR, "desktop_toolkit_validation", "reports")
+
+REPORT_PREFIX = "DevToolkitSmokeValidationReport_"
+
+
+def ensure_dir(path):
+    os.makedirs(path, exist_ok=True)
+
+
+def reset_dir(path):
+    if not os.path.isdir(path):
+        os.makedirs(path, exist_ok=True)
+        return
+
+    for name in os.listdir(path):
+        child = os.path.join(path, name)
+        try:
+            if os.path.isdir(child):
+                for root, dirs, files in os.walk(child, topdown=False):
+                    for file_name in files:
+                        os.remove(os.path.join(root, file_name))
+                    for dir_name in dirs:
+                        os.rmdir(os.path.join(root, dir_name))
+                os.rmdir(child)
+            else:
+                os.remove(child)
+        except Exception:
+            pass
+
+
+def detect_branch_state():
+    head_path = os.path.join(ROOT_DIR, ".git", "HEAD")
+    try:
+        with open(head_path, "r", encoding="utf-8") as handle:
+            return handle.read().strip()
+    except Exception:
+        return "unavailable"
+
+
+def latest_file_matching(folder_path, prefix, suffix=""):
+    if not os.path.isdir(folder_path):
+        return ""
+
+    best_path = ""
+    best_mtime = -1.0
+    for name in os.listdir(folder_path):
+        if not name.lower().startswith(prefix.lower()):
+            continue
+        if suffix and not name.lower().endswith(suffix.lower()):
+            continue
+        path = os.path.join(folder_path, name)
+        if not os.path.isfile(path):
+            continue
+        try:
+            mtime = os.path.getmtime(path)
+        except OSError:
+            continue
+        if mtime >= best_mtime:
+            best_mtime = mtime
+            best_path = path
+    return best_path
+
+
+def matching_files(folder_path, prefix, suffix):
+    if not os.path.isdir(folder_path):
+        return set()
+
+    matches = set()
+    for name in os.listdir(folder_path):
+        if not name.lower().startswith(prefix.lower()):
+            continue
+        if suffix and not name.lower().endswith(suffix.lower()):
+            continue
+        path = os.path.join(folder_path, name)
+        if os.path.isfile(path):
+            matches.add(os.path.abspath(path))
+    return matches
+
+
+def read_text(path):
+    if not path or not os.path.isfile(path):
+        return ""
+    with open(path, "r", encoding="utf-8", errors="ignore") as handle:
+        return handle.read()
+
+
+def line_status(ok, detail):
+    return {"ok": bool(ok), "detail": detail}
+
+
+def hidden_subprocess_kwargs():
+    kwargs = {
+        "stdout": subprocess.PIPE,
+        "stderr": subprocess.PIPE,
+        "text": True,
+        "encoding": "utf-8",
+        "errors": "replace",
+    }
+
+    if os.name == "nt":
+        startupinfo = subprocess.STARTUPINFO()
+        startupinfo.dwFlags |= subprocess.STARTF_USESHOWWINDOW
+        startupinfo.wShowWindow = 0
+        kwargs["startupinfo"] = startupinfo
+        kwargs["creationflags"] = getattr(subprocess, "CREATE_NO_WINDOW", 0)
+
+    return kwargs
+
+
+def run_validation_case(name, script_path, report_root, report_prefix, timeout_seconds):
+    before_reports = matching_files(report_root, report_prefix, ".txt")
+    result = subprocess.run(
+        [sys.executable, script_path],
+        cwd=ROOT_DIR,
+        timeout=timeout_seconds,
+        **hidden_subprocess_kwargs(),
+    )
+
+    after_reports = matching_files(report_root, report_prefix, ".txt")
+    new_reports = after_reports - before_reports
+    if len(new_reports) == 1:
+        report_path = sorted(new_reports)[0]
+    elif new_reports:
+        report_path = latest_file_matching(report_root, report_prefix, ".txt")
+    else:
+        report_path = latest_file_matching(report_root, report_prefix, ".txt")
+
+    report_text = read_text(report_path)
+    checks = {
+        "script_exit_zero": line_status(
+            result.returncode == 0,
+            f"exit={result.returncode}",
+        ),
+        "fresh_report_created": line_status(
+            bool(report_path) and os.path.isfile(report_path) and os.path.abspath(report_path) in after_reports,
+            report_path or "missing report",
+        ),
+        "report_overall_pass": line_status(
+            "Overall Result: PASS" in report_text,
+            report_path or "missing report",
+        ),
+        "traceback_absent": line_status(
+            "Traceback" not in result.stdout and "Traceback" not in result.stderr,
+            "no traceback in stdout/stderr",
+        ),
+    }
+
+    return {
+        "name": name,
+        "script_path": script_path,
+        "report_path": report_path,
+        "stdout": result.stdout.strip(),
+        "stderr": result.stderr.strip(),
+        "checks": checks,
+    }
+
+
+def collect_failures(section):
+    failures = []
+    for key, value in section["checks"].items():
+        if not value["ok"]:
+            failures.append(f"{section['name']} :: {key}: {value['detail']}")
+    return failures
+
+
+def build_report_text(branch_state, report_path, sections, overall_ok):
+    lines = [
+        "DEV TOOLKIT SMOKE VALIDATION",
+        f"Report: {report_path}",
+        f"Branch: {branch_state}",
+        f"Overall Result: {'PASS' if overall_ok else 'FAIL'}",
+        "",
+    ]
+
+    for section in sections:
+        lines.append(f"{section['name']}:")
+        lines.append(f"  script: {section['script_path']}")
+        if section.get("report_path"):
+            lines.append(f"  report: {section['report_path']}")
+        for key, value in section["checks"].items():
+            lines.append(f"  {'PASS' if value['ok'] else 'FAIL'} :: {key} :: {value['detail']}")
+        if section.get("stdout"):
+            lines.append("  stdout:")
+            lines.extend(f"    {line}" for line in section["stdout"].splitlines())
+        if section.get("stderr"):
+            lines.append("  stderr:")
+            lines.extend(f"    {line}" for line in section["stderr"].splitlines())
+        lines.append("")
+
+    return "\n".join(lines) + "\n"
+
+
+def main(argv):
+    open_report = "--open-report" in argv
+
+    reset_dir(BASE_LOG_ROOT)
+    ensure_dir(REPORTS_DIR)
+
+    sections = [
+        run_validation_case(
+            name="Boot Helper Toolkit Validation",
+            script_path=BOOT_TOOLKIT_VALIDATION_SCRIPT,
+            report_root=BOOT_TOOLKIT_REPORTS_DIR,
+            report_prefix="BootToolkitValidationReport_",
+            timeout_seconds=240,
+        ),
+        run_validation_case(
+            name="Desktop Helper Toolkit Validation",
+            script_path=DESKTOP_TOOLKIT_VALIDATION_SCRIPT,
+            report_root=DESKTOP_TOOLKIT_REPORTS_DIR,
+            report_prefix="DesktopToolkitValidationReport_",
+            timeout_seconds=240,
+        ),
+    ]
+
+    failures = []
+    for section in sections:
+        failures.extend(collect_failures(section))
+
+    overall_ok = not failures
+    branch_state = detect_branch_state()
+    stamp = datetime.datetime.now().strftime("%Y%m%d_%H%M%S")
+    report_path = os.path.join(REPORTS_DIR, f"{REPORT_PREFIX}{stamp}.txt")
+    json_path = os.path.join(REPORTS_DIR, f"{REPORT_PREFIX}{stamp}.json")
+    report_text = build_report_text(branch_state, report_path, sections, overall_ok)
+
+    with open(report_path, "w", encoding="utf-8") as handle:
+        handle.write(report_text)
+
+    with open(json_path, "w", encoding="utf-8") as handle:
+        json.dump(
+            {
+                "branch_state": branch_state,
+                "overall_ok": overall_ok,
+                "sections": sections,
+                "failures": failures,
+                "report_path": report_path,
+            },
+            handle,
+            indent=2,
+            sort_keys=True,
+        )
+
+    if open_report and os.name == "nt":
+        try:
+            os.startfile(report_path)
+        except Exception:
+            pass
+
+    print(report_text)
+    return 0 if overall_ok else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))

--- a/dev/launchers/jarvis_dev_launcher.pyw
+++ b/dev/launchers/jarvis_dev_launcher.pyw
@@ -2009,7 +2009,7 @@ class DevLauncherWindow(QWidget):
         try:
             lane = self.current_lane()
             lane_key = self.current_lane_key()
-            mode_key = self.current_mode_key()
+            mode_key = self.current_launch_mode_key()
             lane_label = lane.get("label", "Unknown lane")
             if lane.get("requires_bundle_input"):
                 source_path = self.select_support_bundle_source()
@@ -2057,7 +2057,7 @@ class DevLauncherWindow(QWidget):
                 self.session_launch_records.pop(launch_key, None)
             self.active_background_run = {}
             self.runtime_milestone(
-                f"TOOLKIT_MAIN|LANE_LAUNCH_FAILED|lane={self.current_lane_key()}|mode={self.current_mode_key()}|reason={type(exc).__name__}"
+                f"TOOLKIT_MAIN|LANE_LAUNCH_FAILED|lane={self.current_lane_key()}|mode={self.current_launch_mode_key()}|reason={type(exc).__name__}"
             )
             self.set_status(f"Launch failed: {self.active_label()} :: {exc}")
         finally:

--- a/dev/launchers/jarvis_dev_launcher.pyw
+++ b/dev/launchers/jarvis_dev_launcher.pyw
@@ -2249,12 +2249,15 @@ def main():
     if not acquire_or_prompt_replace(
         dev_toolkit_guard,
         dev_toolkit_relaunch_signal,
-        "Jarvis Dev Toolkit Already Open",
-        "Jarvis Dev Toolkit is already open.\n\nDo you want to close the current toolkit window and open a new one?",
+        "Dev Toolkit Session Active",
+        "A Jarvis Dev Toolkit session is already open.\n\nDo you want to close the current toolkit window and relaunch a fresh Dev Toolkit session?",
+        eyebrow_text="JARVIS DEV TOOLKIT",
+        primary_button_text="Relaunch Dev Toolkit",
+        secondary_button_text="Keep Current Toolkit",
     ):
         return 0
 
-    app = QApplication(sys.argv)
+    app = QApplication.instance() or QApplication(sys.argv)
     app.setFont(QFont("Consolas", 10))
     window = DevLauncherWindow()
     window.show()

--- a/dev/launchers/jarvis_dev_launcher.pyw
+++ b/dev/launchers/jarvis_dev_launcher.pyw
@@ -270,6 +270,24 @@ LANE_CONFIG = {
         "report_suffix": ".txt",
         "crash_folder": "",
     },
+    "devToolkitSmokeValidation": {
+        "label": "Dev Toolkit Smoke Validation",
+        "detail": (
+            "Runs the boot-side Toolkit validation and the desktop-side Toolkit validation in sequence, "
+            "then writes one consolidated smoke report so the current helper-lane wiring can be checked "
+            "with a single background run."
+        ),
+        "quiet_launcher": "launch_jarvis_dev_toolkit_smoke_validation.vbs",
+        "voice_launcher": "",
+        "supports_voice": False,
+        "available_modes": ("quiet",),
+        "opens_window": False,
+        "log_root": os.path.join(DEV_LOGS_DIR, "dev_toolkit_smoke_validation"),
+        "report_root": os.path.join(DEV_LOGS_DIR, "dev_toolkit_smoke_validation", "reports"),
+        "report_prefix": "DevToolkitSmokeValidationReport_",
+        "report_suffix": ".txt",
+        "crash_folder": "",
+    },
     "launcherRegression": {
         "label": "Desktop Launcher Regression Harness",
         "detail": (
@@ -386,6 +404,7 @@ CONFIG_LANE_GROUPS = (
             "desktopHealthy",
             "launcherHealthy",
             "desktopToolkitValidation",
+            "devToolkitSmokeValidation",
             "launcherRegression",
         ),
     },

--- a/dev/launchers/jarvis_dev_launcher.pyw
+++ b/dev/launchers/jarvis_dev_launcher.pyw
@@ -148,6 +148,23 @@ LANE_CONFIG = {
         "report_suffix": ".txt",
         "crash_folder": "",
     },
+    "bootTransitionCapture": {
+        "label": "Boot Transition Capture",
+        "detail": (
+            "Runs the quiet auto-handoff boot path, captures primary-screen transition frames at key "
+            "handoff markers, and writes a compact report with the saved PNG sequence."
+        ),
+        "quiet_launcher": "launch_jarvis_boot_transition_capture.vbs",
+        "voice_launcher": "",
+        "supports_voice": False,
+        "available_modes": ("quiet",),
+        "opens_window": False,
+        "log_root": os.path.join(DEV_LOGS_DIR, "boot_transition_capture"),
+        "report_root": os.path.join(DEV_LOGS_DIR, "boot_transition_capture", "reports"),
+        "report_prefix": "BootTransitionCaptureReport_",
+        "report_suffix": ".txt",
+        "crash_folder": "",
+    },
     "bootMonitorPreflight": {
         "label": "Boot Monitor Preflight",
         "detail": (
@@ -232,6 +249,24 @@ LANE_CONFIG = {
         "log_root": os.path.join(DEV_LOGS_DIR, "desktop_launcher_healthy_validation"),
         "report_root": os.path.join(DEV_LOGS_DIR, "desktop_launcher_healthy_validation", "reports"),
         "report_prefix": "DesktopLauncherHealthyValidationReport_",
+        "report_suffix": ".txt",
+        "crash_folder": "",
+    },
+    "desktopToolkitValidation": {
+        "label": "Desktop Helper Toolkit Validation",
+        "detail": (
+            "Runs a contained offscreen validation of the desktop helper lanes and verifies the "
+            "Dev Toolkit can launch Healthy Desktop Launch Validation and Healthy Launcher Path "
+            "Validation and reopen their fresh reports."
+        ),
+        "quiet_launcher": "launch_jarvis_desktop_toolkit_validation.vbs",
+        "voice_launcher": "",
+        "supports_voice": False,
+        "available_modes": ("quiet",),
+        "opens_window": False,
+        "log_root": os.path.join(DEV_LOGS_DIR, "desktop_toolkit_validation"),
+        "report_root": os.path.join(DEV_LOGS_DIR, "desktop_toolkit_validation", "reports"),
+        "report_prefix": "DesktopToolkitValidationReport_",
         "report_suffix": ".txt",
         "crash_folder": "",
     },
@@ -339,13 +374,20 @@ CONFIG_LANE_GROUPS = (
             "bootManualFlow",
             "bootAutoHandoffSkipImport",
             "bootTransitionVerification",
+            "bootTransitionCapture",
             "bootMonitorPreflight",
             "bootToolkitValidation",
         ),
     },
     {
         "label": "Voice, Healthy Start, & Regression",
-        "lane_keys": ("voiceRegression", "desktopHealthy", "launcherHealthy", "launcherRegression"),
+        "lane_keys": (
+            "voiceRegression",
+            "desktopHealthy",
+            "launcherHealthy",
+            "desktopToolkitValidation",
+            "launcherRegression",
+        ),
     },
     {
         "label": "Support Bundles & Reporting",
@@ -1047,6 +1089,12 @@ class DevLauncherWindow(QWidget):
         refresh_btn.clicked.connect(self.refresh_previous_launches)
         layout.addWidget(refresh_btn)
 
+        self.previous_summary_label = QLabel("Scanning saved dev evidence...")
+        self.previous_summary_label.setObjectName("noteBox")
+        self.previous_summary_label.setWordWrap(True)
+        self.previous_summary_label.setSizePolicy(QSizePolicy.Expanding, QSizePolicy.Minimum)
+        layout.addWidget(self.previous_summary_label)
+
         previous_choice_label = QLabel("Previous Launch")
         previous_choice_label.setObjectName("fieldLabel")
         layout.addWidget(previous_choice_label)
@@ -1529,13 +1577,27 @@ class DevLauncherWindow(QWidget):
             return f"{lane_label} | {mode_label} | {timestamp_text} #{run_tag}"
         return f"{lane_label} | {mode_label} | {timestamp_text}"
 
+    def previous_entry_artifact_summary(self, entry: dict) -> str:
+        parts = ["Evidence Root"]
+        if entry.get("runtime_log"):
+            parts.append("Runtime")
+        if entry.get("report_path"):
+            parts.append("Report")
+        if entry.get("crash_folder"):
+            parts.append("Crash Folder")
+        return ", ".join(parts)
+
     def previous_entry_detail(self, entry: dict) -> str:
         wrap_width = self.detail_wrap_width_for_label(self.previous_detail_label)
+        run_tag = self.previous_entry_run_tag(entry)
         lines = [
             f"Lane: {entry['lane_label']}",
             f"Mode: {self.compact_previous_mode_label(entry['mode_label'])}",
             f"Saved Evidence Time: {entry.get('timestamp_text', 'Unknown time')}",
+            f"Artifacts Available: {self.previous_entry_artifact_summary(entry)}",
         ]
+        if run_tag:
+            lines.append(f"Run Tag: {run_tag}")
         self.append_wrapped_detail(lines, "Evidence Root", entry["evidence_root"], width=wrap_width)
         if entry.get("runtime_log"):
             self.append_wrapped_detail(lines, "Runtime", entry["runtime_log"], width=wrap_width)
@@ -1759,8 +1821,29 @@ class DevLauncherWindow(QWidget):
         entries.sort(key=lambda entry: entry["last_activity"], reverse=True)
         return entries
 
+    def update_previous_summary(self):
+        if not hasattr(self, "previous_summary_label"):
+            return
+
+        entry_count = len(self.previous_launch_entries)
+        if not entry_count:
+            self.previous_summary_label.setText(
+                "No saved previous launches were found yet under the current dev evidence roots."
+            )
+            return
+
+        lane_count = len({entry["lane_key"] for entry in self.previous_launch_entries})
+        latest = self.previous_launch_entries[0]
+        latest_mode = self.compact_previous_mode_label(latest["mode_label"])
+        latest_time = latest.get("timestamp_text", "Unknown time")
+        self.previous_summary_label.setText(
+            f"Found {entry_count} saved launch artifact set(s) across {lane_count} lane(s). "
+            f"Latest: {latest['lane_label']} | {latest_mode} | {latest_time}."
+        )
+
     def refresh_previous_launches(self):
         self.previous_launch_entries = self.scan_previous_launch_entries()
+        self.update_previous_summary()
         if not hasattr(self, "previous_launch_combo"):
             return
 
@@ -1781,6 +1864,8 @@ class DevLauncherWindow(QWidget):
             entry["combo_key"] = key
             if previous_value and key == previous_value:
                 selected_index = index
+        if selected_index == 0 and self.previous_launch_entries:
+            selected_index = 1
         self.previous_launch_combo.setCurrentIndex(selected_index)
         self.previous_launch_combo.blockSignals(False)
         self.on_previous_launch_changed()

--- a/dev/launchers/jarvis_dev_launcher.pyw
+++ b/dev/launchers/jarvis_dev_launcher.pyw
@@ -165,6 +165,24 @@ LANE_CONFIG = {
         "report_suffix": ".txt",
         "crash_folder": "",
     },
+    "bootToolkitValidation": {
+        "label": "Boot Helper Toolkit Validation",
+        "detail": (
+            "Runs a contained offscreen validation of the Boot & Transition helper lanes and verifies "
+            "the Dev Toolkit can launch Boot Monitor Preflight and Boot To Desktop Handoff Verification "
+            "and then reopen their fresh reports."
+        ),
+        "quiet_launcher": "launch_jarvis_boot_toolkit_validation.vbs",
+        "voice_launcher": "",
+        "supports_voice": False,
+        "available_modes": ("quiet",),
+        "opens_window": False,
+        "log_root": os.path.join(DEV_LOGS_DIR, "boot_toolkit_validation"),
+        "report_root": os.path.join(DEV_LOGS_DIR, "boot_toolkit_validation", "reports"),
+        "report_prefix": "BootToolkitValidationReport_",
+        "report_suffix": ".txt",
+        "crash_folder": "",
+    },
     "voiceRegression": {
         "label": "Voice Regression Harness",
         "detail": (
@@ -322,6 +340,7 @@ CONFIG_LANE_GROUPS = (
             "bootAutoHandoffSkipImport",
             "bootTransitionVerification",
             "bootMonitorPreflight",
+            "bootToolkitValidation",
         ),
     },
     {

--- a/dev/launchers/jarvis_dev_launcher.pyw
+++ b/dev/launchers/jarvis_dev_launcher.pyw
@@ -3,6 +3,7 @@ import os
 import subprocess
 import sys
 import textwrap
+import time
 
 from PySide6.QtCore import QEvent, QPoint, QRect, Qt, QTimer
 from PySide6.QtGui import QFont, QFontMetrics, QGuiApplication
@@ -13,6 +14,7 @@ from PySide6.QtWidgets import (
     QFrame,
     QHBoxLayout,
     QLabel,
+    QProgressBar,
     QPushButton,
     QScrollArea,
     QSizePolicy,
@@ -32,6 +34,10 @@ DEV_LAUNCHERS_DIR = os.path.dirname(os.path.abspath(__file__))
 CLIENT_LOGS_DIR = os.path.join(ROOT_DIR, "logs")
 DEV_LOGS_DIR = os.path.join(DEV_DIR, "logs")
 DEV_TOOLKIT_SESSION_LOG_DIR = os.path.join(DEV_LOGS_DIR, "dev_toolkit_session")
+DEV_TOOLKIT_SMOKE_REPORT_DIR = os.path.join(DEV_LOGS_DIR, "dev_toolkit_smoke_validation", "reports")
+BOOT_TRANSITION_CAPTURE_ROOT = os.path.join(DEV_LOGS_DIR, "boot_transition_capture")
+BOOT_TRANSITION_CAPTURE_REPORT_DIR = os.path.join(BOOT_TRANSITION_CAPTURE_ROOT, "reports")
+BOOT_TRANSITION_CAPTURE_FRAMES_DIR = os.path.join(BOOT_TRANSITION_CAPTURE_ROOT, "captures")
 SUPPORT_BUNDLE_TRIAGE_SCRIPT = os.path.join(ROOT_DIR, "dev", "jarvis_support_bundle_triage.py")
 
 PYTHONW_PATH = r"C:\Users\anden\AppData\Local\Python\pythoncore-3.14-64\pythonw.exe"
@@ -486,6 +492,99 @@ def latest_directory_named(root_path: str, folder_name: str) -> str:
     return best_path
 
 
+def latest_subdirectory(root_path: str) -> str:
+    if not os.path.isdir(root_path):
+        return ""
+
+    best_path = ""
+    best_time = -1.0
+    for name in os.listdir(root_path):
+        path = os.path.join(root_path, name)
+        if not os.path.isdir(path):
+            continue
+        try:
+            modified = os.path.getmtime(path)
+        except OSError:
+            continue
+        if modified >= best_time:
+            best_time = modified
+            best_path = path
+    return best_path
+
+
+BACKGROUND_PROGRESS_PROFILES = {
+    "default": {
+        "expected_seconds": 28.0,
+        "stages": (
+            (12, "Initializing the selected helper lane."),
+            (34, "Launching the helper process and waiting for its first artifact."),
+            (62, "Running the core validation or capture work."),
+            (86, "Finalizing evidence and writing the latest artifact."),
+            (96, "Waiting for the lane to finish cleanly."),
+        ),
+    },
+    "bootMonitorPreflight": {
+        "expected_seconds": 10.0,
+        "stages": (
+            (18, "Preparing the current monitor-topology probe."),
+            (52, "Reading the left, center, and right monitor assumptions."),
+            (82, "Writing the compact preflight report."),
+            (96, "Waiting for the fresh report artifact to land."),
+        ),
+    },
+    "bootTransitionVerification": {
+        "expected_seconds": 24.0,
+        "stages": (
+            (12, "Preparing the quiet boot-to-desktop verification run."),
+            (34, "Launching the boot harness and waiting for handoff markers."),
+            (68, "Checking the handoff ordering against the expected milestone chain."),
+            (88, "Writing the verification summary report."),
+            (96, "Waiting for the fresh report artifact to land."),
+        ),
+    },
+    "bootTransitionCapture": {
+        "expected_seconds": 26.0,
+        "stages": (
+            (10, "Preparing the quiet auto-handoff capture lane."),
+            (32, "Launching Boot Jarvis and waiting for the transition window."),
+            (70, "Capturing the handoff frames and saving the PNG sequence."),
+            (90, "Writing the capture report and indexing the newest frame set."),
+            (96, "Waiting for the fresh capture artifact to land."),
+        ),
+    },
+    "bootToolkitValidation": {
+        "expected_seconds": 24.0,
+        "stages": (
+            (10, "Preparing the boot-side Toolkit validation run."),
+            (36, "Launching Boot Monitor Preflight through the Toolkit surface."),
+            (68, "Launching Boot To Desktop Handoff Verification through the Toolkit surface."),
+            (88, "Writing the consolidated boot-helper Toolkit validation report."),
+            (96, "Waiting for the fresh report artifact to land."),
+        ),
+    },
+    "desktopToolkitValidation": {
+        "expected_seconds": 26.0,
+        "stages": (
+            (10, "Preparing the desktop-side Toolkit validation run."),
+            (38, "Launching Healthy Desktop Launch Validation through the Toolkit surface."),
+            (68, "Launching Healthy Launcher Path Validation through the Toolkit surface."),
+            (88, "Writing the consolidated desktop-helper Toolkit validation report."),
+            (96, "Waiting for the fresh report artifact to land."),
+        ),
+    },
+    "devToolkitSmokeValidation": {
+        "expected_seconds": 42.0,
+        "stages": (
+            (8, "Preparing the top-level Dev Toolkit smoke validation."),
+            (28, "Running the boot-helper Toolkit validation."),
+            (62, "Running the desktop-helper Toolkit validation."),
+            (90, "Writing the consolidated smoke report."),
+            (96, "Waiting for the fresh smoke artifact to land."),
+        ),
+    },
+}
+
+
 class TitleBar(QFrame):
     def __init__(self, owner):
         super().__init__(owner)
@@ -726,6 +825,28 @@ class DevLauncherWindow(QWidget):
                 color: #d4af37;
             }
 
+            QLabel#statusSubtext {
+                color: #8cc6cf;
+                font-size: 8pt;
+                padding-left: 2px;
+                padding-right: 2px;
+            }
+
+            QProgressBar#statusProgress {
+                border: 1px solid #134353;
+                background: #06111a;
+                color: #d4af37;
+                text-align: center;
+                padding: 1px;
+                font-size: 8pt;
+                min-height: 16px;
+            }
+
+            QProgressBar#statusProgress::chunk {
+                background: #0fe1ff;
+                width: 12px;
+            }
+
             QLabel#headerHint {
                 color: #8cc6cf;
                 font-size: 8pt;
@@ -857,6 +978,20 @@ class DevLauncherWindow(QWidget):
         self.status_label.setSizePolicy(QSizePolicy.Expanding, QSizePolicy.Fixed)
         self.status_label.setMaximumHeight(26)
         status_panel.layout.addWidget(self.status_label)
+        self.status_detail_label = QLabel("No background lane is running right now.")
+        self.status_detail_label.setObjectName("statusSubtext")
+        self.status_detail_label.setWordWrap(True)
+        self.status_detail_label.setAlignment(Qt.AlignVCenter | Qt.AlignLeft)
+        self.status_detail_label.setSizePolicy(QSizePolicy.Expanding, QSizePolicy.Minimum)
+        status_panel.layout.addWidget(self.status_detail_label)
+        self.status_progress = QProgressBar()
+        self.status_progress.setObjectName("statusProgress")
+        self.status_progress.setRange(0, 100)
+        self.status_progress.setValue(0)
+        self.status_progress.setTextVisible(True)
+        self.status_progress.setFormat("Idle")
+        self.status_progress.setFixedHeight(18)
+        status_panel.layout.addWidget(self.status_progress)
         self.status_panel = status_panel
 
         global_utils_panel = Panel("Global Utilities")
@@ -994,33 +1129,38 @@ class DevLauncherWindow(QWidget):
         self.populate_lane_group_choices("")
 
     def _build_global_utilities_panel(self, layout):
-        button_row = QHBoxLayout()
-        button_row.setContentsMargins(0, 0, 0, 0)
-        button_row.setSpacing(6)
-        button_row.addStretch(1)
-
-        buttons = [
-            ("Jarvis Root", self.open_jarvis_root, "Open Jarvis Root"),
-            ("Dev Folder", self.open_dev_folder, "Open Dev Folder"),
-            ("Dev Logs", self.open_dev_logs_root, "Open Dev Logs Root"),
-            ("Latest Toolkit Log", self.open_latest_toolkit_session_log, "Open Latest Toolkit Session Log"),
-            ("Dev Launchers", self.open_launchers_folder, "Open Dev Launchers Folder"),
-        ]
-        for text, handler, tooltip in buttons:
-            btn = QPushButton(text)
-            btn.setObjectName("headerUtilityButton")
-            btn.clicked.connect(handler)
-            btn.setToolTip(tooltip)
-            btn.setMinimumWidth(126)
-            btn.setFixedHeight(30)
-            btn.setSizePolicy(QSizePolicy.Maximum, QSizePolicy.Fixed)
-            button_row.addWidget(btn)
-
-        button_row.addStretch(1)
-        layout.addLayout(button_row)
+        button_rows = (
+            [
+                ("Jarvis Root", self.open_jarvis_root, "Open Jarvis Root"),
+                ("Dev Folder", self.open_dev_folder, "Open Dev Folder"),
+                ("Dev Logs", self.open_dev_logs_root, "Open Dev Logs Root"),
+                ("Latest Toolkit Log", self.open_latest_toolkit_session_log, "Open Latest Toolkit Session Log"),
+            ],
+            [
+                ("Latest Smoke Report", self.open_latest_smoke_report, "Open Latest Dev Toolkit Smoke Report"),
+                ("Latest Transition Capture", self.open_latest_transition_capture, "Open Latest Boot Transition Capture"),
+                ("Dev Launchers", self.open_launchers_folder, "Open Dev Launchers Folder"),
+            ],
+        )
+        for row_buttons in button_rows:
+            button_row = QHBoxLayout()
+            button_row.setContentsMargins(0, 0, 0, 0)
+            button_row.setSpacing(6)
+            button_row.addStretch(1)
+            for text, handler, tooltip in row_buttons:
+                btn = QPushButton(text)
+                btn.setObjectName("headerUtilityButton")
+                btn.clicked.connect(handler)
+                btn.setToolTip(tooltip)
+                btn.setMinimumWidth(132)
+                btn.setFixedHeight(30)
+                btn.setSizePolicy(QSizePolicy.Maximum, QSizePolicy.Fixed)
+                button_row.addWidget(btn)
+            button_row.addStretch(1)
+            layout.addLayout(button_row)
 
         note = QLabel(
-            "Stable developer locations that never depend on the selected lane, including the latest Dev Toolkit session log."
+            "Stable developer locations and newest top-level helper artifacts that never depend on the selected lane."
         )
         note.setObjectName("headerHint")
         note.setWordWrap(False)
@@ -1942,8 +2082,23 @@ class DevLauncherWindow(QWidget):
         self.cancel_btn.setEnabled(self.launch_timer.isActive())
         self.refresh_utility_buttons()
 
-    def set_status(self, text: str):
+    def apply_status_widgets(self, text: str, detail: str, progress: int):
+        progress_value = max(0, min(100, int(progress)))
         self.status_label.setText(text)
+        self.status_detail_label.setText(detail)
+        self.status_progress.setValue(progress_value)
+        self.status_progress.setFormat("Idle" if progress_value <= 0 else f"{progress_value}%")
+
+    def set_status(self, text: str, detail: str | None = None, progress: int | None = None):
+        if detail is None:
+            detail = (
+                "A background lane is still running."
+                if self.active_background_run
+                else "No background lane is running right now."
+            )
+        if progress is None:
+            progress = self.status_progress.value() if self.active_background_run else 0
+        self.apply_status_widgets(text, detail, progress)
         self.refresh_utility_buttons()
 
     def runtime_milestone(self, event: str):
@@ -1969,6 +2124,24 @@ class DevLauncherWindow(QWidget):
             return runtime_path
         return ""
 
+    def background_progress_profile(self, lane_key: str) -> dict:
+        return BACKGROUND_PROGRESS_PROFILES.get(lane_key, BACKGROUND_PROGRESS_PROFILES["default"])
+
+    def background_progress_snapshot(self, run: dict, record: dict) -> tuple[int, str]:
+        lane_key = record.get("lane_key", "")
+        profile = self.background_progress_profile(lane_key)
+        expected_seconds = max(1.0, float(profile.get("expected_seconds", 28.0)))
+        started_at_ts = float(run.get("started_at_ts", record.get("launched_at_ts", time.time())))
+        elapsed = max(0.0, time.time() - started_at_ts)
+        progress_value = min(96, max(3, int((elapsed / expected_seconds) * 96)))
+        detail = "Running the selected helper lane."
+        for threshold, stage_text in profile.get("stages", ()):
+            if progress_value <= threshold:
+                detail = stage_text
+                break
+            detail = stage_text
+        return progress_value, detail
+
     def refresh_background_run_status(self):
         run = self.active_background_run
         if not run:
@@ -1979,12 +2152,24 @@ class DevLauncherWindow(QWidget):
             self.active_background_run = {}
             return
 
-        if self.completion_artifact_for_record(record):
+        report_path = self.latest_report_for_record(record, record.get("launched_at_ts", 0.0))
+        artifact_path = report_path or self.latest_runtime_log_for_record(record, record.get("launched_at_ts", 0.0))
+        if artifact_path:
+            artifact_label = "fresh report artifact" if report_path else "fresh runtime artifact"
             self.active_background_run = {}
-            self.status_label.setText(f"Test complete: {run.get('label', 'Selected lane')}")
+            self.apply_status_widgets(
+                f"Test complete: {run.get('label', 'Selected lane')}",
+                f"Finished cleanly and wrote a {artifact_label}. You can open it from the utilities now.",
+                100,
+            )
             return
 
-        self.status_label.setText(f"Test in progress: {run.get('label', 'Selected lane')}")
+        progress_value, detail = self.background_progress_snapshot(run, record)
+        self.apply_status_widgets(
+            f"Test in progress: {run.get('label', 'Selected lane')}",
+            detail,
+            progress_value,
+        )
 
     def refresh_utility_buttons(self):
         current_record = self.current_session_record()
@@ -2117,7 +2302,11 @@ class DevLauncherWindow(QWidget):
         self.launch_btn.setEnabled(False)
         self.cancel_btn.setEnabled(True)
         self.launch_timer.start(delay_seconds * 1000)
-        self.set_status(f"Launching {self.active_label()} in {delay_seconds} second(s)...")
+        self.set_status(
+            f"Launching {self.active_label()} in {delay_seconds} second(s)...",
+            "Waiting for the launch delay to elapse before the selected lane starts.",
+            0,
+        )
 
     def cancel_launch(self, silent: bool = False):
         if self.launch_timer.isActive():
@@ -2126,7 +2315,7 @@ class DevLauncherWindow(QWidget):
         self.launch_btn.setEnabled(True)
         self.cancel_btn.setEnabled(False)
         if not silent:
-            self.set_status("Pending launch cancelled.")
+            self.set_status("Pending launch cancelled.", "No background lane is running right now.", 0)
 
     def run_selected_launcher(self):
         try:
@@ -2148,13 +2337,18 @@ class DevLauncherWindow(QWidget):
                     self.active_background_run = {
                         "artifact_key": launch_key,
                         "label": self.active_label(),
+                        "started_at_ts": time.time(),
                     }
                 subprocess.Popen([PYTHONW_PATH, lane["script_path"], source_path], cwd=ROOT_DIR)
                 self.runtime_milestone(
                     f"TOOLKIT_MAIN|LANE_LAUNCHED|lane={lane_key}|mode={mode_key}|label={lane_label}"
                 )
                 if self.lane_runs_in_background(lane):
-                    self.set_status(f"Test in progress: {self.active_label()} :: {source_path}")
+                    self.set_status(
+                        f"Test in progress: {self.active_label()} :: {source_path}",
+                        "Launching the selected helper lane with the chosen support bundle source.",
+                        3,
+                    )
                 else:
                     self.set_status(f"Launched: {self.active_label()} :: {source_path}")
                 return
@@ -2166,13 +2360,18 @@ class DevLauncherWindow(QWidget):
                 self.active_background_run = {
                     "artifact_key": launch_key,
                     "label": self.active_label(),
+                    "started_at_ts": time.time(),
                 }
             subprocess.Popen(["wscript.exe", launcher_path], cwd=DEV_LAUNCHERS_DIR)
             self.runtime_milestone(
                 f"TOOLKIT_MAIN|LANE_LAUNCHED|lane={lane_key}|mode={mode_key}|label={lane_label}"
             )
             if self.lane_runs_in_background(lane):
-                self.set_status(f"Test in progress: {self.active_label()}")
+                self.set_status(
+                    f"Test in progress: {self.active_label()}",
+                    "Launching the selected helper lane and waiting for its first artifact.",
+                    3,
+                )
             else:
                 self.set_status(f"Launched: {self.active_label()}")
         except Exception as exc:
@@ -2220,6 +2419,26 @@ class DevLauncherWindow(QWidget):
             self.set_status(f"No toolkit session log found yet in: {DEV_TOOLKIT_SESSION_LOG_DIR}")
             return
         self.open_path(latest, f"Opened latest toolkit session log: {latest}")
+
+    def open_latest_smoke_report(self):
+        latest = latest_file_matching(DEV_TOOLKIT_SMOKE_REPORT_DIR, "DevToolkitSmokeValidationReport_", ".txt")
+        if not latest:
+            self.set_status(f"No smoke report found yet in: {DEV_TOOLKIT_SMOKE_REPORT_DIR}")
+            return
+        self.open_path(latest, f"Opened latest smoke report: {latest}")
+
+    def open_latest_transition_capture(self):
+        latest_capture = latest_subdirectory(BOOT_TRANSITION_CAPTURE_FRAMES_DIR)
+        if latest_capture:
+            self.open_path(latest_capture, f"Opened latest transition capture: {latest_capture}")
+            return
+        latest_report = latest_file_matching(BOOT_TRANSITION_CAPTURE_REPORT_DIR, "BootTransitionCaptureReport_", ".txt")
+        if latest_report:
+            self.open_path(latest_report, f"Opened latest transition capture report: {latest_report}")
+            return
+        self.set_status(
+            f"No transition capture artifact found yet under: {BOOT_TRANSITION_CAPTURE_ROOT}"
+        )
 
     def open_launchers_folder(self):
         self.open_path(DEV_LAUNCHERS_DIR, "Opened: Dev launchers folder")

--- a/dev/launchers/jarvis_dev_launcher.pyw
+++ b/dev/launchers/jarvis_dev_launcher.pyw
@@ -131,6 +131,40 @@ LANE_CONFIG = {
         "log_root": os.path.join(DEV_LOGS_DIR, "boot_auto_handoff_skip_import"),
         "crash_folder": "",
     },
+    "bootTransitionVerification": {
+        "label": "Boot To Desktop Handoff Verification",
+        "detail": (
+            "Runs a contained quiet boot-to-desktop verification pass, validates the current "
+            "handoff milestone order, then writes a compact pass/fail report."
+        ),
+        "quiet_launcher": "launch_jarvis_boot_transition_verification.vbs",
+        "voice_launcher": "",
+        "supports_voice": False,
+        "available_modes": ("quiet",),
+        "opens_window": False,
+        "log_root": os.path.join(DEV_LOGS_DIR, "boot_transition_verification"),
+        "report_root": os.path.join(DEV_LOGS_DIR, "boot_transition_verification", "reports"),
+        "report_prefix": "BootTransitionVerificationReport_",
+        "report_suffix": ".txt",
+        "crash_folder": "",
+    },
+    "bootMonitorPreflight": {
+        "label": "Boot Monitor Preflight",
+        "detail": (
+            "Captures the current monitor topology using the same left/center/right assumptions "
+            "as Boot Jarvis and writes a compact readiness report before you run a boot lane."
+        ),
+        "quiet_launcher": "launch_jarvis_boot_monitor_preflight.vbs",
+        "voice_launcher": "",
+        "supports_voice": False,
+        "available_modes": ("quiet",),
+        "opens_window": False,
+        "log_root": os.path.join(DEV_LOGS_DIR, "boot_monitor_preflight"),
+        "report_root": os.path.join(DEV_LOGS_DIR, "boot_monitor_preflight", "reports"),
+        "report_prefix": "BootMonitorPreflightReport_",
+        "report_suffix": ".txt",
+        "crash_folder": "",
+    },
     "voiceRegression": {
         "label": "Voice Regression Harness",
         "detail": (
@@ -283,7 +317,12 @@ CONFIG_LANE_GROUPS = (
     },
     {
         "label": "Boot & Transition Checks",
-        "lane_keys": ("bootManualFlow", "bootAutoHandoffSkipImport"),
+        "lane_keys": (
+            "bootManualFlow",
+            "bootAutoHandoffSkipImport",
+            "bootTransitionVerification",
+            "bootMonitorPreflight",
+        ),
     },
     {
         "label": "Voice, Healthy Start, & Regression",
@@ -884,6 +923,7 @@ class DevLauncherWindow(QWidget):
             ("Jarvis Root", self.open_jarvis_root, "Open Jarvis Root"),
             ("Dev Folder", self.open_dev_folder, "Open Dev Folder"),
             ("Dev Logs", self.open_dev_logs_root, "Open Dev Logs Root"),
+            ("Latest Toolkit Log", self.open_latest_toolkit_session_log, "Open Latest Toolkit Session Log"),
             ("Dev Launchers", self.open_launchers_folder, "Open Dev Launchers Folder"),
         ]
         for text, handler, tooltip in buttons:
@@ -900,7 +940,7 @@ class DevLauncherWindow(QWidget):
         layout.addLayout(button_row)
 
         note = QLabel(
-            "Stable developer locations that never depend on the selected lane."
+            "Stable developer locations that never depend on the selected lane, including the latest Dev Toolkit session log."
         )
         note.setObjectName("headerHint")
         note.setWordWrap(False)
@@ -2050,6 +2090,13 @@ class DevLauncherWindow(QWidget):
     def open_dev_logs_root(self):
         os.makedirs(DEV_LOGS_DIR, exist_ok=True)
         self.open_path(DEV_LOGS_DIR, f"Opened: Dev logs root :: {DEV_LOGS_DIR}")
+
+    def open_latest_toolkit_session_log(self):
+        latest = latest_file_matching(DEV_TOOLKIT_SESSION_LOG_DIR, "Runtime_")
+        if not latest:
+            self.set_status(f"No toolkit session log found yet in: {DEV_TOOLKIT_SESSION_LOG_DIR}")
+            return
+        self.open_path(latest, f"Opened latest toolkit session log: {latest}")
 
     def open_launchers_folder(self):
         self.open_path(DEV_LAUNCHERS_DIR, "Opened: Dev launchers folder")

--- a/dev/launchers/jarvis_dev_launcher.pyw
+++ b/dev/launchers/jarvis_dev_launcher.pyw
@@ -22,6 +22,11 @@ from PySide6.QtWidgets import (
 
 
 ROOT_DIR = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+if ROOT_DIR not in sys.path:
+    sys.path.insert(0, ROOT_DIR)
+
+from desktop.single_instance import NamedSignal, SingleInstanceGuard, acquire_or_prompt_replace
+
 DEV_DIR = os.path.join(ROOT_DIR, "dev")
 DEV_LAUNCHERS_DIR = os.path.dirname(os.path.abspath(__file__))
 CLIENT_LOGS_DIR = os.path.join(ROOT_DIR, "logs")
@@ -29,6 +34,10 @@ DEV_LOGS_DIR = os.path.join(DEV_DIR, "logs")
 SUPPORT_BUNDLE_TRIAGE_SCRIPT = os.path.join(ROOT_DIR, "dev", "jarvis_support_bundle_triage.py")
 
 PYTHONW_PATH = r"C:\Users\anden\AppData\Local\Python\pythoncore-3.14-64\pythonw.exe"
+DEV_TOOLKIT_MUTEX = r"Local\JarvisDevToolkitSingletonV1"
+DEV_TOOLKIT_RELAUNCH_EVENT = r"Local\JarvisDevToolkitRelaunchRequestV1"
+dev_toolkit_guard = SingleInstanceGuard(DEV_TOOLKIT_MUTEX)
+dev_toolkit_relaunch_signal = NamedSignal(DEV_TOOLKIT_RELAUNCH_EVENT)
 
 LANE_CONFIG = {
     "diagnostics": {
@@ -2219,13 +2228,44 @@ class DevLauncherWindow(QWidget):
         return super().eventFilter(source, event)
 
 
+def install_dev_toolkit_relaunch_monitor(window: DevLauncherWindow):
+    timer = QTimer(window)
+
+    def poll_relaunch_request():
+        if not dev_toolkit_relaunch_signal.consume():
+            return
+        window.set_status("Relaunch request received. Closing current Dev Toolkit window.")
+        window.close()
+        app = QApplication.instance()
+        if app is not None:
+            QTimer.singleShot(0, app.quit)
+
+    timer.timeout.connect(poll_relaunch_request)
+    timer.start(200)
+    return timer
+
+
 def main():
+    if not acquire_or_prompt_replace(
+        dev_toolkit_guard,
+        dev_toolkit_relaunch_signal,
+        "Jarvis Dev Toolkit Already Open",
+        "Jarvis Dev Toolkit is already open.\n\nDo you want to close the current toolkit window and open a new one?",
+    ):
+        return 0
+
     app = QApplication(sys.argv)
     app.setFont(QFont("Consolas", 10))
     window = DevLauncherWindow()
     window.show()
-    sys.exit(app.exec())
+    relaunch_timer = install_dev_toolkit_relaunch_monitor(window)
+    try:
+        return app.exec()
+    finally:
+        relaunch_timer.stop()
+        dev_toolkit_guard.release()
+        dev_toolkit_relaunch_signal.close()
 
 
 if __name__ == "__main__":
-    main()
+    raise SystemExit(main())

--- a/dev/launchers/jarvis_dev_launcher.pyw
+++ b/dev/launchers/jarvis_dev_launcher.pyw
@@ -31,6 +31,7 @@ DEV_DIR = os.path.join(ROOT_DIR, "dev")
 DEV_LAUNCHERS_DIR = os.path.dirname(os.path.abspath(__file__))
 CLIENT_LOGS_DIR = os.path.join(ROOT_DIR, "logs")
 DEV_LOGS_DIR = os.path.join(DEV_DIR, "logs")
+DEV_TOOLKIT_SESSION_LOG_DIR = os.path.join(DEV_LOGS_DIR, "dev_toolkit_session")
 SUPPORT_BUNDLE_TRIAGE_SCRIPT = os.path.join(ROOT_DIR, "dev", "jarvis_support_bundle_triage.py")
 
 PYTHONW_PATH = r"C:\Users\anden\AppData\Local\Python\pythoncore-3.14-64\pythonw.exe"
@@ -38,6 +39,23 @@ DEV_TOOLKIT_MUTEX = r"Local\JarvisDevToolkitSingletonV1"
 DEV_TOOLKIT_RELAUNCH_EVENT = r"Local\JarvisDevToolkitRelaunchRequestV1"
 dev_toolkit_guard = SingleInstanceGuard(DEV_TOOLKIT_MUTEX)
 dev_toolkit_relaunch_signal = NamedSignal(DEV_TOOLKIT_RELAUNCH_EVENT)
+
+
+def create_dev_toolkit_runtime_log() -> str:
+    os.makedirs(DEV_TOOLKIT_SESSION_LOG_DIR, exist_ok=True)
+    stamp = datetime.datetime.now().strftime("%Y%m%d_%H%M%S_%f")
+    return os.path.join(DEV_TOOLKIT_SESSION_LOG_DIR, f"Runtime_{stamp}.txt")
+
+
+def write_dev_toolkit_runtime_marker(runtime_log_file: str, event: str) -> None:
+    if not runtime_log_file:
+        return
+    try:
+        ts = datetime.datetime.now().strftime("%H:%M:%S")
+        with open(runtime_log_file, "a", encoding="utf-8") as f:
+            f.write(f"[{ts}] {event}\n")
+    except Exception:
+        pass
 
 LANE_CONFIG = {
     "diagnostics": {
@@ -421,8 +439,9 @@ class GuardedComboBox(QComboBox):
 
 
 class DevLauncherWindow(QWidget):
-    def __init__(self):
+    def __init__(self, runtime_logger=None):
         super().__init__()
+        self.runtime_logger = runtime_logger
         self.setWindowTitle("Jarvis Dev Toolkit")
         self.setWindowFlags(Qt.Window | Qt.FramelessWindowHint)
         self.resize(980, 900)
@@ -1764,6 +1783,14 @@ class DevLauncherWindow(QWidget):
         self.status_label.setText(text)
         self.refresh_utility_buttons()
 
+    def runtime_milestone(self, event: str):
+        if not callable(self.runtime_logger):
+            return
+        try:
+            self.runtime_logger(event)
+        except Exception:
+            pass
+
     def lane_runs_in_background(self, lane: dict) -> bool:
         return bool(lane) and not lane.get("opens_window", False)
 
@@ -1941,9 +1968,15 @@ class DevLauncherWindow(QWidget):
     def run_selected_launcher(self):
         try:
             lane = self.current_lane()
+            lane_key = self.current_lane_key()
+            mode_key = self.current_mode_key()
+            lane_label = lane.get("label", "Unknown lane")
             if lane.get("requires_bundle_input"):
                 source_path = self.select_support_bundle_source()
                 if not source_path:
+                    self.runtime_milestone(
+                        f"TOOLKIT_MAIN|LANE_LAUNCH_CANCELLED|lane={lane_key}|mode={mode_key}|reason=no_source_selected"
+                    )
                     self.set_status("Launch cancelled: no support bundle selected.")
                     return
                 launch_key = self.current_session_artifact_key()
@@ -1954,6 +1987,9 @@ class DevLauncherWindow(QWidget):
                         "label": self.active_label(),
                     }
                 subprocess.Popen([PYTHONW_PATH, lane["script_path"], source_path], cwd=ROOT_DIR)
+                self.runtime_milestone(
+                    f"TOOLKIT_MAIN|LANE_LAUNCHED|lane={lane_key}|mode={mode_key}|label={lane_label}"
+                )
                 if self.lane_runs_in_background(lane):
                     self.set_status(f"Test in progress: {self.active_label()} :: {source_path}")
                 else:
@@ -1969,6 +2005,9 @@ class DevLauncherWindow(QWidget):
                     "label": self.active_label(),
                 }
             subprocess.Popen(["wscript.exe", launcher_path], cwd=DEV_LAUNCHERS_DIR)
+            self.runtime_milestone(
+                f"TOOLKIT_MAIN|LANE_LAUNCHED|lane={lane_key}|mode={mode_key}|label={lane_label}"
+            )
             if self.lane_runs_in_background(lane):
                 self.set_status(f"Test in progress: {self.active_label()}")
             else:
@@ -1977,6 +2016,9 @@ class DevLauncherWindow(QWidget):
             if 'launch_key' in locals():
                 self.session_launch_records.pop(launch_key, None)
             self.active_background_run = {}
+            self.runtime_milestone(
+                f"TOOLKIT_MAIN|LANE_LAUNCH_FAILED|lane={self.current_lane_key()}|mode={self.current_mode_key()}|reason={type(exc).__name__}"
+            )
             self.set_status(f"Launch failed: {self.active_label()} :: {exc}")
         finally:
             self.launch_timer.stop()
@@ -2228,12 +2270,14 @@ class DevLauncherWindow(QWidget):
         return super().eventFilter(source, event)
 
 
-def install_dev_toolkit_relaunch_monitor(window: DevLauncherWindow):
+def install_dev_toolkit_relaunch_monitor(window: DevLauncherWindow, runtime_logger=None):
     timer = QTimer(window)
 
     def poll_relaunch_request():
         if not dev_toolkit_relaunch_signal.consume():
             return
+        if callable(runtime_logger):
+            runtime_logger("TOOLKIT_MAIN|RELAUNCH_REQUEST_RECEIVED")
         window.set_status("Relaunch request received. Closing current Dev Toolkit window.")
         window.close()
         app = QApplication.instance()
@@ -2246,6 +2290,16 @@ def install_dev_toolkit_relaunch_monitor(window: DevLauncherWindow):
 
 
 def main():
+    runtime_log_file = create_dev_toolkit_runtime_log()
+
+    def runtime_milestone(event: str):
+        write_dev_toolkit_runtime_marker(runtime_log_file, event)
+
+    runtime_milestone("TOOLKIT_MAIN|START")
+
+    def log_single_instance_event(event: str):
+        runtime_milestone(f"TOOLKIT_MAIN|{event}")
+
     if not acquire_or_prompt_replace(
         dev_toolkit_guard,
         dev_toolkit_relaunch_signal,
@@ -2254,16 +2308,24 @@ def main():
         eyebrow_text="JARVIS DEV TOOLKIT",
         primary_button_text="Relaunch Dev Toolkit",
         secondary_button_text="Keep Current Toolkit",
+        event_logger=log_single_instance_event,
     ):
+        runtime_milestone("TOOLKIT_MAIN|SINGLE_INSTANCE_BLOCKED")
+        runtime_milestone("TOOLKIT_MAIN|EXIT|code=0")
         return 0
 
     app = QApplication.instance() or QApplication(sys.argv)
+    runtime_milestone("TOOLKIT_MAIN|QAPPLICATION_READY")
     app.setFont(QFont("Consolas", 10))
-    window = DevLauncherWindow()
+    window = DevLauncherWindow(runtime_logger=runtime_milestone)
+    runtime_milestone("TOOLKIT_MAIN|WINDOW_CONSTRUCTED")
     window.show()
-    relaunch_timer = install_dev_toolkit_relaunch_monitor(window)
+    runtime_milestone("TOOLKIT_MAIN|WINDOW_SHOWN")
+    relaunch_timer = install_dev_toolkit_relaunch_monitor(window, runtime_milestone)
     try:
-        return app.exec()
+        exit_code = app.exec()
+        runtime_milestone(f"TOOLKIT_MAIN|EXIT|code={exit_code}")
+        return exit_code
     finally:
         relaunch_timer.stop()
         dev_toolkit_guard.release()

--- a/dev/launchers/jarvis_dev_launcher.pyw
+++ b/dev/launchers/jarvis_dev_launcher.pyw
@@ -76,6 +76,34 @@ LANE_CONFIG = {
         "log_root_with_voice": os.path.join(DEV_LOGS_DIR, "manual_launcher_startup_abort_test_with_voice"),
         "crash_folder": "crash",
     },
+    "bootManualFlow": {
+        "label": "Boot Jarvis Manual Flow",
+        "detail": (
+            "Launches the dev-only main.py boot harness in manual mode so Boot Jarvis reaches "
+            "the first prompt and waits for operator input."
+        ),
+        "quiet_launcher": "launch_jarvis_main_manual_test.vbs",
+        "voice_launcher": "launch_jarvis_main_manual_test_with_voice.vbs",
+        "supports_voice": True,
+        "available_modes": ("quiet", "voice"),
+        "opens_window": True,
+        "log_root": os.path.join(DEV_LOGS_DIR, "boot_manual_flow"),
+        "crash_folder": "",
+    },
+    "bootAutoHandoffSkipImport": {
+        "label": "Boot Jarvis Auto Handoff (Skip Import)",
+        "detail": (
+            "Launches the dev-only main.py boot harness in auto-handoff mode so Boot Jarvis "
+            "drives the existing engage hud -> no chain and hands off into Desktop Jarvis."
+        ),
+        "quiet_launcher": "launch_jarvis_main_auto_handoff_skip_import.vbs",
+        "voice_launcher": "launch_jarvis_main_auto_handoff_skip_import_with_voice.vbs",
+        "supports_voice": True,
+        "available_modes": ("quiet", "voice"),
+        "opens_window": True,
+        "log_root": os.path.join(DEV_LOGS_DIR, "boot_auto_handoff_skip_import"),
+        "crash_folder": "",
+    },
     "voiceRegression": {
         "label": "Voice Regression Harness",
         "detail": (
@@ -225,6 +253,10 @@ CONFIG_LANE_GROUPS = (
     {
         "label": "Diagnostics & Recovery Checks",
         "lane_keys": ("diagnostics", "repeatedCrash", "startupAbort"),
+    },
+    {
+        "label": "Boot & Transition Checks",
+        "lane_keys": ("bootManualFlow", "bootAutoHandoffSkipImport"),
     },
     {
         "label": "Voice, Healthy Start, & Regression",

--- a/dev/launchers/launch_jarvis_boot_monitor_preflight.vbs
+++ b/dev/launchers/launch_jarvis_boot_monitor_preflight.vbs
@@ -1,0 +1,3 @@
+Set WshShell = CreateObject("WScript.Shell")
+WshShell.Run """C:\Users\anden\AppData\Local\Python\pythoncore-3.14-64\pythonw.exe"" ""C:\Jarvis\dev\jarvis_boot_monitor_preflight.py""", 0
+Set WshShell = Nothing

--- a/dev/launchers/launch_jarvis_boot_toolkit_validation.vbs
+++ b/dev/launchers/launch_jarvis_boot_toolkit_validation.vbs
@@ -1,0 +1,3 @@
+Set WshShell = CreateObject("WScript.Shell")
+WshShell.Run """C:\Users\anden\AppData\Local\Python\pythoncore-3.14-64\pythonw.exe"" ""C:\Jarvis\dev\jarvis_boot_toolkit_validation.py"" --open-report", 0
+Set WshShell = Nothing

--- a/dev/launchers/launch_jarvis_boot_transition_capture.vbs
+++ b/dev/launchers/launch_jarvis_boot_transition_capture.vbs
@@ -1,0 +1,3 @@
+Set WshShell = CreateObject("WScript.Shell")
+WshShell.Run """C:\Users\anden\AppData\Local\Python\pythoncore-3.14-64\pythonw.exe"" ""C:\Jarvis\dev\jarvis_boot_transition_capture.py"" --open-report", 0
+Set WshShell = Nothing

--- a/dev/launchers/launch_jarvis_boot_transition_verification.vbs
+++ b/dev/launchers/launch_jarvis_boot_transition_verification.vbs
@@ -1,0 +1,3 @@
+Set WshShell = CreateObject("WScript.Shell")
+WshShell.Run """C:\Users\anden\AppData\Local\Python\pythoncore-3.14-64\pythonw.exe"" ""C:\Jarvis\dev\jarvis_boot_transition_verification.py""", 0
+Set WshShell = Nothing

--- a/dev/launchers/launch_jarvis_desktop_toolkit_validation.vbs
+++ b/dev/launchers/launch_jarvis_desktop_toolkit_validation.vbs
@@ -1,0 +1,3 @@
+Set WshShell = CreateObject("WScript.Shell")
+WshShell.Run """C:\Users\anden\AppData\Local\Python\pythoncore-3.14-64\pythonw.exe"" ""C:\Jarvis\dev\jarvis_desktop_toolkit_validation.py"" --open-report", 0
+Set WshShell = Nothing

--- a/dev/launchers/launch_jarvis_dev_toolkit_smoke_validation.vbs
+++ b/dev/launchers/launch_jarvis_dev_toolkit_smoke_validation.vbs
@@ -1,0 +1,3 @@
+Set WshShell = CreateObject("WScript.Shell")
+WshShell.Run """C:\Users\anden\AppData\Local\Python\pythoncore-3.14-64\pythonw.exe"" ""C:\Jarvis\dev\jarvis_dev_toolkit_smoke_validation.py"" --open-report", 0
+Set WshShell = Nothing

--- a/dev/launchers/launch_jarvis_main_auto_handoff_skip_import.vbs
+++ b/dev/launchers/launch_jarvis_main_auto_handoff_skip_import.vbs
@@ -1,0 +1,3 @@
+Set WshShell = CreateObject("WScript.Shell")
+WshShell.Run """C:\Users\anden\AppData\Local\Python\pythoncore-3.14-64\pythonw.exe"" ""C:\Jarvis\main.py"" --boot-profile auto_handoff_skip_import --audio-mode quiet", 0
+Set WshShell = Nothing

--- a/dev/launchers/launch_jarvis_main_auto_handoff_skip_import_with_voice.vbs
+++ b/dev/launchers/launch_jarvis_main_auto_handoff_skip_import_with_voice.vbs
@@ -1,0 +1,3 @@
+Set WshShell = CreateObject("WScript.Shell")
+WshShell.Run """C:\Users\anden\AppData\Local\Python\pythoncore-3.14-64\pythonw.exe"" ""C:\Jarvis\main.py"" --boot-profile auto_handoff_skip_import --audio-mode voice", 0
+Set WshShell = Nothing

--- a/dev/launchers/launch_jarvis_main_dev.vbs
+++ b/dev/launchers/launch_jarvis_main_dev.vbs
@@ -1,0 +1,3 @@
+Set WshShell = CreateObject("WScript.Shell")
+WshShell.Run """C:\Users\anden\AppData\Local\Python\pythoncore-3.14-64\pythonw.exe"" ""C:\Jarvis\main.py""", 0
+Set WshShell = Nothing

--- a/dev/launchers/launch_jarvis_main_manual_test.vbs
+++ b/dev/launchers/launch_jarvis_main_manual_test.vbs
@@ -1,0 +1,3 @@
+Set WshShell = CreateObject("WScript.Shell")
+WshShell.Run """C:\Users\anden\AppData\Local\Python\pythoncore-3.14-64\pythonw.exe"" ""C:\Jarvis\main.py"" --boot-profile manual --audio-mode quiet", 0
+Set WshShell = Nothing

--- a/dev/launchers/launch_jarvis_main_manual_test_with_voice.vbs
+++ b/dev/launchers/launch_jarvis_main_manual_test_with_voice.vbs
@@ -1,0 +1,3 @@
+Set WshShell = CreateObject("WScript.Shell")
+WshShell.Run """C:\Users\anden\AppData\Local\Python\pythoncore-3.14-64\pythonw.exe"" ""C:\Jarvis\main.py"" --boot-profile manual --audio-mode voice", 0
+Set WshShell = Nothing

--- a/main.py
+++ b/main.py
@@ -727,6 +727,7 @@ class JarvisSystem:
                 and
                 pynput_keyboard.Key.end in self.hotkeys_pressed
             ):
+                self.runtime_milestone("BOOT_MAIN|HOTKEY_SHUTDOWN_TRIGGERED")
                 self.emit_bus(self.bus.shutdown_requested)
         except Exception:
             pass
@@ -764,6 +765,26 @@ class JarvisSystem:
                 f.write(f"[{ts}] {event}\n")
         except Exception:
             pass
+
+    def normalized_marker_input(self, text, limit=40):
+        normalized = "_".join(text.strip().lower().split())
+        if not normalized:
+            return "empty"
+
+        cleaned = []
+        for ch in normalized:
+            if ch.isalnum() or ch in {"_", "-"}:
+                cleaned.append(ch)
+            else:
+                cleaned.append("_")
+
+        collapsed = "".join(cleaned).strip("_")
+        while "__" in collapsed:
+            collapsed = collapsed.replace("__", "_")
+
+        if not collapsed:
+            return "empty"
+        return collapsed[:limit]
 
     def sleep_ms(self, ms):
         time.sleep(ms / 1000.0)
@@ -1055,10 +1076,15 @@ class JarvisSystem:
                 self.run_voice("Would you like me to import your home preferences?", show_input_after=True)
 
             elif user_input == "shutdown interface":
+                self.runtime_milestone("BOOT_MAIN|SHUTDOWN_COMMAND_ACCEPTED|stage=command_1")
                 self.run_voice("Understood. Shutting down interface.")
                 self.emit_bus(self.bus.shutdown_requested)
 
             else:
+                normalized_input = self.normalized_marker_input(user_input)
+                self.runtime_milestone(
+                    f"BOOT_MAIN|FIRST_COMMAND_REJECTED|input={normalized_input}"
+                )
                 self.run_voice("Command not recognized.", show_input_after=True)
                 self.set_status("AWAITING COMMAND")
 
@@ -1078,10 +1104,15 @@ class JarvisSystem:
                 self.transition_to_hud(import_home=False)
 
             elif user_input == "shutdown interface":
+                self.runtime_milestone("BOOT_MAIN|SHUTDOWN_COMMAND_ACCEPTED|stage=command_2")
                 self.run_voice("Understood. Shutting down interface.")
                 self.emit_bus(self.bus.shutdown_requested)
 
             else:
+                normalized_input = self.normalized_marker_input(user_input)
+                self.runtime_milestone(
+                    f"BOOT_MAIN|IMPORT_CHOICE_REJECTED|input={normalized_input}"
+                )
                 self.set_status("CONFIRM IMPORT")
                 self.run_voice("Please answer yes or no.", show_input_after=True)
 
@@ -1123,7 +1154,12 @@ class JarvisSystem:
         self.log_event("> Center Jarvis core stabilizing into desktop mode")
         self.sleep_ms(120)
 
-        self.emit_bus(self.bus.begin_desktop_handoff)
+        if self.emit_bus(self.bus.begin_desktop_handoff):
+            self.runtime_milestone("BOOT_MAIN|HANDOFF_SIGNAL_EMITTED")
+        else:
+            self.runtime_milestone(
+                "BOOT_MAIN|HANDOFF_SIGNAL_DROPPED|reason=shutdown_in_progress_or_runtime_error"
+            )
 
     def begin_desktop_handoff(self):
         desktop_reveal_delay_ms = 140

--- a/main.py
+++ b/main.py
@@ -589,11 +589,16 @@ class JarvisSystem:
             self.boot_profile,
             self.audio_mode,
         )
+
+        def log_single_instance_event(event):
+            write_boot_runtime_marker(self.runtime_log_file, f"BOOT_MAIN|{event}")
+
         if not acquire_or_prompt_replace(
             runtime_instance_guard,
             runtime_relaunch_signal,
             "Jarvis Already Running",
             "Jarvis is already running.\n\nDo you want to close the current instance and open a new one?",
+            event_logger=log_single_instance_event,
         ):
             write_boot_runtime_marker(self.runtime_log_file, "BOOT_MAIN|SINGLE_INSTANCE_BLOCKED")
             raise SystemExit(0)

--- a/main.py
+++ b/main.py
@@ -596,8 +596,11 @@ class JarvisSystem:
         if not acquire_or_prompt_replace(
             runtime_instance_guard,
             runtime_relaunch_signal,
-            "Jarvis Already Running",
-            "Jarvis is already running.\n\nDo you want to close the current instance and open a new one?",
+            "Boot Jarvis Session Active",
+            "A Boot Jarvis session is already active.\n\nDo you want to close the current Jarvis session and relaunch from this boot entrypoint?",
+            eyebrow_text="BOOT JARVIS",
+            primary_button_text="Relaunch Boot Jarvis",
+            secondary_button_text="Keep Current Session",
             event_logger=log_single_instance_event,
         ):
             write_boot_runtime_marker(self.runtime_log_file, "BOOT_MAIN|SINGLE_INSTANCE_BLOCKED")
@@ -612,7 +615,7 @@ class JarvisSystem:
             f"BOOT_MAIN|START|profile={self.boot_profile}|audio={self.audio_mode}"
         )
 
-        self.app = QApplication(self.dev_config["qt_argv"])
+        self.app = QApplication.instance() or QApplication(self.dev_config["qt_argv"])
         self.app.setQuitOnLastWindowClosed(False)
         self.relaunch_timer = QTimer()
         self.relaunch_timer.timeout.connect(self.check_relaunch_request)

--- a/main.py
+++ b/main.py
@@ -20,6 +20,11 @@ from PySide6.QtGui import QGuiApplication, QKeyEvent
 from PySide6.QtWebEngineWidgets import QWebEngineView
 
 from Audio.jarvis_voice import JarvisSpeaker
+from desktop.single_instance import (
+    NamedSignal,
+    SingleInstanceGuard,
+    acquire_or_prompt_replace,
+)
 
 
 VALID_BOOT_PROFILES = {"manual", "auto_handoff_skip_import"}
@@ -32,6 +37,10 @@ AUTO_STAGE_COMMANDS = {
     "command_1": "engage hud",
     "command_2": "no",
 }
+RUNTIME_INSTANCE_MUTEX = r"Local\JarvisRuntimeSingletonV1"
+RUNTIME_RELAUNCH_EVENT = r"Local\JarvisRuntimeRelaunchRequestV1"
+runtime_instance_guard = SingleInstanceGuard(RUNTIME_INSTANCE_MUTEX)
+runtime_relaunch_signal = NamedSignal(RUNTIME_RELAUNCH_EVENT)
 
 
 def parse_dev_run_config(argv):
@@ -75,6 +84,12 @@ def resolve_boot_runtime_log_paths(base_dir, boot_profile, audio_mode):
     stamp = datetime.datetime.now().strftime("%Y%m%d_%H%M%S_%f")
     runtime_file = os.path.join(runtime_root, f"Runtime_{stamp}_{audio_mode}.txt")
     return runtime_root, runtime_file
+
+
+def write_boot_runtime_marker(runtime_file, event):
+    stamp = datetime.datetime.now().strftime("[%H:%M:%S]")
+    with open(runtime_file, "a", encoding="utf-8") as f:
+        f.write(f"{stamp} {event}\n")
 
 
 def screen_marker(screen):
@@ -574,10 +589,19 @@ class JarvisSystem:
             self.boot_profile,
             self.audio_mode,
         )
+        if not acquire_or_prompt_replace(
+            runtime_instance_guard,
+            runtime_relaunch_signal,
+            "Jarvis Already Running",
+            "Jarvis is already running.\n\nDo you want to close the current instance and open a new one?",
+        ):
+            write_boot_runtime_marker(self.runtime_log_file, "BOOT_MAIN|SINGLE_INSTANCE_BLOCKED")
+            raise SystemExit(0)
 
         self.prompt_markers_emitted = set()
         self.auto_command_pending_stages = set()
         self.desktop_settled_logged = False
+        self.shutdown_in_progress = False
 
         self.runtime_milestone(
             f"BOOT_MAIN|START|profile={self.boot_profile}|audio={self.audio_mode}"
@@ -585,6 +609,9 @@ class JarvisSystem:
 
         self.app = QApplication(self.dev_config["qt_argv"])
         self.app.setQuitOnLastWindowClosed(False)
+        self.relaunch_timer = QTimer()
+        self.relaunch_timer.timeout.connect(self.check_relaunch_request)
+        self.relaunch_timer.start(200)
 
         self.bus = UIBus()
         self.speaker = JarvisSpeaker() if self.audio_mode == "voice" else None
@@ -692,7 +719,7 @@ class JarvisSystem:
                 and
                 pynput_keyboard.Key.end in self.hotkeys_pressed
             ):
-                self.bus.shutdown_requested.emit()
+                self.emit_bus(self.bus.shutdown_requested)
         except Exception:
             pass
 
@@ -701,13 +728,23 @@ class JarvisSystem:
             self.hotkeys_pressed.remove(key)
 
     def shutdown_interface(self):
+        if self.shutdown_in_progress:
+            return
+        self.shutdown_in_progress = True
         self.runtime_milestone("BOOT_MAIN|SHUTDOWN_REQUESTED")
+        if hasattr(self, "relaunch_timer"):
+            self.relaunch_timer.stop()
         try:
             self.hotkey_listener.stop()
         except Exception:
             pass
         self.stop_voice_visualizer()
         QApplication.quit()
+
+    def check_relaunch_request(self):
+        if runtime_relaunch_signal.consume():
+            self.runtime_milestone("BOOT_MAIN|RELAUNCH_REQUEST_RECEIVED")
+            self.shutdown_interface()
 
     def runtime_milestone(self, event):
         if not self.runtime_log_file:
@@ -723,17 +760,27 @@ class JarvisSystem:
     def sleep_ms(self, ms):
         time.sleep(ms / 1000.0)
 
+    def emit_bus(self, signal, *args):
+        if self.shutdown_in_progress:
+            return False
+        try:
+            signal.emit(*args)
+            return True
+        except RuntimeError:
+            self.shutdown_in_progress = True
+            return False
+
     def log_event(self, text):
-        self.bus.append_overlay_log.emit(text)
+        self.emit_bus(self.bus.append_overlay_log, text)
 
     def set_status(self, text):
-        self.bus.set_overlay_status.emit(text)
+        self.emit_bus(self.bus.set_overlay_status, text)
 
     def set_visual_state(self, state):
-        self.bus.set_visual_state.emit(state)
+        self.emit_bus(self.bus.set_visual_state, state)
 
     def set_voice_level(self, level):
-        self.bus.set_voice_level.emit(level)
+        self.emit_bus(self.bus.set_voice_level, level)
 
     def mark_prompt_shown(self):
         marker = ""
@@ -824,7 +871,7 @@ class JarvisSystem:
         self.voice_busy = True
         self.pending_input_after_voice = show_input_after
 
-        self.bus.hide_command_input.emit()
+        self.emit_bus(self.bus.hide_command_input)
 
         if self.audio_mode == "quiet":
             self.runtime_milestone(f"BOOT_MAIN|VOICE_BYPASSED|stage={self.awaiting_stage}")
@@ -833,7 +880,7 @@ class JarvisSystem:
 
             if self.pending_input_after_voice and self.awaiting_stage != "complete":
                 self.sleep_ms(80)
-                self.bus.show_command_input.emit()
+                self.emit_bus(self.bus.show_command_input)
                 self.mark_prompt_shown()
                 self.maybe_schedule_auto_command()
 
@@ -854,7 +901,7 @@ class JarvisSystem:
 
             if self.pending_input_after_voice and self.awaiting_stage != "complete":
                 self.sleep_ms(180)
-                self.bus.show_command_input.emit()
+                self.emit_bus(self.bus.show_command_input)
                 self.mark_prompt_shown()
                 self.maybe_schedule_auto_command()
 
@@ -865,13 +912,14 @@ class JarvisSystem:
         steps = 18
         delta = max(1, int((target - current) / max(1, steps)))
         if current >= target:
-            self.bus.set_progress.emit(target)
+            self.emit_bus(self.bus.set_progress, target)
             return
 
         value = current
-        while value < target:
+        while value < target and not self.shutdown_in_progress:
             value = min(target, value + delta)
-            self.bus.set_progress.emit(value)
+            if not self.emit_bus(self.bus.set_progress, value):
+                return
             self.sleep_ms(max(10, duration_ms // steps))
 
     def stage_hud_subroutines(self):
@@ -890,8 +938,10 @@ class JarvisSystem:
             left_lines.append(left_text)
             right_lines.append(right_text)
 
-            self.bus.set_left_body.emit("\n".join(left_lines))
-            self.bus.set_right_body.emit("\n".join(right_lines))
+            if not self.emit_bus(self.bus.set_left_body, "\n".join(left_lines)):
+                return
+            if not self.emit_bus(self.bus.set_right_body, "\n".join(right_lines)):
+                return
             self.sleep_ms(300)
 
     def boot_sequence(self):
@@ -899,15 +949,15 @@ class JarvisSystem:
         self.runtime_milestone("BOOT_MAIN|BOOT_SEQUENCE_START")
 
         self.set_visual_state("boot")
-        self.bus.set_overlay_title.emit("Installing Jarvis")
+        self.emit_bus(self.bus.set_overlay_title, "Installing Jarvis")
         self.set_status("PREPARING INSTALLATION")
-        self.bus.set_overlay_log.emit("")
-        self.bus.show_progress.emit()
-        self.bus.set_progress.emit(0)
+        self.emit_bus(self.bus.set_overlay_log, "")
+        self.emit_bus(self.bus.show_progress)
+        self.emit_bus(self.bus.set_progress, 0)
         self.set_voice_level(0.0)
 
-        self.bus.set_left_body.emit("")
-        self.bus.set_right_body.emit("")
+        self.emit_bus(self.bus.set_left_body, "")
+        self.emit_bus(self.bus.set_right_body, "")
 
         install_steps = [
             (8,  "Allocating core memory"),
@@ -923,6 +973,8 @@ class JarvisSystem:
         ]
 
         for value, text in install_steps:
+            if self.shutdown_in_progress:
+                return
             self.set_status(text)
             self.log_event(f"> {text}")
             self.animate_progress_to(value, duration_ms=420)
@@ -930,7 +982,10 @@ class JarvisSystem:
 
         self.sleep_ms(500)
 
-        self.bus.set_overlay_title.emit("JARVIS")
+        if self.shutdown_in_progress:
+            return
+
+        self.emit_bus(self.bus.set_overlay_title, "JARVIS")
         self.set_status("COMING ONLINE")
         self.log_event("")
         self.log_event("> Jarvis installation verified")
@@ -945,12 +1000,14 @@ class JarvisSystem:
         ]
 
         for step in online_steps:
+            if self.shutdown_in_progress:
+                return
             self.log_event(f"> {step}")
             self.sleep_ms(420)
 
         self.sleep_ms(700)
 
-        self.bus.hide_progress.emit()
+        self.emit_bus(self.bus.hide_progress)
         self.set_status("ONLINE")
 
         self.awaiting_stage = "command_1"
@@ -971,7 +1028,7 @@ class JarvisSystem:
 
     def handle_command(self, text):
         user_input = text.strip().lower()
-        self.bus.clear_command_input.emit()
+        self.emit_bus(self.bus.clear_command_input)
 
         if self.voice_busy:
             return
@@ -991,7 +1048,7 @@ class JarvisSystem:
 
             elif user_input == "shutdown interface":
                 self.run_voice("Understood. Shutting down interface.")
-                self.bus.shutdown_requested.emit()
+                self.emit_bus(self.bus.shutdown_requested)
 
             else:
                 self.run_voice("Command not recognized.", show_input_after=True)
@@ -1001,20 +1058,20 @@ class JarvisSystem:
             if user_input in {"yes", "yes sir", "affirmative"}:
                 self.runtime_milestone("BOOT_MAIN|IMPORT_CHOICE_RESOLVED|choice=import_home")
                 self.awaiting_stage = "complete"
-                self.bus.hide_command_input.emit()
+                self.emit_bus(self.bus.hide_command_input)
                 self.run_voice("Importing home preferences.")
                 self.transition_to_hud(import_home=True)
 
             elif user_input in {"no", "negative"}:
                 self.runtime_milestone("BOOT_MAIN|IMPORT_CHOICE_RESOLVED|choice=skip")
                 self.awaiting_stage = "complete"
-                self.bus.hide_command_input.emit()
+                self.emit_bus(self.bus.hide_command_input)
                 self.run_voice("Proceeding without home preferences.")
                 self.transition_to_hud(import_home=False)
 
             elif user_input == "shutdown interface":
                 self.run_voice("Understood. Shutting down interface.")
-                self.bus.shutdown_requested.emit()
+                self.emit_bus(self.bus.shutdown_requested)
 
             else:
                 self.set_status("CONFIRM IMPORT")
@@ -1037,14 +1094,16 @@ class JarvisSystem:
         else:
             self.log_event("> Home preferences skipped")
 
-        self.bus.set_left_body.emit(
+        self.emit_bus(
+            self.bus.set_left_body,
             "LEFT MODULE ....... RESERVED\n"
             "TARGET ROLE ....... TELEMETRY / SENSORS\n"
             "APP OWNER ......... FUTURE EXTERNAL MODULE\n"
             "STATE ............. READY"
         )
 
-        self.bus.set_right_body.emit(
+        self.emit_bus(
+            self.bus.set_right_body,
             "RIGHT MODULE ...... RESERVED\n"
             "TARGET ROLE ....... STATUS / SENSOR WALL\n"
             "APP OWNER ......... FUTURE EXTERNAL MODULE\n"
@@ -1056,7 +1115,7 @@ class JarvisSystem:
         self.log_event("> Center Jarvis core stabilizing into desktop mode")
         self.sleep_ms(120)
 
-        self.bus.begin_desktop_handoff.emit()
+        self.emit_bus(self.bus.begin_desktop_handoff)
 
     def begin_desktop_handoff(self):
         desktop_reveal_delay_ms = 140

--- a/main.py
+++ b/main.py
@@ -6,6 +6,7 @@ import time
 import ctypes
 import random
 import math
+import datetime
 from ctypes import wintypes
 
 from pynput import keyboard as pynput_keyboard
@@ -19,6 +20,69 @@ from PySide6.QtGui import QGuiApplication, QKeyEvent
 from PySide6.QtWebEngineWidgets import QWebEngineView
 
 from Audio.jarvis_voice import JarvisSpeaker
+
+
+VALID_BOOT_PROFILES = {"manual", "auto_handoff_skip_import"}
+VALID_AUDIO_MODES = {"voice", "quiet"}
+BOOT_LOG_ROOTS = {
+    "manual": os.path.join("dev", "logs", "boot_manual_flow"),
+    "auto_handoff_skip_import": os.path.join("dev", "logs", "boot_auto_handoff_skip_import"),
+}
+AUTO_STAGE_COMMANDS = {
+    "command_1": "engage hud",
+    "command_2": "no",
+}
+
+
+def parse_dev_run_config(argv):
+    boot_profile = "manual"
+    audio_mode = "voice"
+    qt_argv = [argv[0]]
+
+    i = 1
+    while i < len(argv):
+        arg = argv[i]
+
+        if arg == "--boot-profile" and i + 1 < len(argv):
+            candidate = argv[i + 1].strip().lower()
+            if candidate in VALID_BOOT_PROFILES:
+                boot_profile = candidate
+            i += 2
+            continue
+
+        if arg == "--audio-mode" and i + 1 < len(argv):
+            candidate = argv[i + 1].strip().lower()
+            if candidate in VALID_AUDIO_MODES:
+                audio_mode = candidate
+            i += 2
+            continue
+
+        qt_argv.append(arg)
+        i += 1
+
+    return {
+        "boot_profile": boot_profile,
+        "audio_mode": audio_mode,
+        "qt_argv": qt_argv,
+    }
+
+
+def resolve_boot_runtime_log_paths(base_dir, boot_profile, audio_mode):
+    relative_root = BOOT_LOG_ROOTS[boot_profile]
+    runtime_root = os.path.join(base_dir, relative_root)
+    os.makedirs(runtime_root, exist_ok=True)
+
+    stamp = datetime.datetime.now().strftime("%Y%m%d_%H%M%S_%f")
+    runtime_file = os.path.join(runtime_root, f"Runtime_{stamp}_{audio_mode}.txt")
+    return runtime_root, runtime_file
+
+
+def screen_marker(screen):
+    g = screen.geometry()
+    return (
+        f"{screen.name()}"
+        f"@x{g.x()}_y{g.y()}_w{g.width()}_h{g.height()}"
+    )
 
 
 # ---------------------------
@@ -501,11 +565,29 @@ class JarvisBootCenterWindow(BaseWindow):
 
 class JarvisSystem:
     def __init__(self):
-        self.app = QApplication(sys.argv)
+        self.base_dir = os.path.dirname(os.path.abspath(__file__))
+        self.dev_config = parse_dev_run_config(sys.argv)
+        self.boot_profile = self.dev_config["boot_profile"]
+        self.audio_mode = self.dev_config["audio_mode"]
+        self.runtime_log_root, self.runtime_log_file = resolve_boot_runtime_log_paths(
+            self.base_dir,
+            self.boot_profile,
+            self.audio_mode,
+        )
+
+        self.prompt_markers_emitted = set()
+        self.auto_command_pending_stages = set()
+        self.desktop_settled_logged = False
+
+        self.runtime_milestone(
+            f"BOOT_MAIN|START|profile={self.boot_profile}|audio={self.audio_mode}"
+        )
+
+        self.app = QApplication(self.dev_config["qt_argv"])
         self.app.setQuitOnLastWindowClosed(False)
 
         self.bus = UIBus()
-        self.speaker = JarvisSpeaker()
+        self.speaker = JarvisSpeaker() if self.audio_mode == "voice" else None
 
         self.awaiting_stage = "boot"
         self.voice_busy = False
@@ -524,6 +606,7 @@ class JarvisSystem:
 
         screens = QGuiApplication.screens()
         if len(screens) < 3:
+            self.runtime_milestone(f"BOOT_MAIN|TOPOLOGY_INVALID|screen_count={len(screens)}")
             print("Error: Need 3 monitors connected.")
             sys.exit(1)
 
@@ -540,8 +623,7 @@ class JarvisSystem:
             self.left_screen = other_sorted[0]
             self.right_screen = other_sorted[1]
 
-        base_dir = os.path.dirname(os.path.abspath(__file__))
-        visual_html = os.path.join(base_dir, "jarvis_visual", "jarvis_core.html")
+        visual_html = os.path.join(self.base_dir, "jarvis_visual", "jarvis_core.html")
 
         self.left_window = BootSideWindow(self.left_screen, "LEFT MODULE")
         self.boot_center_window = JarvisBootCenterWindow(self.center_screen, visual_html)
@@ -583,6 +665,15 @@ class JarvisSystem:
             g = screen.geometry()
             print(f"{label}: {screen.name()} | x={g.x()} y={g.y()} w={g.width()} h={g.height()}")
 
+        self.runtime_milestone(
+            "BOOT_MAIN|TOPOLOGY_RESOLVED|"
+            f"screen_count={len(screens)}|"
+            f"left={screen_marker(self.left_screen)}|"
+            f"center={screen_marker(self.center_screen)}|"
+            f"right={screen_marker(self.right_screen)}"
+        )
+        self.runtime_milestone("BOOT_MAIN|WINDOWS_CONSTRUCTED")
+
     def set_visual_state_all(self, state_name):
         self.boot_center_window.set_visual_state(state_name)
         self.desktop_center_window.set_visual_state(state_name)
@@ -610,12 +701,24 @@ class JarvisSystem:
             self.hotkeys_pressed.remove(key)
 
     def shutdown_interface(self):
+        self.runtime_milestone("BOOT_MAIN|SHUTDOWN_REQUESTED")
         try:
             self.hotkey_listener.stop()
         except Exception:
             pass
         self.stop_voice_visualizer()
         QApplication.quit()
+
+    def runtime_milestone(self, event):
+        if not self.runtime_log_file:
+            return
+
+        try:
+            ts = datetime.datetime.now().strftime("%H:%M:%S")
+            with open(self.runtime_log_file, "a", encoding="utf-8") as f:
+                f.write(f"[{ts}] {event}\n")
+        except Exception:
+            pass
 
     def sleep_ms(self, ms):
         time.sleep(ms / 1000.0)
@@ -631,6 +734,48 @@ class JarvisSystem:
 
     def set_voice_level(self, level):
         self.bus.set_voice_level.emit(level)
+
+    def mark_prompt_shown(self):
+        marker = ""
+        if self.awaiting_stage == "command_1":
+            marker = "BOOT_MAIN|FIRST_PROMPT_SHOWN"
+        elif self.awaiting_stage == "command_2":
+            marker = "BOOT_MAIN|IMPORT_PROMPT_SHOWN"
+
+        if not marker or marker in self.prompt_markers_emitted:
+            return
+
+        self.prompt_markers_emitted.add(marker)
+        self.runtime_milestone(marker)
+
+    def maybe_schedule_auto_command(self):
+        if self.boot_profile != "auto_handoff_skip_import":
+            return
+
+        stage = self.awaiting_stage
+        command = AUTO_STAGE_COMMANDS.get(stage, "")
+        if not command or stage in self.auto_command_pending_stages:
+            return
+
+        command_marker = command.replace(" ", "_")
+        self.auto_command_pending_stages.add(stage)
+        self.runtime_milestone(
+            f"BOOT_MAIN|AUTO_COMMAND_QUEUED|stage={stage}|command={command_marker}"
+        )
+
+        def worker():
+            self.sleep_ms(220)
+            try:
+                if self.awaiting_stage != stage or self.voice_busy:
+                    return
+                self.runtime_milestone(
+                    f"BOOT_MAIN|AUTO_COMMAND_SUBMITTED|stage={stage}|command={command_marker}"
+                )
+                self.start_command_thread(command)
+            finally:
+                self.auto_command_pending_stages.discard(stage)
+
+        threading.Thread(target=worker, daemon=True).start()
 
     def start_voice_visualizer(self, text: str):
         self.stop_voice_visualizer()
@@ -680,8 +825,24 @@ class JarvisSystem:
         self.pending_input_after_voice = show_input_after
 
         self.bus.hide_command_input.emit()
+
+        if self.audio_mode == "quiet":
+            self.runtime_milestone(f"BOOT_MAIN|VOICE_BYPASSED|stage={self.awaiting_stage}")
+            self.voice_busy = False
+            self.set_visual_state("idle")
+
+            if self.pending_input_after_voice and self.awaiting_stage != "complete":
+                self.sleep_ms(80)
+                self.bus.show_command_input.emit()
+                self.mark_prompt_shown()
+                self.maybe_schedule_auto_command()
+
+            self.pending_input_after_voice = False
+            return
+
         self.set_visual_state("speaking")
         self.start_voice_visualizer(text)
+        self.runtime_milestone(f"BOOT_MAIN|VOICE_STARTED|stage={self.awaiting_stage}")
 
         try:
             asyncio.run(self.speaker.speak(text))
@@ -689,10 +850,13 @@ class JarvisSystem:
             self.stop_voice_visualizer()
             self.voice_busy = False
             self.set_visual_state("idle")
+            self.runtime_milestone(f"BOOT_MAIN|VOICE_COMPLETED|stage={self.awaiting_stage}")
 
             if self.pending_input_after_voice and self.awaiting_stage != "complete":
                 self.sleep_ms(180)
                 self.bus.show_command_input.emit()
+                self.mark_prompt_shown()
+                self.maybe_schedule_auto_command()
 
             self.pending_input_after_voice = False
 
@@ -732,6 +896,7 @@ class JarvisSystem:
 
     def boot_sequence(self):
         self.awaiting_stage = "boot"
+        self.runtime_milestone("BOOT_MAIN|BOOT_SEQUENCE_START")
 
         self.set_visual_state("boot")
         self.bus.set_overlay_title.emit("Installing Jarvis")
@@ -813,6 +978,7 @@ class JarvisSystem:
 
         if self.awaiting_stage == "command_1":
             if user_input in {"engage hud", "engage heads up display"}:
+                self.runtime_milestone("BOOT_MAIN|FIRST_COMMAND_ACCEPTED|command=engage_hud")
                 self.awaiting_stage = "command_2"
                 self.set_status("CONFIRM IMPORT")
                 self.log_event("> Heads up display request accepted")
@@ -833,12 +999,14 @@ class JarvisSystem:
 
         elif self.awaiting_stage == "command_2":
             if user_input in {"yes", "yes sir", "affirmative"}:
+                self.runtime_milestone("BOOT_MAIN|IMPORT_CHOICE_RESOLVED|choice=import_home")
                 self.awaiting_stage = "complete"
                 self.bus.hide_command_input.emit()
                 self.run_voice("Importing home preferences.")
                 self.transition_to_hud(import_home=True)
 
             elif user_input in {"no", "negative"}:
+                self.runtime_milestone("BOOT_MAIN|IMPORT_CHOICE_RESOLVED|choice=skip")
                 self.awaiting_stage = "complete"
                 self.bus.hide_command_input.emit()
                 self.run_voice("Proceeding without home preferences.")
@@ -853,6 +1021,8 @@ class JarvisSystem:
                 self.run_voice("Please answer yes or no.", show_input_after=True)
 
     def transition_to_hud(self, import_home=True):
+        import_marker = "true" if import_home else "false"
+        self.runtime_milestone(f"BOOT_MAIN|TRANSITION_BEGIN|import_home={import_marker}")
         self.set_status("ENGAGING HEADS UP DISPLAY")
         self.set_visual_state("processing")
 
@@ -895,6 +1065,7 @@ class JarvisSystem:
         self.desktop_center_window.set_visual_state("dormant")
         self.desktop_center_window.set_voice_level(0.0)
         self.desktop_center_window.raise_()
+        self.runtime_milestone("BOOT_MAIN|DESKTOP_SHOWN")
 
         self.desktop_center_window.enable_desktop_mode()
         self.reinforce_desktop_mode()
@@ -902,6 +1073,7 @@ class JarvisSystem:
         QTimer.singleShot(900, self.reinforce_desktop_mode)
         QTimer.singleShot(2200, self.reinforce_desktop_mode)
         QTimer.singleShot(5000, self.reinforce_desktop_mode)
+        QTimer.singleShot(1100, self.mark_desktop_settled)
 
         self.desktop_center_window.fade_in(start_opacity=0.0, end_opacity=1.0, duration_ms=900)
 
@@ -931,10 +1103,17 @@ class JarvisSystem:
         make_window_noninteractive(hwnd)
         self.desktop_center_window.lower()
 
+    def mark_desktop_settled(self):
+        if self.desktop_settled_logged:
+            return
+        self.desktop_settled_logged = True
+        self.runtime_milestone("BOOT_MAIN|DESKTOP_SETTLED|state=dormant")
+
     def start(self):
         self.left_window.show()
         self.boot_center_window.show()
         self.right_window.show()
+        self.runtime_milestone("BOOT_MAIN|WINDOWS_SHOWN")
 
         self.boot_center_window.set_title("JARVIS")
         self.boot_center_window.set_status("BOOTING")
@@ -947,7 +1126,9 @@ class JarvisSystem:
 
         QTimer.singleShot(500, self.start_boot_thread)
 
-        sys.exit(self.app.exec())
+        exit_code = self.app.exec()
+        self.runtime_milestone(f"BOOT_MAIN|EVENT_LOOP_EXIT|code={exit_code}")
+        return exit_code
 
     def start_boot_thread(self):
         threading.Thread(target=self.boot_sequence, daemon=True).start()
@@ -955,4 +1136,4 @@ class JarvisSystem:
 
 if __name__ == "__main__":
     jarvis = JarvisSystem()
-    jarvis.start()
+    raise SystemExit(jarvis.start())

--- a/main.py
+++ b/main.py
@@ -1059,12 +1059,14 @@ class JarvisSystem:
         self.bus.begin_desktop_handoff.emit()
 
     def begin_desktop_handoff(self):
+        desktop_reveal_delay_ms = 140
+        desktop_state_commit_delay_ms = 220
+        desktop_settle_delay_ms = desktop_reveal_delay_ms + desktop_state_commit_delay_ms + 320
+
         self.desktop_center_window.prepare_desktop_geometry()
-        self.desktop_center_window.setWindowOpacity(0.0)
+        self.desktop_center_window.setWindowOpacity(1.0)
         self.desktop_center_window.show()
-        self.desktop_center_window.set_visual_state("dormant")
         self.desktop_center_window.set_voice_level(0.0)
-        self.desktop_center_window.raise_()
         self.runtime_milestone("BOOT_MAIN|DESKTOP_SHOWN")
 
         self.desktop_center_window.enable_desktop_mode()
@@ -1073,29 +1075,42 @@ class JarvisSystem:
         QTimer.singleShot(900, self.reinforce_desktop_mode)
         QTimer.singleShot(2200, self.reinforce_desktop_mode)
         QTimer.singleShot(5000, self.reinforce_desktop_mode)
-        QTimer.singleShot(1100, self.mark_desktop_settled)
-
-        self.desktop_center_window.fade_in(start_opacity=0.0, end_opacity=1.0, duration_ms=900)
+        QTimer.singleShot(desktop_settle_delay_ms, self.mark_desktop_settled)
 
         self.boot_center_window.enter_background_visual_mode()
-        self.boot_center_window.fade_overlay(end_opacity=0.0, duration_ms=650)
-        self.boot_center_window.fade_whole_window(end_opacity=0.0, duration_ms=900)
+        self.boot_center_window.fade_overlay(end_opacity=0.0, duration_ms=260)
 
         self.left_anim = QPropertyAnimation(self.left_window, b"windowOpacity")
-        self.left_anim.setDuration(800)
+        self.left_anim.setDuration(500)
         self.left_anim.setStartValue(self.left_window.windowOpacity())
         self.left_anim.setEndValue(0.0)
         self.left_anim.start()
 
         self.right_anim = QPropertyAnimation(self.right_window, b"windowOpacity")
-        self.right_anim.setDuration(800)
+        self.right_anim.setDuration(500)
         self.right_anim.setStartValue(self.right_window.windowOpacity())
         self.right_anim.setEndValue(0.0)
         self.right_anim.start()
 
-        QTimer.singleShot(980, self.boot_center_window.hide)
-        QTimer.singleShot(980, self.left_window.hide)
-        QTimer.singleShot(980, self.right_window.hide)
+        QTimer.singleShot(
+            desktop_reveal_delay_ms,
+            lambda: self.complete_desktop_visual_handoff(
+                desktop_state_commit_delay_ms,
+            ),
+        )
+
+    def complete_desktop_visual_handoff(self, state_commit_delay_ms=220):
+        self.boot_center_window.hide()
+        self.left_window.hide()
+        self.right_window.hide()
+        self.runtime_milestone("BOOT_MAIN|BOOT_WINDOWS_HIDDEN")
+        self.desktop_center_window.setWindowOpacity(1.0)
+        self.runtime_milestone("BOOT_MAIN|DESKTOP_VISIBLE")
+        QTimer.singleShot(state_commit_delay_ms, self.commit_desktop_state)
+
+    def commit_desktop_state(self):
+        self.desktop_center_window.set_visual_state("dormant")
+        self.runtime_milestone("BOOT_MAIN|DESKTOP_STATE_COMMITTED|state=dormant")
 
     def reinforce_desktop_mode(self):
         hwnd = int(self.desktop_center_window.winId())


### PR DESCRIPTION
## Summary

This branch delivers the first contained v2.1.0 workstream on top of the v2.0 foundation.

## What Changed

Included:
- Boot Jarvis Phase 1 seams in main.py, including quiet mode, auto-handoff skip-import, dedicated boot evidence roots, and structured BOOT_MAIN markers
- dev-only boot launchers and Boot & Transition Checks surfacing in the Dev Toolkit
- continuous boot-to-desktop handoff behavior
- desktop renderer observability improvements plus WorkerW probe follow-through and guarded Progman fallback
- cooperative single-instance relaunch behavior with Jarvis-owned prompt and decision logging
- Dev Toolkit session logging, validation lanes, smoke validation, progress/status strip, and latest-artifact utilities
- remaining FB-024 boot edge-path marker completion

- FB-025 boot/desktop milestone taxonomy cleanup
- FB-026 Dev Toolkit uploaded-bundle intake surface

Architecture boundaries preserved:
- main.py remains the dev-only Boot Jarvis harness
- launch_jarvis_desktop.vbs remains the normal manual user launch
- controlled desktop path remains jarvis_desktop_launcher.pyw -> jarvis_desktop_main.py

Included:
- Boot Jarvis Phase 1 seams in main.py, including quiet mode, auto-handoff skip-import, dedicated boot evidence roots, and structured BOOT_MAIN markers
- dev-only boot launchers and Boot & Transition Checks surfacing in the Dev Toolkit
- continuous boot-to-desktop handoff behavior
- desktop renderer observability improvements plus WorkerW probe follow-through and guarded Progman fallback
- cooperative single-instance relaunch behavior with Jarvis-owned prompt and decision logging
- Dev Toolkit session logging, validation lanes, smoke validation, progress/status strip, and latest-artifact utilities
- remaining FB-024 boot edge-path marker completion

- FB-025 boot/desktop milestone taxonomy cleanup
- FB-026 Dev Toolkit uploaded-bundle intake surface

Architecture boundaries preserved:
- main.py remains the dev-only Boot Jarvis harness
- launch_jarvis_desktop.vbs remains the normal manual user launch
- controlled desktop path remains jarvis_desktop_launcher.pyw -> jarvis_desktop_main.py
