### PR TITLE
release/v2.2.1 release - Finalize v2.2.1 desktop stability and typed interaction slice

### DIFF
--- a/Docs/Main.md
+++ b/Docs/Main.md
@@ -40,6 +40,11 @@ These are the default project-governance and product-boundary docs:
 - `docs/codex_modes.md`
 - `docs/jarvis_task_template.md`
 
+Within that core set:
+
+- `docs/jarvis_vision.md` owns the product-wide meaning of `pre-Beta`, `Beta`, and `Full`
+- `docs/feature_backlog.md` owns per-item or per-slice release-stage assignment
+
 Use these when the task concerns:
 
 - repo-wide rules
@@ -54,11 +59,13 @@ Use these when the task concerns:
 These are the current canonical planning docs for specific active planning areas:
 
 - `docs/boot_access_design.md`
+- `docs/jarvis_interaction_architecture.md`
 - `docs/workspace_layout_plan.md`
 
 Current canonical ownership:
 
 - `boot_access_design.md` is the canonical boot-planning source
+- `jarvis_interaction_architecture.md` is the canonical interaction-planning source
 - `workspace_layout_plan.md` is the canonical workspace-planning source
 
 Use these only when the task is directly about those workstreams.
@@ -133,7 +140,7 @@ Add `architecture.md` or startup-path docs only if path-sensitive surfaces are d
 
 ### Analysis / Sequencing Work
 
-For “what should we do next,” “is this complete,” or “is this the right target” tasks, prompts should usually include:
+For "what should we do next," "is this complete," or "is this the right target" tasks, prompts should usually include:
 
 - `docs/development_rules.md`
 - `docs/Main.md`

--- a/Docs/Main.md
+++ b/Docs/Main.md
@@ -72,6 +72,7 @@ These docs are still valid, but they are not part of the default prompt baseline
 - `docs/v1.8.0_closeout.md`
 - `docs/v1.9.0_closeout.md`
 - `docs/v2.0_closeout.md`
+- `docs/v2.2.0_closeout.md`
 
 Use them when the task depends on:
 

--- a/Docs/architecture.md
+++ b/Docs/architecture.md
@@ -135,6 +135,18 @@ Responsible for:
 - recovery and retry flow
 - runtime and crash logging
 
+### Launcher-Owned Root Log Boundary
+
+Current root-owned live launcher surfaces remain under `C:/Jarvis/logs` only for approved launcher/runtime truth such as:
+
+- launcher-generated `Runtime_*.txt`
+- matching live crash logs under `C:/Jarvis/logs/crash`
+- launcher control/status files when relevant
+- the current launcher-owned historical state file until a later approved relocation moves it elsewhere
+
+Dev/test/worker/toolkit evidence does not belong in the live root logs tree.
+That evidence must write under `C:/Jarvis/dev/logs/<lane>/...` and must not introduce new artifact families or new subfolders under `C:/Jarvis/logs` or `C:/Jarvis/logs/crash` without explicit approval.
+
 ### Renderer (`jarvis_desktop_main.py`)
 
 Responsible for:

--- a/Docs/development_rules.md
+++ b/Docs/development_rules.md
@@ -65,6 +65,17 @@ After every revision, review:
 - Do not assume behavior without log evidence
 - Prefer structured markers over raw output
 
+## Root Logs Governance
+
+- `C:/Jarvis/logs` and `C:/Jarvis/logs/crash` are reserved for already-approved live launcher/runtime truth surfaces only
+- current approved root-owned surfaces are:
+  - launcher-generated `Runtime_*.txt`
+  - matching live crash logs
+  - launcher control/status files when relevant
+  - the current launcher-owned historical state file `jarvis_history_v1.jsonl` until a later explicitly approved relocation slice moves it
+- dev/test/worker/toolkit evidence must write under `C:/Jarvis/dev/logs/<lane>/...`
+- no new dev/test/worker evidence roots, new subfolders, or new artifact families may be introduced under `C:/Jarvis/logs` or `C:/Jarvis/logs/crash` without explicit user approval
+
 ## Orchestration Philosophy
 
 Build in this order:

--- a/Docs/feature_backlog.md
+++ b/Docs/feature_backlog.md
@@ -266,10 +266,10 @@ This should remain a reporting refinement only and must not change launcher beha
 
 ### [ID: FB-008] Shutdown voice degradation effect
 
-Status: On Hold  
+Status: Implemented (v2.2.0 rev2)  
 Priority: Low  
-Suggested Version: TBD  
-Suggested Revision: TBD  
+Suggested Version: v2.2.0  
+Suggested Revision: rev2  
 
 Description:
 Refine the existing staged degradation effect on the final "Shutting down" voice line so Jarvis sounds more convincingly like he is losing power during terminal shutdown.
@@ -278,10 +278,14 @@ Why it matters:
 Shutdown-line tuning would make Jarvis feel more state-aware and physically present during failure termination without widening the diagnostics/error voice path.
 
 Proposed Change:
-Tune the existing shutdown-only voice envelope using staged slowdown, optional pitch drop, and final tail fade or hesitation. Keep the work limited to shutdown-line-only envelope refinement rather than first-time implementation or broader voice-path redesign.
+Implemented model:
+- the final `Shutting down.` line remains routed through the existing dedicated shutdown-only path in `Audio/jarvis_error_voice.py`
+- the late shutdown envelope is now tuned so the collapse stays concentrated on `down` while the tail remains degraded but intelligible
+- the existing dev-only voice regression harness remains the regression guard for the launcher-owned shutdown line, and its normal-voice probe path now matches the current `Audio/jarvis_voice.py` repo layout
 
 Likely Files Affected:
 - C:/Jarvis/Audio/jarvis_error_voice.py
+- C:/Jarvis/dev/jarvis_voice_regression_harness.py
 
 Scope:
 - shutdown voice-effect refinement
@@ -293,8 +297,13 @@ Out of Scope:
 - renderer changes
 
 Notes:
-Current repo truth already includes a dedicated shutdown-only effect path for the final "Shutting down." line inside the diagnostics/error voice script. This item now represents any future shutdown-envelope tuning on top of that existing path, not first implementation of a shutdown-specific branch.
-This item is intentionally paused behind `FB-020` so the Dev Toolkit utility model and dev-only evidence-root cleanup can land first without mixing voice refinement into the current developer-surface rework.
+This item is now implemented as a tiny shutdown-line-only refinement.
+Current repo truth already includes:
+
+- the pre-existing dedicated shutdown-only effect path for the final `Shutting down.` line inside the diagnostics/error voice script
+- a bounded late-tail tuning pass in `apply_shutdown_source_slowdown()` so the collapse remains focused on `down` without over-dragging the final suffix
+- a directly supportive dev-only voice-harness path correction so the normal-voice probe resolves the live `Audio/jarvis_voice.py` location
+- passing voice-regression evidence across repeated-crash, startup-abort, direct diagnostics/error probes, and direct normal-voice probe coverage
 
 ---
 

--- a/Docs/feature_backlog.md
+++ b/Docs/feature_backlog.md
@@ -119,6 +119,7 @@ Status: Deferred (planning groundwork complete enough to pause)
 Priority: High  
 Suggested Version: v2.0  
 Suggested Revision: rev1  
+Release Stage: Slice-staged  
 
 Description:
 Design and later implement top-level boot orchestration above the desktop launcher.
@@ -147,6 +148,13 @@ Out of Scope:
 Notes:
 Current planning truth already includes the minimal future boot-orchestrator stage model in `docs/architecture.md` and aligned boot-access planning language in `docs/boot_access_design.md`. That completed groundwork is now complete enough to pause. This item therefore remains deferred only for later implementation-facing planning or runtime work and should not be mixed into current desktop orchestration revisions.
 
+Release-stage mapping:
+
+- completed planning groundwork is historical completion, not future-stage work
+- later internal implementation-facing groundwork belongs to `pre-Beta`
+- any later packaged or installable user-facing boot-orchestrator delivery belongs no earlier than `Beta`
+- broader mature boot-layer delivery belongs to `Full`
+
 ---
 
 ### [ID: FB-005] Workspace and folder organization
@@ -155,6 +163,7 @@ Status: Deferred (partial implementation through Step 4)
 Priority: Low  
 Suggested Version: v2.0  
 Suggested Revision: rev1  
+Release Stage: Slice-staged  
 
 Description:
 Continue staged project-directory cleanup for clarity and scalability while keeping top-level entrypoint and broader workspace restructuring deferred.
@@ -196,6 +205,12 @@ That means:
 - `launch_jarvis_desktop.vbs` remains root-owned
 - the remaining root-owned entrypoint boundary no longer belongs to the active workspace-cleanup lane and should be treated as later boot / entrypoint-ownership work outside `FB-005`
 - broader folder cleanup, broader `Audio` casing normalization, and `logs/` reorganization remain out of scope until a later explicitly approved slice
+
+Release-stage mapping:
+
+- completed Steps 3 and 4 are historical completion, not future-stage work
+- Step 5 is a later `pre-Beta` internal path-shaping slice if intentionally resumed
+- broader workspace follow-through should remain separately approved rather than being treated as an automatic `Beta` or `Full` product feature lane
 
 ---
 
@@ -530,6 +545,7 @@ Status: Deferred (rev1a clarification complete enough to pause)
 Priority: Medium  
 Suggested Version: v2.0  
 Suggested Revision: rev1a  
+Release Stage: Slice-staged  
 
 Description:
 Define the conceptual boundary between future boot-stage orchestration and the already stabilized desktop-stage launcher layer.
@@ -556,6 +572,11 @@ Out of Scope:
 
 Notes:
 This remains preparation work only. Current planning truth already includes the architecture-level `FB-015 rev1a` phase-boundary contract in `docs/architecture.md` plus the aligned downstream-input contract in `docs/boot_access_design.md`. That clarification work is now complete enough to pause. Any later boot-planning follow-through remains deferred, this item must not introduce boot-level runtime control, and it still does not authorize `FB-004` implementation work.
+
+Release-stage mapping:
+
+- completed `rev1a` clarification is historical completion, not future-stage work
+- any later follow-through remains `pre-Beta` internal clarification unless a separate later slice explicitly widens beyond that planning boundary
 
 ---
 
@@ -977,6 +998,7 @@ Status: Deferred
 Priority: Low  
 Suggested Version: v2.1.0  
 Suggested Revision: rev5  
+Release Stage: pre-Beta  
 
 Description:
 Clarify the shared naming shape between `BOOT_MAIN|...` and `RENDERER_MAIN|...` milestone families once both lanes have enough core markers to make cross-lane evidence easier to compare.
@@ -1054,6 +1076,57 @@ Current repo truth already includes:
 - latest-artifact convenience utilities
 
 This landed as a bounded dev-tools-only intake slice and did not change production reporting behavior, issue-submission behavior, or support-bundle schema.
+
+---
+
+### [ID: FB-027] Jarvis interaction surfaces and shared action model
+
+Status: Deferred  
+Priority: High  
+Suggested Version: TBD  
+Suggested Revision: rev1  
+Release Stage: Slice-staged  
+
+Description:
+Define and later deliver the Jarvis interaction system as a voice-first, typed-sufficient, user-customizable command surface with one shared action model underneath typed commands, future voice commands, aliases, routines, and profiles.
+
+Why it matters:
+This is the clearest future product-facing lane for turning Jarvis from a stabilized orchestration foundation into a system-facing interaction layer the user can actually shape and use day to day.
+
+Proposed Change:
+For current repo truth, keep the canonical interaction architecture in `docs/jarvis_interaction_architecture.md` and deliver it through staged slices rather than one broad feature push.
+
+Likely Files Affected:
+- C:/Jarvis/docs/jarvis_interaction_architecture.md
+- future typed command overlay surfaces
+- future shared action-model surfaces
+- future action-customization surfaces
+- future install and setup surfaces
+
+Scope:
+- Jarvis interaction planning and staged delivery
+- typed command overlay
+- shared action model
+- customizable actions, aliases, routines, and profiles
+- later voice-first parity through the same model
+
+Out of Scope:
+- auth or trust mechanics
+- launcher-policy changes
+- shell, tray, renderer, or notification implementation mechanics
+- plugin implementation mechanics
+- broader boot-orchestrator runtime implementation
+
+Notes:
+Current planning truth already lives in `docs/jarvis_interaction_architecture.md`.
+
+Release-stage mapping:
+
+- `pre-Beta`: typed-first interaction foundation, including the quick command overlay, natural-language typed entry, minimal shared action model, direct actions and saved aliases, and desktop-mode command confirmation before execution
+- `Beta`: packaged and installable user-facing release with practical setup expectations and broader customization beyond the first internal slice
+- `Full`: later wake-word voice invocation, richer routines and profiles, and any future plugin capability if the shared action model proves stable enough
+
+This item must be staged by slice rather than treated as one single blanket stage.
 
 ---
 

--- a/Docs/feature_backlog.md
+++ b/Docs/feature_backlog.md
@@ -191,8 +191,10 @@ Completed slices now include:
 Step 5 and broader workspace work remain intentionally deferred.
 That means:
 
+- the current `FB-005` workspace slice is closed at the completed Step 4 boundary
 - `main.py` remains root-owned
 - `launch_jarvis_desktop.vbs` remains root-owned
+- the remaining root-owned entrypoint boundary no longer belongs to the active workspace-cleanup lane and should be treated as later boot / entrypoint-ownership work outside `FB-005`
 - broader folder cleanup, broader `Audio` casing normalization, and `logs/` reorganization remain out of scope until a later explicitly approved slice
 
 ---

--- a/Docs/feature_backlog.md
+++ b/Docs/feature_backlog.md
@@ -1130,6 +1130,66 @@ This item must be staged by slice rather than treated as one single blanket stag
 
 ---
 
+### [ID: FB-028] Relocate launcher history state out of root logs
+
+Status: Deferred  
+Priority: Medium  
+Suggested Version: TBD  
+Suggested Revision: rev1  
+Release Stage: pre-Beta  
+
+Description:
+Move the launcher-owned historical-memory file out of the user-visible root logs tree into a dedicated launcher-owned runtime state location.
+
+Why it matters:
+`jarvis_history_v1.jsonl` is not a runtime log, crash artifact, or dev evidence root. Keeping it in `C:/Jarvis/logs` makes internal cross-run state look like user-facing log clutter and conflicts with the current root-logs governance rule that the live root logs tree should stay reserved for already-approved launcher/runtime truth surfaces only.
+
+Proposed Change:
+Later bounded relocation slice:
+
+- choose a non-user-facing launcher-owned state root outside `C:/Jarvis/logs` and outside `C:/Jarvis/dev/logs`, preferably `%LOCALAPPDATA%/Jarvis/state`
+- patch the launcher history-path helper to read and write there
+- add a one-time migration from the existing root `C:/Jarvis/logs/jarvis_history_v1.jsonl` if present
+- preserve fail-safe degradation if migration or new-state writes fail
+- update the contained history harness and any other history-path consumers
+- sync the governing docs after the relocation lands
+
+Likely Files Affected:
+- C:/Jarvis/desktop/jarvis_desktop_launcher.pyw
+- C:/Jarvis/desktop/jarvis_history_harness_runner.py
+- C:/Jarvis/docs/development_rules.md
+- C:/Jarvis/docs/architecture.md
+- C:/Jarvis/docs/feature_backlog.md
+
+Scope:
+- launcher-owned historical-state relocation only
+- one-time migration and fallback behavior
+- keeping live runtime/crash roots and dev evidence roots unchanged
+
+Out of Scope:
+- moving runtime logs
+- moving crash logs
+- changing support-bundle locations
+- redesigning historical-memory semantics
+- dev evidence-root cleanup beyond the history file itself
+
+Notes:
+Current explicit decision:
+
+- do not move `jarvis_history_v1.jsonl` during the post-`v2.2.0` logs-cleanup pass
+- keep the current file in place until this later relocation slice is explicitly selected
+
+Detailed future plan:
+
+1. define the dedicated target state root and document it
+2. patch the launcher history path to resolve to that root
+3. add a one-time copy-forward migration from the existing root file
+4. keep clean fallback to existing non-historical behavior if the new root is unavailable
+5. update contained history-harness coverage to prove no writes spill back into live root `logs`
+6. verify the live root `logs` tree no longer exposes the history file after migration
+
+---
+
 ## Completed Items
 
 Move completed backlog items here for history tracking.

--- a/Docs/jarvis_interaction_architecture.md
+++ b/Docs/jarvis_interaction_architecture.md
@@ -1,0 +1,285 @@
+# Jarvis Interaction Architecture
+
+## Purpose
+
+This document is the canonical planning baseline for Jarvis user interaction as a voice-first, typed-sufficient, user-customizable system layer.
+
+It defines:
+
+- the primary user-facing interaction surfaces
+- the shared action model that should sit underneath voice and typed commands
+- the customization model for saved actions, routines, aliases, and profiles
+- the intended pre-Beta, Beta, and later Full release scope
+
+This is still a planning artifact.
+It does not define implementation mechanics for wake-word detection, speech-to-text, auth backend behavior, shell integration, tray mechanics, renderer wiring, plugin loading, or concrete runtime execution logic.
+
+## Relationship To Core Source-Of-Truth Docs
+
+This document is downstream of:
+
+- `architecture.md` for launcher-owned desktop authority and higher-layer read-only limits
+- `jarvis_vision.md` for Jarvis as the intended system-facing experience
+- `boot_access_design.md` for future pre-desktop access, trust, recovery, and resident trust-state boundaries
+- `feature_backlog.md` for workstream status and scope control
+
+This document does not replace those files.
+It narrows only the future Jarvis interaction surface and its customization model.
+
+## Product Intent
+
+Jarvis should evolve toward a system-facing interaction layer that feels more like a personal operator than a conventional desktop app launcher.
+
+At the user level, that means:
+
+- Jarvis is voice-first in personality and product direction
+- typed interaction remains fully sufficient
+- users can speak or type naturally rather than memorize rigid command syntax
+- Jarvis can map natural intent to reusable user-defined actions, routines, and environments
+- users can inspect, customize, and trust what Jarvis will do
+
+The system should feel closer to:
+
+- "Hey Jarvis, launch sim"
+- "Open Windows Explorer"
+- "I'd like you to open my sim setup"
+
+than to a brittle command console that only accepts one exact phrase.
+
+## Governing Interaction Principles
+
+- voice-first, not voice-only
+- typed-sufficient for all core interaction
+- one shared action system underneath all input surfaces
+- user-customizable by default rather than hardcoded around one machine
+- observable and inspectable rather than opaque
+- safe by default when actions could be risky or ambiguous
+- local product identity first, not a generic desktop launcher clone
+
+## Core Interaction Surfaces
+
+At planning level, Jarvis interaction should eventually be split across four primary user-facing surfaces:
+
+### 1. Voice Invocation Surface
+
+The long-term voice-first surface is the wake-word path, such as:
+
+- `Jarvis`
+- `Hey Jarvis`
+
+This is the future always-ready interaction posture, but it is not required for the first pre-Beta slice.
+
+### 2. Quick Command Overlay
+
+The typed-first companion surface is a dismissible command overlay.
+
+At planning level, this should be:
+
+- fast to open
+- fast to dismiss
+- usable as the typed equivalent of speaking to Jarvis
+- able to accept natural-language typed requests
+
+The current preferred default hotkey is:
+
+- `Ctrl+Alt+Home`
+
+That hotkey should be treated as a planning-level default, not a permanently fixed non-configurable rule.
+
+### 3. Action Studio
+
+The customization surface is the place where the user defines and edits saved actions, aliases, routines, and profiles.
+
+This is the closest conceptual analogue to a StreamDeck-style authoring surface, but it should remain Jarvis-shaped rather than becoming a clone of button-grid hardware software.
+
+### 4. Runtime And Status Surface
+
+Jarvis should expose a clear runtime/status surface that explains what it is doing now, what it just ran, and where a routine or command currently stands.
+
+This surface exists to preserve user trust and reduce "black box" behavior.
+
+## Shared Action Model
+
+Voice and typed interaction must not become separate products.
+
+At planning level, both should resolve into one shared interaction model:
+
+- `intent`
+  - what the user means
+- `action`
+  - one executable user-facing thing Jarvis can do
+- `routine`
+  - an ordered bundle of actions
+- `profile`
+  - a saved user-defined environment or context, such as a sim setup
+- `alias`
+  - alternate phrases that resolve to the same action or routine
+
+The key rule is:
+
+- voice input and typed input should resolve into the same action, routine, alias, and profile model
+
+This prevents Jarvis from splitting into:
+
+- one system for "voice commands"
+- another system for "typed commands"
+- a third system for "saved presets"
+
+## Natural-Language Command Contract
+
+Jarvis should be open to ordinary language variation rather than one exact command syntax.
+
+At planning level, that means a user should be able to express similar intent in multiple ways, such as:
+
+- `open windows explorer`
+- `open file explorer`
+- `I'd like you to open Windows Explorer`
+
+without the system being planned around one rigid phrase only.
+
+This does not authorize freeform AI action execution without boundaries.
+It only defines the product-level expectation that intent matching should be flexible and user-friendly.
+
+## Desktop-Mode Command Confirmation Contract
+
+At planning level, when Jarvis is already inside desktop mode and is about to run a user-requested command, Jarvis should confirm the interpreted action before execution.
+
+That confirmation should make clear:
+
+- what Jarvis believes the user asked for
+- which defined action, alias, routine, or target Jarvis resolved
+- which user-defined path, app target, or launch context Jarvis is about to use when that matters
+
+The purpose of this confirmation is:
+
+- to ensure Jarvis and the user share the same interpretation before execution
+- to keep desktop-mode command execution observable and trustworthy
+- to reduce accidental execution caused by ambiguous natural-language interpretation
+
+This planning contract does not define the exact UI phrasing, visual layout, or confirmation-control mechanics.
+It only defines the product rule that desktop-mode command execution should be explicitly confirmed before Jarvis runs the resolved action.
+
+## Customization Contract
+
+Jarvis customization should allow users to define:
+
+- action names
+- aliases and alternate phrases
+- app, file, folder, URL, or command targets
+- ordered launch steps
+- saved routines or environment profiles
+- preferred starting posture for recurring contexts, such as sim-racing setups
+
+At planning level, this contract should support user-defined targets like:
+
+- `Launch Sim`
+- `Start Racing`
+- `Open Work Setup`
+
+without forcing every user into the same built-in command map.
+
+## Release-Stage Model
+
+At planning level, the release stages for this interaction lane should follow the product-wide release-stage framing in `jarvis_vision.md`:
+
+- `pre-Beta`
+  - internal or tightly controlled delivery of the first usable interaction slices
+  - architecture, interaction model, and command-surface proof rather than packaged user distribution
+- `Beta`
+  - a packaged, installable, user-facing release with a real `.exe` or installer path, stable setup expectations, and practical customization
+- `Full`
+  - the broader mature interaction system beyond the first installable/testing release
+
+## Pre-Beta Release Direction
+
+The pre-Beta phase should prioritize the smallest coherent user-visible interaction foundation.
+
+At planning level, pre-Beta should center on:
+
+- the quick command overlay
+- typed natural-language command entry
+- the shared action model underneath typed commands and future voice commands
+- saved actions, aliases, routines, and profiles
+- a clear runtime/status surface for launched actions
+
+Pre-Beta should aim to prove:
+
+- Jarvis can feel like a coherent command surface rather than a generic app menu
+- users can define reusable launch actions and routines for their own machine
+- typed interaction already uses the same model that future voice interaction will depend on
+
+## Pre-Beta First Deliverable Direction
+
+The first pre-Beta deliverable should be the smallest typed-first slice of this interaction model:
+
+- a dismissible quick command overlay
+- natural-language typed command entry
+- a minimal shared action model for direct actions and saved aliases
+- desktop-mode confirmation before executing the resolved action
+
+This first deliverable should not require the full Action Studio, wake-word support, or advanced routine graphing.
+
+## Beta Release Direction
+
+At planning level, the Beta release should expand the proven pre-Beta interaction foundation into a packaged and installable user-facing release.
+
+Beta may later include:
+
+- a real `.exe` or installer path
+- stable install-time setup expectations
+- practical user-facing customization beyond the first internal slice
+- stronger reliability and usability for broader testing
+
+## Full Release Direction
+
+At planning level, the Full release may later expand into:
+
+- wake-word voice invocation
+- stronger voice parity with typed commands
+- richer saved routines and environment profiles
+- more advanced customization surfaces
+- import/export or sharing of user-defined actions
+- future plugin capability if the shared action model proves stable enough
+
+These later additions should remain downstream of the same shared action system rather than becoming parallel products.
+
+## Explicit Deferrals
+
+This planning baseline intentionally defers:
+
+- wake-word implementation mechanics
+- speech-to-text or local-audio pipeline mechanics
+- shell, tray, renderer, or notification mechanics
+- exact runtime execution engine mechanics
+- auth backend or trust mechanics
+- Windows Hello or TOTP implementation mechanics
+- plugin architecture and plugin lifecycle design
+- exact screen layout or UI flow details for the Action Studio
+- advanced node-graph or visual process-tree editing
+
+## Out-Of-Bounds Patterns
+
+The following are out of bounds for this planning baseline:
+
+- building separate logic stacks for voice commands and typed commands
+- treating voice-only interaction as sufficient
+- treating typed interaction as a temporary debug path rather than a first-class certainty path
+- collapsing Jarvis into a generic launcher with no user-defined action model
+- turning the first pre-Beta slice into plugin work
+- coupling the interaction layer to launcher-owned desktop authority or control decisions
+
+## Success Criteria
+
+This planning baseline is heading in the right direction if future implementation makes it feel like:
+
+- Jarvis is the command surface
+- Jarvis is understandable and customizable
+- Jarvis can be shaped around the user's machine and habits
+- voice and typed interaction feel like two entry paths into one coherent system
+
+This planning baseline is drifting if future implementation makes it feel like:
+
+- a generic desktop app launcher
+- a brittle command parser with exact syntax only
+- an opaque automation engine the user cannot inspect
+- disconnected voice, typed, and preset systems pretending to be one product

--- a/Docs/jarvis_vision.md
+++ b/Docs/jarvis_vision.md
@@ -72,6 +72,28 @@ This vision does not mean all boot ownership should be implemented immediately.
 
 Boot ownership, startup immersion, login and launch timing, shell behavior, and Windows integration should be handled as later dedicated revision tracks after orchestration is stable.
 
+## Product Release-Stage Framing
+
+Across the Jarvis product, release stages should be understood as:
+
+- `pre-Beta`
+  - internal or tightly controlled delivery of the first usable system slices
+  - architecture proof, interaction proof, and product-shape validation rather than installable public-facing distribution
+- `Beta`
+  - a packaged, installable, user-facing release with a real `.exe` or installer path, practical setup expectations, and enough stability for broader real-world testing
+- `Full`
+  - the broader mature product beyond the first installable/testing release
+
+This means Jarvis may have meaningful pre-Beta implementation progress without yet being considered Beta.
+
+Beta should not be assumed merely because:
+
+- a lane becomes user-visible internally
+- a planning doc defines a first deliverable
+- one subsystem becomes coherent enough for controlled internal use
+
+The product should not be treated as Beta until the installable and user-facing release threshold is intentionally reached.
+
 ## Behavior Philosophy (Early Definition)
 
 Jarvis should behave conservatively first:

--- a/Docs/v2.2.0_closeout.md
+++ b/Docs/v2.2.0_closeout.md
@@ -1,0 +1,131 @@
+# Jarvis v2.2.0 Closeout
+
+## Version
+
+v2.2.0
+
+## Scope
+
+Contained developer-surface and shutdown-voice closeout for the `v2.2.0` lane.
+
+This version stayed intentionally contained to:
+
+- `FB-026` Dev Toolkit uploaded-bundle intake delivery
+- `FB-008` shutdown-line-only diagnostics/error voice refinement
+- one directly supportive dev-only voice-harness path correction required to keep regression validation aligned with current repo layout
+- exact source-of-truth sync for the delivered lane
+
+It did not reopen boot implementation, desktop milestone taxonomy cleanup, workspace Step 5, product-facing upload behavior, or broader voice redesign.
+
+---
+
+## What Is Complete
+
+### `FB-026` Dev Toolkit Uploaded-Bundle Intake Surface
+
+* the Dev Toolkit now includes a dedicated lower `Uploads` intake area
+* engineers can stage either a support-bundle zip or an extracted bundle folder
+* the currently selected source is displayed clearly before helper launch
+* the staged source routes into the existing Support Bundle Triage Helper instead of a parallel flow
+* the dev-only Toolkit validator covers both zip and extracted-folder intake paths end to end
+
+### `FB-008` Shutdown-Line Voice Refinement
+
+* the final `Shutting down.` line kept its dedicated shutdown-only branch inside `Audio/jarvis_error_voice.py`
+* the shutdown line's late envelope is now tuned so the collapse stays concentrated on `down` while the tail remains degraded but intelligible
+* the refinement stayed inside the existing shutdown-only tuning path and did not touch startup voice, normal voice, or generic diagnostics/error voice behavior
+* the directly supportive normal-voice probe path in the voice regression harness now matches the current `Audio/jarvis_voice.py` repo layout
+
+### Source-Of-Truth Alignment
+
+* `docs/feature_backlog.md` now records `FB-026` as implemented in `v2.2.0 rev1`
+* `docs/feature_backlog.md` now records `FB-008` as implemented in `v2.2.0 rev2`
+* `docs/Main.md` can now use this closeout as the latest stable optional closeout baseline for `v2.2.x` sequencing questions
+
+---
+
+## Accepted Developer Entry Surfaces
+
+* accepted PySide Dev Toolkit:
+  * `dev/launchers/jarvis_dev_launcher.pyw`
+  * `dev/launchers/launch_jarvis_dev_toolkit.vbs`
+* accepted voice validation surface:
+  * `dev/jarvis_voice_regression_harness.py`
+
+---
+
+## Validation And Evidence
+
+* `FB-026` Toolkit intake validation:
+  * `dev/logs/support_bundle_triage_toolkit_validation/reports/SupportBundleTriageToolkitValidationReport_20260404_142731.txt`
+* `FB-008` voice-path validation:
+  * `dev/logs/voice_regression_harness/reports/VoiceRegressionReport_20260404_152717.txt`
+
+These evidence surfaces show:
+
+* staged zip and extracted-folder intake both pass through the Toolkit into the existing support-bundle triage helper
+* the launcher-owned repeated-crash and startup-abort shutdown voice lanes still pass
+* direct diagnostics/error probes still pass for `Shutting down.` and the other existing diagnostics lines
+* the direct normal-voice probe passes against the current `Audio/jarvis_voice.py` path
+
+---
+
+## Current Guarantees
+
+* `main.py` remains the dev-only Boot Jarvis harness
+* `launch_jarvis_desktop.vbs` remains the normal manual user launch
+* the controlled desktop path remains:
+  * `desktop/jarvis_desktop_launcher.pyw`
+  * `desktop/jarvis_desktop_main.py`
+* the shutdown voice refinement remains limited to the final `Shutting down.` line
+* normal voice and diagnostics/error voice remain intentionally separate
+* the Dev Toolkit uploaded-bundle intake remains dev-only and routes into the existing triage helper rather than changing production reporting behavior
+
+---
+
+## What Is Intentionally Not Implemented
+
+* `FB-025` boot and desktop milestone taxonomy clarification
+* `FB-005` Step 5 or broader workspace follow-through
+* `FB-004` future boot-orchestrator runtime implementation
+* `FB-015` follow-through beyond the paused boundary clarification
+* product-facing upload UI or support-bundle schema redesign
+* broader diagnostics/error voice redesign or voice-path unification
+
+---
+
+## Deferred Beyond This Version
+
+* `FB-004` later implementation-facing boot-orchestrator work
+* `FB-005` Step 5 and broader workspace reorganization
+* `FB-015` later phase-boundary follow-through beyond the existing pause point
+* `FB-025` later boot/desktop milestone taxonomy cleanup
+
+---
+
+## Final Audit Outcome
+
+The `v2.2.0` lane is coherent across:
+
+* current backlog truth
+* the landed `FB-026` Dev Toolkit intake surface
+* the landed `FB-008` shutdown-only voice refinement
+* the support-bundle Toolkit validation evidence
+* the voice regression harness evidence
+
+No contradiction remains across those surfaces.
+
+Observed version-level behavior is consistent:
+
+* the uploaded-bundle intake surface is implemented and validated
+* the shutdown-line refinement remains isolated and validated
+* the directly supportive normal-voice probe-path correction is validated and does not widen into product behavior change
+* later work remains explicitly deferred rather than implicitly queued
+
+---
+
+## Final Status
+
+`v2.2.0` is complete enough to close out at the current layer.
+
+The next safe move after this closeout is `v2.2.1` lane selection, not automatic continuation inside `v2.2.0`.

--- a/desktop/desktop_renderer.py
+++ b/desktop/desktop_renderer.py
@@ -462,6 +462,9 @@ class DesktopJarvisWindow(QWidget):
 
         return QRect(x, y, width, height)
 
+    def prepare_desktop_geometry(self):
+        self.setGeometry(self.compute_compact_geometry())
+
     def showEvent(self, event):
         super().showEvent(event)
 
@@ -510,9 +513,9 @@ class DesktopJarvisWindow(QWidget):
         target_geometry = self.compute_compact_geometry()
         hwnd = int(self.winId())
 
+        self.setGeometry(target_geometry)
         attached = attach_window_to_desktop(hwnd)
         if attached:
-            self.setGeometry(target_geometry)
             make_window_noninteractive(hwnd)
             position_desktop_child(
                 hwnd,
@@ -531,6 +534,9 @@ class DesktopJarvisWindow(QWidget):
         self.update()
         self._run_javascript("window.dispatchEvent(new Event('resize'));")
         self.lower()
+
+    def reinforce_desktop_mode(self):
+        self._reinforce_desktop_mode()
 
     def _schedule_desktop_mode_enable(self):
         if not self._desktop_mode_requested or self.desktop_mode or self._is_shutting_down:
@@ -682,11 +688,12 @@ class DesktopJarvisWindow(QWidget):
         self.show()
 
         hwnd = int(self.winId())
+        target_geometry = self.compute_compact_geometry()
+        self.setGeometry(target_geometry)
 
         attached = attach_window_to_desktop(hwnd)
         if attached:
             make_window_noninteractive(hwnd)
-            target_geometry = self.compute_compact_geometry()
             position_desktop_child(
                 hwnd,
                 target_geometry.x(),

--- a/desktop/desktop_renderer.py
+++ b/desktop/desktop_renderer.py
@@ -1,11 +1,13 @@
 import os
 import ctypes
+import json
 
 from PySide6.QtWidgets import QWidget, QVBoxLayout, QApplication
-from PySide6.QtCore import Qt, QTimer, QUrl, QRect
+from PySide6.QtCore import Qt, QTimer, QUrl, QRect, Signal
 from PySide6.QtGui import QColor
 from PySide6.QtWebEngineWidgets import QWebEngineView
 
+from .interaction_overlay_model import CommandOverlayModel, launch_command_action
 from .workerw_utils import (
     attach_window_to_desktop,
     get_last_workerw_probe_events,
@@ -17,6 +19,8 @@ HTTRANSPARENT = -1
 
 
 class DesktopJarvisWindow(QWidget):
+    command_mode_changed = Signal(bool)
+
     def __init__(self, screen, visual_html_path: str, event_logger=None):
         super().__init__()
 
@@ -29,6 +33,10 @@ class DesktopJarvisWindow(QWidget):
         self._page_ready = False
         self._pending_visual_state = None
         self._pending_voice_level = None
+        self._command_model = CommandOverlayModel()
+        self._result_close_timer = QTimer(self)
+        self._result_close_timer.setSingleShot(True)
+        self._result_close_timer.timeout.connect(self._close_command_overlay_after_result)
 
         # Window configuration (Concept 2 test)
         self.setWindowFlags(Qt.FramelessWindowHint | Qt.Tool | Qt.WindowDoesNotAcceptFocus)
@@ -103,6 +111,15 @@ class DesktopJarvisWindow(QWidget):
         self._run_javascript(js)
         self._pending_voice_level = None
 
+    def _apply_command_overlay_state(self):
+        if not self._page_ready:
+            return
+
+        payload = json.dumps(self._command_model.view_payload())
+        self._run_javascript(
+            f"window.setCommandOverlayState && window.setCommandOverlayState({payload});"
+        )
+
     def _on_load_finished(self, ok):
         if not ok:
             self._log_event("RENDERER_MAIN|VISUAL_PAGE_LOAD_FAILED")
@@ -112,6 +129,7 @@ class DesktopJarvisWindow(QWidget):
         self._log_event("RENDERER_MAIN|VISUAL_PAGE_READY")
         self._apply_pending_visual_state()
         self._apply_pending_voice_level()
+        self._apply_command_overlay_state()
 
     def set_visual_state(self, state_name):
         self._pending_visual_state = state_name
@@ -124,6 +142,95 @@ class DesktopJarvisWindow(QWidget):
 
         if self._page_ready:
             self._apply_pending_voice_level()
+
+    def _set_command_mode_active(self, active: bool):
+        self.command_mode_changed.emit(bool(active))
+
+    def open_command_overlay(self):
+        if self._is_shutting_down:
+            return
+
+        self._result_close_timer.stop()
+        self._command_model.open()
+        self._apply_command_overlay_state()
+        self._set_command_mode_active(True)
+        self._log_event("RENDERER_MAIN|COMMAND_OVERLAY_OPENED")
+
+    def close_command_overlay(self):
+        if not self._command_model.visible:
+            return
+
+        self._result_close_timer.stop()
+        self._command_model.close()
+        self._apply_command_overlay_state()
+        self._set_command_mode_active(False)
+        self._log_event("RENDERER_MAIN|COMMAND_OVERLAY_CLOSED")
+
+    def toggle_command_overlay(self):
+        if self._command_model.visible:
+            self.close_command_overlay()
+        else:
+            self.open_command_overlay()
+
+    def handle_command_character(self, char: str):
+        self._command_model.append_text(char)
+        self._apply_command_overlay_state()
+
+    def handle_command_backspace(self):
+        self._command_model.backspace()
+        self._apply_command_overlay_state()
+
+    def handle_command_escape(self):
+        result = self._command_model.escape()
+        self._apply_command_overlay_state()
+
+        if result == "confirm_cancelled":
+            self._log_event("RENDERER_MAIN|COMMAND_CONFIRM_CANCELLED")
+            return
+
+        if result == "closed":
+            self._set_command_mode_active(False)
+            self._log_event("RENDERER_MAIN|COMMAND_OVERLAY_CLOSED")
+
+    def _show_command_result(self, status_kind: str, status_text: str):
+        self._command_model.show_result(status_kind, status_text)
+        self._apply_command_overlay_state()
+        self._set_command_mode_active(False)
+        self._result_close_timer.start(1200)
+
+    def _close_command_overlay_after_result(self):
+        self.close_command_overlay()
+
+    def handle_command_submit(self):
+        result, payload = self._command_model.submit()
+        self._apply_command_overlay_state()
+
+        if result == "confirm_ready":
+            self._log_event(f"RENDERER_MAIN|COMMAND_CONFIRM_READY|action_id={payload.id}")
+            return
+
+        if result == "not_found":
+            self._log_event("RENDERER_MAIN|COMMAND_NOT_FOUND")
+            return
+
+        if result == "ambiguous":
+            self._log_event(f"RENDERER_MAIN|COMMAND_AMBIGUOUS|count={len(payload)}")
+            return
+
+        if result != "execute_confirmed":
+            return
+
+        action = payload
+        self._log_event(f"RENDERER_MAIN|COMMAND_EXECUTION_REQUESTED|action_id={action.id}")
+        try:
+            launch_command_action(action)
+        except Exception as exc:
+            self._log_event(f"RENDERER_MAIN|COMMAND_LAUNCH_FAILED|action_id={action.id}")
+            self._show_command_result("launch_failed", f"Launch failed: {exc}")
+            return
+
+        self._log_event(f"RENDERER_MAIN|COMMAND_LAUNCH_REQUEST_SENT|action_id={action.id}")
+        self._show_command_result("launch_requested", "Launch request sent.")
 
     def nativeEvent(self, eventType, message):
         if self.desktop_mode:
@@ -164,6 +271,7 @@ class DesktopJarvisWindow(QWidget):
 
         self._log_event("RENDERER_MAIN|RENDERER_SHUTDOWN_BEGIN")
         self._is_shutting_down = True
+        self._result_close_timer.stop()
 
         self.webview.stop()
         self.hide()

--- a/desktop/desktop_renderer.py
+++ b/desktop/desktop_renderer.py
@@ -20,6 +20,7 @@ from .workerw_utils import (
     attach_window_to_desktop,
     get_last_workerw_probe_events,
     make_window_noninteractive,
+    position_desktop_child,
 )
 
 WM_NCHITTEST = 0x0084
@@ -427,12 +428,11 @@ class DesktopJarvisWindow(QWidget):
         self._result_close_timer.setSingleShot(True)
         self._result_close_timer.timeout.connect(self._close_command_overlay_after_result)
 
-        # Window configuration (Concept 2 test)
-        self.setWindowFlags(Qt.FramelessWindowHint | Qt.Tool | Qt.WindowDoesNotAcceptFocus)
-        self.setAttribute(Qt.WA_TranslucentBackground, True)
-        self.setAttribute(Qt.WA_ShowWithoutActivating, True)
-        self.setFocusPolicy(Qt.NoFocus)
-        self.setStyleSheet("background: transparent;")
+        # Align the standalone desktop route with the proven Boot handoff window model.
+        self.setWindowFlags(Qt.FramelessWindowHint | Qt.WindowStaysOnTopHint)
+        self.setAutoFillBackground(True)
+        self.setFocusPolicy(Qt.StrongFocus)
+        self.setStyleSheet("background-color: rgb(0, 0, 0);")
 
         self.setGeometry(self.compute_compact_geometry())
 
@@ -441,12 +441,11 @@ class DesktopJarvisWindow(QWidget):
         root.setSpacing(0)
 
         self.webview = QWebEngineView(self)
-        self.webview.setAttribute(Qt.WA_TranslucentBackground, True)
-        self.webview.setStyleSheet("background: transparent; border: none;")
+        self.webview.setStyleSheet("background-color: rgb(0, 0, 0); border: none;")
         self.webview.setContextMenuPolicy(Qt.NoContextMenu)
         self.webview.setFocusPolicy(Qt.NoFocus)
 
-        self.webview.page().setBackgroundColor(QColor(0, 0, 0, 0))
+        self.webview.page().setBackgroundColor(QColor(0, 0, 0))
         self.webview.loadFinished.connect(self._on_load_finished)
         self.webview.load(QUrl.fromLocalFile(self.visual_html_path))
 
@@ -503,6 +502,35 @@ class DesktopJarvisWindow(QWidget):
 
     def _apply_command_overlay_state(self):
         self._command_panel.render_payload(self._command_model.view_payload())
+
+    def _reinforce_desktop_mode(self):
+        if not self.desktop_mode or self._is_shutting_down:
+            return
+
+        target_geometry = self.compute_compact_geometry()
+        hwnd = int(self.winId())
+
+        attached = attach_window_to_desktop(hwnd)
+        if attached:
+            self.setGeometry(target_geometry)
+            make_window_noninteractive(hwnd)
+            position_desktop_child(
+                hwnd,
+                target_geometry.x(),
+                target_geometry.y(),
+                target_geometry.width(),
+                target_geometry.height(),
+            )
+            self._log_event(
+                "RENDERER_MAIN|DESKTOP_GEOMETRY_RESET"
+                f"|x={target_geometry.x()}|y={target_geometry.y()}"
+                f"|w={target_geometry.width()}|h={target_geometry.height()}"
+            )
+
+        self.webview.update()
+        self.update()
+        self._run_javascript("window.dispatchEvent(new Event('resize'));")
+        self.lower()
 
     def _schedule_desktop_mode_enable(self):
         if not self._desktop_mode_requested or self.desktop_mode or self._is_shutting_down:
@@ -645,7 +673,10 @@ class DesktopJarvisWindow(QWidget):
         self.desktop_mode = True
         self._desktop_mode_requested = False
 
+        self.setWindowFlag(Qt.WindowStaysOnTopHint, False)
         self.setAttribute(Qt.WA_TransparentForMouseEvents, True)
+        self.setAttribute(Qt.WA_ShowWithoutActivating, True)
+        self.setFocusPolicy(Qt.NoFocus)
 
         self.hide()
         self.show()
@@ -655,6 +686,14 @@ class DesktopJarvisWindow(QWidget):
         attached = attach_window_to_desktop(hwnd)
         if attached:
             make_window_noninteractive(hwnd)
+            target_geometry = self.compute_compact_geometry()
+            position_desktop_child(
+                hwnd,
+                target_geometry.x(),
+                target_geometry.y(),
+                target_geometry.width(),
+                target_geometry.height(),
+            )
         else:
             self._log_event("RENDERER_MAIN|DESKTOP_ATTACH_FALLBACK_VISIBLE_MODE")
         self._log_event(
@@ -667,6 +706,10 @@ class DesktopJarvisWindow(QWidget):
         self.update()
         self._run_javascript("window.dispatchEvent(new Event('resize'));")
         self.lower()
+        if attached:
+            QTimer.singleShot(80, self._reinforce_desktop_mode)
+            QTimer.singleShot(260, self._reinforce_desktop_mode)
+            QTimer.singleShot(900, self._reinforce_desktop_mode)
 
     def request_shutdown(self):
         if self._is_shutting_down:

--- a/desktop/desktop_renderer.py
+++ b/desktop/desktop_renderer.py
@@ -31,6 +31,7 @@ class DesktopJarvisWindow(QWidget):
         self.desktop_mode = False
         self._is_shutting_down = False
         self._page_ready = False
+        self._desktop_mode_requested = False
         self._pending_visual_state = None
         self._pending_voice_level = None
         self._command_model = CommandOverlayModel()
@@ -78,7 +79,8 @@ class DesktopJarvisWindow(QWidget):
         super().showEvent(event)
 
         if not self.desktop_mode:
-            QTimer.singleShot(50, self.enable_desktop_mode)
+            self._desktop_mode_requested = True
+            self._schedule_desktop_mode_enable()
 
     def _log_event(self, event):
         if callable(self.event_logger):
@@ -120,6 +122,13 @@ class DesktopJarvisWindow(QWidget):
             f"window.setCommandOverlayState && window.setCommandOverlayState({payload});"
         )
 
+    def _schedule_desktop_mode_enable(self):
+        if not self._desktop_mode_requested or self.desktop_mode or self._is_shutting_down:
+            return
+        if not self._page_ready:
+            return
+        QTimer.singleShot(50, self.enable_desktop_mode)
+
     def _on_load_finished(self, ok):
         if not ok:
             self._log_event("RENDERER_MAIN|VISUAL_PAGE_LOAD_FAILED")
@@ -130,6 +139,7 @@ class DesktopJarvisWindow(QWidget):
         self._apply_pending_visual_state()
         self._apply_pending_voice_level()
         self._apply_command_overlay_state()
+        self._schedule_desktop_mode_enable()
 
     def set_visual_state(self, state_name):
         self._pending_visual_state = state_name
@@ -242,11 +252,12 @@ class DesktopJarvisWindow(QWidget):
         return super().nativeEvent(eventType, message)
 
     def enable_desktop_mode(self):
-        if self.desktop_mode or self._is_shutting_down:
+        if self.desktop_mode or self._is_shutting_down or not self._page_ready:
             return
 
         self._log_event("RENDERER_MAIN|DESKTOP_MODE_ENABLE_BEGIN")
         self.desktop_mode = True
+        self._desktop_mode_requested = False
 
         self.setAttribute(Qt.WA_TransparentForMouseEvents, True)
 
@@ -256,13 +267,19 @@ class DesktopJarvisWindow(QWidget):
         hwnd = int(self.winId())
 
         attached = attach_window_to_desktop(hwnd)
-        make_window_noninteractive(hwnd)
+        if attached:
+            make_window_noninteractive(hwnd)
+        else:
+            self._log_event("RENDERER_MAIN|DESKTOP_ATTACH_FALLBACK_VISIBLE_MODE")
         self._log_event(
             f"RENDERER_MAIN|DESKTOP_ATTACH_RESULT|success={'true' if attached else 'false'}"
         )
         for probe_event in get_last_workerw_probe_events():
             self._log_event(f"RENDERER_MAIN|{probe_event}")
 
+        self.webview.update()
+        self.update()
+        self._run_javascript("window.dispatchEvent(new Event('resize'));")
         self.lower()
 
     def request_shutdown(self):

--- a/desktop/desktop_renderer.py
+++ b/desktop/desktop_renderer.py
@@ -1,8 +1,16 @@
 import os
 import ctypes
-import json
 
-from PySide6.QtWidgets import QWidget, QVBoxLayout, QApplication
+from PySide6.QtWidgets import (
+    QWidget,
+    QVBoxLayout,
+    QApplication,
+    QFrame,
+    QLabel,
+    QLineEdit,
+    QHBoxLayout,
+    QGridLayout,
+)
 from PySide6.QtCore import Qt, QTimer, QUrl, QRect, Signal
 from PySide6.QtGui import QColor
 from PySide6.QtWebEngineWidgets import QWebEngineView
@@ -18,9 +26,383 @@ WM_NCHITTEST = 0x0084
 HTTRANSPARENT = -1
 
 
+class CommandInputLineEdit(QLineEdit):
+    submit_requested = Signal()
+    escape_requested = Signal()
+    input_armed_changed = Signal(bool)
+
+    def __init__(self, parent=None):
+        super().__init__(parent)
+        self._input_armed = False
+        self.setContextMenuPolicy(Qt.NoContextMenu)
+        self.setPlaceholderText("Left-click or right-click to activate command entry")
+        self.setReadOnly(True)
+
+    def is_input_armed(self) -> bool:
+        return self._input_armed
+
+    def set_input_armed(self, armed: bool, notify: bool = True):
+        armed = bool(armed)
+        if self._input_armed == armed:
+            return
+
+        self._input_armed = armed
+        self.setReadOnly(not armed)
+        if not armed:
+            self.clearFocus()
+        if notify:
+            self.input_armed_changed.emit(armed)
+
+    def mousePressEvent(self, event):
+        if event.button() in (Qt.LeftButton, Qt.RightButton):
+            if not self._input_armed:
+                self.set_input_armed(True)
+            self.setFocus(Qt.MouseFocusReason)
+            if event.button() == Qt.RightButton:
+                event.accept()
+                return
+
+        super().mousePressEvent(event)
+
+    def keyPressEvent(self, event):
+        if event.key() in (Qt.Key_Return, Qt.Key_Enter):
+            self.submit_requested.emit()
+            event.accept()
+            return
+
+        if event.key() == Qt.Key_Escape:
+            self.escape_requested.emit()
+            event.accept()
+            return
+
+        if not self._input_armed:
+            event.accept()
+            return
+
+        super().keyPressEvent(event)
+
+
+class CommandOverlayPanel(QWidget):
+    submit_requested = Signal()
+    escape_requested = Signal()
+    input_text_changed = Signal(str)
+    input_armed_changed = Signal(bool)
+
+    def __init__(self):
+        super().__init__(None, Qt.FramelessWindowHint | Qt.Tool)
+        self.setAttribute(Qt.WA_TranslucentBackground, True)
+        self.setFocusPolicy(Qt.StrongFocus)
+        self.setObjectName("commandOverlayWindow")
+
+        root = QVBoxLayout(self)
+        root.setContentsMargins(0, 0, 0, 0)
+        root.setSpacing(0)
+
+        self.panel = QFrame(self)
+        self.panel.setObjectName("commandPanel")
+        root.addWidget(self.panel)
+
+        layout = QVBoxLayout(self.panel)
+        layout.setContentsMargins(24, 22, 24, 20)
+        layout.setSpacing(0)
+
+        self.kicker_label = QLabel("JARVIS COMMAND", self.panel)
+        self.kicker_label.setObjectName("commandKicker")
+        layout.addWidget(self.kicker_label)
+
+        self.title_label = QLabel("Typed desktop interaction", self.panel)
+        self.title_label.setObjectName("commandTitle")
+        layout.addWidget(self.title_label)
+
+        self.hint_label = QLabel(
+            "Left-click or right-click the command box to activate.",
+            self.panel,
+        )
+        self.hint_label.setObjectName("commandHint")
+        self.hint_label.setWordWrap(True)
+        layout.addWidget(self.hint_label)
+
+        self.input_shell = QFrame(self.panel)
+        self.input_shell.setObjectName("commandInputShell")
+        input_layout = QHBoxLayout(self.input_shell)
+        input_layout.setContentsMargins(16, 14, 16, 14)
+        input_layout.setSpacing(10)
+
+        self.prompt_label = QLabel(">", self.input_shell)
+        self.prompt_label.setObjectName("commandPrompt")
+        input_layout.addWidget(self.prompt_label)
+
+        self.input_line = CommandInputLineEdit(self.input_shell)
+        self.input_line.setObjectName("commandInputLine")
+        self.input_line.textChanged.connect(self.input_text_changed)
+        self.input_line.submit_requested.connect(self.submit_requested)
+        self.input_line.escape_requested.connect(self.escape_requested)
+        self.input_line.input_armed_changed.connect(self.input_armed_changed)
+        input_layout.addWidget(self.input_line, 1)
+
+        self.caret = QFrame(self.input_shell)
+        self.caret.setObjectName("commandCaret")
+        input_layout.addWidget(self.caret)
+
+        layout.addWidget(self.input_shell)
+
+        self.status_label = QLabel("", self.panel)
+        self.status_label.setObjectName("commandStatus")
+        self.status_label.setWordWrap(True)
+        layout.addWidget(self.status_label)
+
+        self.ambiguous_label = QLabel("", self.panel)
+        self.ambiguous_label.setObjectName("commandAmbiguous")
+        self.ambiguous_label.setWordWrap(True)
+        layout.addWidget(self.ambiguous_label)
+
+        self.confirmation_frame = QFrame(self.panel)
+        self.confirmation_frame.setObjectName("commandConfirmation")
+        confirm_layout = QGridLayout(self.confirmation_frame)
+        confirm_layout.setContentsMargins(18, 16, 18, 14)
+        confirm_layout.setHorizontalSpacing(14)
+        confirm_layout.setVerticalSpacing(8)
+
+        confirm_layout.addWidget(self._make_confirm_label("Typed request"), 0, 0)
+        self.confirm_request_value = self._make_confirm_value()
+        confirm_layout.addWidget(self.confirm_request_value, 0, 1)
+
+        confirm_layout.addWidget(self._make_confirm_label("Resolved action"), 1, 0)
+        self.confirm_title_value = self._make_confirm_value()
+        confirm_layout.addWidget(self.confirm_title_value, 1, 1)
+
+        confirm_layout.addWidget(self._make_confirm_label("Target kind"), 2, 0)
+        self.confirm_kind_value = self._make_confirm_value()
+        confirm_layout.addWidget(self.confirm_kind_value, 2, 1)
+
+        confirm_layout.addWidget(self._make_confirm_label("Target"), 3, 0)
+        self.confirm_target_value = self._make_confirm_value()
+        confirm_layout.addWidget(self.confirm_target_value, 3, 1)
+
+        self.confirm_help_label = QLabel(
+            "Press Enter to confirm or Esc to return.",
+            self.confirmation_frame,
+        )
+        self.confirm_help_label.setObjectName("commandConfirmHelp")
+        self.confirm_help_label.setWordWrap(True)
+        confirm_layout.addWidget(self.confirm_help_label, 4, 0, 1, 2)
+
+        layout.addWidget(self.confirmation_frame)
+        self.confirmation_frame.hide()
+
+        self.setStyleSheet(
+            """
+            #commandPanel {
+                border: 1px solid rgba(118, 226, 255, 0.22);
+                border-radius: 22px;
+                background: rgba(4, 16, 28, 238);
+            }
+            #commandKicker {
+                color: rgba(118, 226, 255, 0.72);
+                font-size: 12px;
+                font-weight: 600;
+                letter-spacing: 0.24em;
+            }
+            #commandTitle {
+                margin-top: 8px;
+                color: rgba(238, 250, 255, 0.96);
+                font-size: 28px;
+                font-weight: 600;
+            }
+            #commandHint {
+                margin-top: 10px;
+                color: rgba(172, 215, 235, 0.82);
+                font-size: 14px;
+            }
+            #commandInputShell {
+                margin-top: 18px;
+                border-radius: 16px;
+                border: 1px solid rgba(118, 226, 255, 0.18);
+                background: rgba(6, 18, 30, 196);
+            }
+            #commandInputShell[armed="true"] {
+                border: 1px solid rgba(118, 226, 255, 0.36);
+                background: rgba(7, 22, 36, 220);
+            }
+            #commandInputShell[locked="true"] {
+                border: 1px solid rgba(118, 226, 255, 0.24);
+                background: rgba(8, 18, 30, 214);
+            }
+            #commandPrompt {
+                color: rgba(118, 226, 255, 0.84);
+                font-size: 22px;
+                font-weight: 600;
+            }
+            #commandInputLine {
+                border: none;
+                background: transparent;
+                color: rgba(238, 248, 255, 0.96);
+                font-size: 21px;
+                selection-background-color: rgba(118, 226, 255, 0.28);
+            }
+            #commandInputLine:read-only {
+                color: rgba(170, 194, 208, 0.92);
+            }
+            #commandCaret {
+                min-width: 10px;
+                max-width: 10px;
+                min-height: 24px;
+                max-height: 24px;
+                border-radius: 999px;
+                background: rgba(132, 236, 255, 0.82);
+            }
+            #commandCaret[armed="false"] {
+                background: rgba(132, 236, 255, 0.22);
+            }
+            #commandStatus {
+                margin-top: 14px;
+                min-height: 22px;
+                color: rgba(174, 215, 232, 0.88);
+                font-size: 14px;
+            }
+            #commandStatus[statusKind="not_found"], #commandStatus[statusKind="launch_failed"] {
+                color: rgba(255, 176, 176, 0.95);
+            }
+            #commandStatus[statusKind="ambiguous"] {
+                color: rgba(255, 222, 154, 0.95);
+            }
+            #commandStatus[statusKind="launch_requested"], #commandStatus[statusKind="ready"] {
+                color: rgba(166, 247, 195, 0.94);
+            }
+            #commandAmbiguous {
+                min-height: 20px;
+                color: rgba(255, 222, 154, 0.90);
+                font-size: 13px;
+            }
+            #commandConfirmation {
+                margin-top: 18px;
+                border-radius: 18px;
+                background: rgba(10, 22, 38, 220);
+                border: 1px solid rgba(118, 226, 255, 0.14);
+            }
+            QLabel[confirmRole="label"] {
+                color: rgba(118, 226, 255, 0.66);
+                font-size: 12px;
+                font-weight: 600;
+                letter-spacing: 0.12em;
+            }
+            QLabel[confirmRole="value"] {
+                color: rgba(236, 247, 255, 0.94);
+                font-size: 15px;
+            }
+            #commandConfirmHelp {
+                margin-top: 14px;
+                color: rgba(172, 215, 235, 0.84);
+                font-size: 13px;
+            }
+            """
+        )
+
+    def _make_confirm_label(self, text: str) -> QLabel:
+        label = QLabel(text, self.confirmation_frame)
+        label.setProperty("confirmRole", "label")
+        return label
+
+    def _make_confirm_value(self) -> QLabel:
+        label = QLabel("", self.confirmation_frame)
+        label.setProperty("confirmRole", "value")
+        label.setWordWrap(True)
+        return label
+
+    def keyPressEvent(self, event):
+        if event.key() in (Qt.Key_Return, Qt.Key_Enter):
+            self.submit_requested.emit()
+            event.accept()
+            return
+
+        if event.key() == Qt.Key_Escape:
+            self.escape_requested.emit()
+            event.accept()
+            return
+
+        super().keyPressEvent(event)
+
+    def show_for_geometry(self, host_geometry: QRect, bounds_geometry: QRect | None = None):
+        width = max(460, min(720, int(host_geometry.width() * 0.72)))
+        self.panel.setFixedWidth(width)
+        self.adjustSize()
+
+        x = host_geometry.x() + (host_geometry.width() - self.width()) // 2
+        y = host_geometry.y() + int(host_geometry.height() * 0.68)
+
+        if bounds_geometry is not None:
+            min_x = bounds_geometry.x()
+            max_x = bounds_geometry.x() + max(0, bounds_geometry.width() - self.width())
+            min_y = bounds_geometry.y()
+            max_y = bounds_geometry.y() + max(0, bounds_geometry.height() - self.height())
+            x = max(min_x, min(x, max_x))
+            y = max(min_y, min(y, max_y))
+
+        self.move(x, y)
+        self.show()
+        self.raise_()
+
+    def focus_input(self):
+        self.input_line.setFocus(Qt.MouseFocusReason)
+
+    def render_payload(self, payload: dict):
+        payload = payload or {}
+        phase = payload.get("phase", "hidden")
+        armed = bool(payload.get("input_armed")) and phase == "entry"
+        locked = phase in {"confirm", "result"}
+
+        self.input_shell.setProperty("armed", "true" if armed else "false")
+        self.input_shell.setProperty("locked", "true" if locked else "false")
+        self.caret.setProperty("armed", "true" if armed else "false")
+        for widget in (self.input_shell, self.caret):
+            widget.style().unpolish(widget)
+            widget.style().polish(widget)
+
+        self.input_line.blockSignals(True)
+        if self.input_line.text() != payload.get("input_text", ""):
+            self.input_line.setText(payload.get("input_text", ""))
+        self.input_line.set_input_armed(armed, notify=False)
+        self.input_line.blockSignals(False)
+        if locked:
+            self.setFocus(Qt.ActiveWindowFocusReason)
+
+        if phase == "confirm":
+            self.hint_label.setText("Review the resolved action before execution.")
+        elif phase == "result":
+            self.hint_label.setText("Returning to passive desktop mode.")
+        else:
+            self.hint_label.setText(
+                "Left-click or right-click the command box to activate."
+                if not armed
+                else "Type a saved action or alias, then press Enter."
+            )
+
+        status_kind = payload.get("status_kind", "idle")
+        self.status_label.setProperty("statusKind", status_kind)
+        self.status_label.style().unpolish(self.status_label)
+        self.status_label.style().polish(self.status_label)
+
+        if payload.get("status_text"):
+            self.status_label.setText(payload["status_text"])
+        elif phase == "entry" and not armed:
+            self.status_label.setText("Click inside the command box to begin typing.")
+        else:
+            self.status_label.setText("")
+
+        titles = payload.get("ambiguous_titles") or []
+        self.ambiguous_label.setText(f"Matches: {' | '.join(titles)}" if titles else "")
+
+        action = payload.get("pending_action") or {}
+        show_confirm = phase == "confirm" and bool(action)
+        self.confirmation_frame.setVisible(show_confirm)
+        if show_confirm:
+            self.confirm_request_value.setText(payload.get("typed_request", ""))
+            self.confirm_title_value.setText(action.get("title", ""))
+            self.confirm_kind_value.setText(action.get("target_kind", ""))
+            self.confirm_target_value.setText(action.get("target", ""))
+
+
 class DesktopJarvisWindow(QWidget):
-    command_overlay_visibility_changed = Signal(bool)
-    command_text_capture_changed = Signal(bool)
 
     def __init__(self, screen, visual_html_path: str, event_logger=None):
         super().__init__()
@@ -36,6 +418,11 @@ class DesktopJarvisWindow(QWidget):
         self._pending_visual_state = None
         self._pending_voice_level = None
         self._command_model = CommandOverlayModel()
+        self._command_panel = CommandOverlayPanel()
+        self._command_panel.submit_requested.connect(self.handle_command_submit)
+        self._command_panel.escape_requested.connect(self.handle_command_escape)
+        self._command_panel.input_text_changed.connect(self.handle_command_text_changed)
+        self._command_panel.input_armed_changed.connect(self.handle_command_input_armed_changed)
         self._result_close_timer = QTimer(self)
         self._result_close_timer.setSingleShot(True)
         self._result_close_timer.timeout.connect(self._close_command_overlay_after_result)
@@ -115,13 +502,7 @@ class DesktopJarvisWindow(QWidget):
         self._pending_voice_level = None
 
     def _apply_command_overlay_state(self):
-        if not self._page_ready:
-            return
-
-        payload = json.dumps(self._command_model.view_payload())
-        self._run_javascript(
-            f"window.setCommandOverlayState && window.setCommandOverlayState({payload});"
-        )
+        self._command_panel.render_payload(self._command_model.view_payload())
 
     def _schedule_desktop_mode_enable(self):
         if not self._desktop_mode_requested or self.desktop_mode or self._is_shutting_down:
@@ -154,30 +535,18 @@ class DesktopJarvisWindow(QWidget):
         if self._page_ready:
             self._apply_pending_voice_level()
 
-    def _set_command_overlay_visible(self, active: bool):
-        self.command_overlay_visibility_changed.emit(bool(active))
-
-    def _set_command_text_capture_active(self, active: bool):
-        self.command_text_capture_changed.emit(bool(active))
-
-    def _sync_command_capture_state(self):
-        overlay_visible = self._command_model.visible
-        text_capture_active = (
-            self._command_model.visible
-            and self._command_model.phase == "entry"
-            and self._command_model.input_armed
-        )
-        self._set_command_overlay_visible(overlay_visible)
-        self._set_command_text_capture_active(text_capture_active)
-
     def open_command_overlay(self):
         if self._is_shutting_down:
             return
 
         self._result_close_timer.stop()
         self._command_model.open()
+        self._command_model.input_armed = False
         self._apply_command_overlay_state()
-        self._sync_command_capture_state()
+        self._command_panel.show_for_geometry(
+            self.compute_compact_geometry(),
+            self.screen_ref.availableGeometry(),
+        )
         self._log_event("RENDERER_MAIN|COMMAND_OVERLAY_OPENED")
 
     def close_command_overlay(self):
@@ -185,9 +554,9 @@ class DesktopJarvisWindow(QWidget):
             return
 
         self._result_close_timer.stop()
+        self._command_panel.hide()
         self._command_model.close()
         self._apply_command_overlay_state()
-        self._sync_command_capture_state()
         self._log_event("RENDERER_MAIN|COMMAND_OVERLAY_CLOSED")
 
     def toggle_command_overlay(self):
@@ -196,32 +565,32 @@ class DesktopJarvisWindow(QWidget):
         else:
             self.open_command_overlay()
 
-    def handle_command_character(self, char: str):
-        self._command_model.append_text(char)
+    def handle_command_text_changed(self, text: str):
+        self._command_model.set_input_text(text)
         self._apply_command_overlay_state()
-        self._sync_command_capture_state()
 
-    def handle_command_backspace(self):
-        self._command_model.backspace()
+    def handle_command_input_armed_changed(self, armed: bool):
+        if not self._command_model.visible or self._command_model.phase != "entry":
+            return
+        self._command_model.input_armed = bool(armed)
         self._apply_command_overlay_state()
-        self._sync_command_capture_state()
 
     def handle_command_escape(self):
         result = self._command_model.escape()
         self._apply_command_overlay_state()
-        self._sync_command_capture_state()
 
         if result == "confirm_cancelled":
+            self._command_panel.focus_input()
             self._log_event("RENDERER_MAIN|COMMAND_CONFIRM_CANCELLED")
             return
 
         if result == "closed":
+            self._command_panel.hide()
             self._log_event("RENDERER_MAIN|COMMAND_OVERLAY_CLOSED")
 
     def _show_command_result(self, status_kind: str, status_text: str):
         self._command_model.show_result(status_kind, status_text)
         self._apply_command_overlay_state()
-        self._sync_command_capture_state()
         self._result_close_timer.start(1200)
 
     def _close_command_overlay_after_result(self):
@@ -230,13 +599,9 @@ class DesktopJarvisWindow(QWidget):
     def handle_command_submit(self):
         result, payload = self._command_model.submit()
         self._apply_command_overlay_state()
-        self._sync_command_capture_state()
-
-        if result == "input_armed":
-            self._log_event("RENDERER_MAIN|COMMAND_ENTRY_ACTIVATED")
-            return
 
         if result == "confirm_ready":
+            self._command_panel.setFocus(Qt.ActiveWindowFocusReason)
             self._log_event(f"RENDERER_MAIN|COMMAND_CONFIRM_READY|action_id={payload.id}")
             return
 
@@ -311,6 +676,7 @@ class DesktopJarvisWindow(QWidget):
         self._is_shutting_down = True
         self._result_close_timer.stop()
 
+        self._command_panel.hide()
         self.webview.stop()
         self.hide()
         self.close()

--- a/desktop/desktop_renderer.py
+++ b/desktop/desktop_renderer.py
@@ -19,7 +19,8 @@ HTTRANSPARENT = -1
 
 
 class DesktopJarvisWindow(QWidget):
-    command_mode_changed = Signal(bool)
+    command_overlay_visibility_changed = Signal(bool)
+    command_text_capture_changed = Signal(bool)
 
     def __init__(self, screen, visual_html_path: str, event_logger=None):
         super().__init__()
@@ -153,8 +154,21 @@ class DesktopJarvisWindow(QWidget):
         if self._page_ready:
             self._apply_pending_voice_level()
 
-    def _set_command_mode_active(self, active: bool):
-        self.command_mode_changed.emit(bool(active))
+    def _set_command_overlay_visible(self, active: bool):
+        self.command_overlay_visibility_changed.emit(bool(active))
+
+    def _set_command_text_capture_active(self, active: bool):
+        self.command_text_capture_changed.emit(bool(active))
+
+    def _sync_command_capture_state(self):
+        overlay_visible = self._command_model.visible
+        text_capture_active = (
+            self._command_model.visible
+            and self._command_model.phase == "entry"
+            and self._command_model.input_armed
+        )
+        self._set_command_overlay_visible(overlay_visible)
+        self._set_command_text_capture_active(text_capture_active)
 
     def open_command_overlay(self):
         if self._is_shutting_down:
@@ -163,7 +177,7 @@ class DesktopJarvisWindow(QWidget):
         self._result_close_timer.stop()
         self._command_model.open()
         self._apply_command_overlay_state()
-        self._set_command_mode_active(True)
+        self._sync_command_capture_state()
         self._log_event("RENDERER_MAIN|COMMAND_OVERLAY_OPENED")
 
     def close_command_overlay(self):
@@ -173,7 +187,7 @@ class DesktopJarvisWindow(QWidget):
         self._result_close_timer.stop()
         self._command_model.close()
         self._apply_command_overlay_state()
-        self._set_command_mode_active(False)
+        self._sync_command_capture_state()
         self._log_event("RENDERER_MAIN|COMMAND_OVERLAY_CLOSED")
 
     def toggle_command_overlay(self):
@@ -185,27 +199,29 @@ class DesktopJarvisWindow(QWidget):
     def handle_command_character(self, char: str):
         self._command_model.append_text(char)
         self._apply_command_overlay_state()
+        self._sync_command_capture_state()
 
     def handle_command_backspace(self):
         self._command_model.backspace()
         self._apply_command_overlay_state()
+        self._sync_command_capture_state()
 
     def handle_command_escape(self):
         result = self._command_model.escape()
         self._apply_command_overlay_state()
+        self._sync_command_capture_state()
 
         if result == "confirm_cancelled":
             self._log_event("RENDERER_MAIN|COMMAND_CONFIRM_CANCELLED")
             return
 
         if result == "closed":
-            self._set_command_mode_active(False)
             self._log_event("RENDERER_MAIN|COMMAND_OVERLAY_CLOSED")
 
     def _show_command_result(self, status_kind: str, status_text: str):
         self._command_model.show_result(status_kind, status_text)
         self._apply_command_overlay_state()
-        self._set_command_mode_active(False)
+        self._sync_command_capture_state()
         self._result_close_timer.start(1200)
 
     def _close_command_overlay_after_result(self):
@@ -214,6 +230,11 @@ class DesktopJarvisWindow(QWidget):
     def handle_command_submit(self):
         result, payload = self._command_model.submit()
         self._apply_command_overlay_state()
+        self._sync_command_capture_state()
+
+        if result == "input_armed":
+            self._log_event("RENDERER_MAIN|COMMAND_ENTRY_ACTIVATED")
+            return
 
         if result == "confirm_ready":
             self._log_event(f"RENDERER_MAIN|COMMAND_CONFIRM_READY|action_id={payload.id}")

--- a/desktop/hotkeys.py
+++ b/desktop/hotkeys.py
@@ -5,6 +5,11 @@ from pynput import keyboard as pynput_keyboard
 
 class ShutdownBus(QObject):
     shutdown_requested = Signal()
+    command_overlay_toggle_requested = Signal()
+    command_character_typed = Signal(str)
+    command_backspace_requested = Signal()
+    command_enter_requested = Signal()
+    command_escape_requested = Signal()
 
 
 class GlobalHotkeyManager:
@@ -12,7 +17,9 @@ class GlobalHotkeyManager:
         self.bus = bus
         self._listener = None
         self._pressed = set()
-        self._fired = False
+        self._shutdown_fired = False
+        self._overlay_toggle_fired = False
+        self._command_mode_active = False
 
     def start(self) -> None:
         if self._listener is not None:
@@ -25,10 +32,15 @@ class GlobalHotkeyManager:
             self._listener.stop()
             self._listener = None
         self._pressed.clear()
-        self._fired = False
+        self._shutdown_fired = False
+        self._overlay_toggle_fired = False
+        self._command_mode_active = False
 
     def force_kill(self) -> None:
         os._exit(0)
+
+    def set_command_mode_active(self, active: bool) -> None:
+        self._command_mode_active = bool(active)
 
     def _on_press(self, key) -> None:
         self._pressed.add(key)
@@ -39,18 +51,51 @@ class GlobalHotkeyManager:
             or pynput_keyboard.Key.alt_gr in self._pressed
         )
         end_down = key == pynput_keyboard.Key.end
-        if ctrl_down and alt_down and end_down and not self._fired:
-            self._fired = True
+        home_down = key == pynput_keyboard.Key.home
+
+        if ctrl_down and alt_down and end_down and not self._shutdown_fired:
+            self._shutdown_fired = True
             self.bus.shutdown_requested.emit()
+            return
+
+        if ctrl_down and alt_down and home_down and not self._overlay_toggle_fired:
+            self._overlay_toggle_fired = True
+            self.bus.command_overlay_toggle_requested.emit()
+            return
+
+        if not self._command_mode_active or ctrl_down or alt_down:
+            return
+
+        if key == pynput_keyboard.Key.esc:
+            self.bus.command_escape_requested.emit()
+            return
+
+        if key == pynput_keyboard.Key.enter:
+            self.bus.command_enter_requested.emit()
+            return
+
+        if key == pynput_keyboard.Key.backspace:
+            self.bus.command_backspace_requested.emit()
+            return
+
+        if key == pynput_keyboard.Key.space:
+            self.bus.command_character_typed.emit(" ")
+            return
+
+        char = getattr(key, "char", None)
+        if isinstance(char, str) and char.isprintable():
+            self.bus.command_character_typed.emit(char)
 
     def _on_release(self, key) -> None:
         self._pressed.discard(key)
         if key in (
             pynput_keyboard.Key.end,
+            pynput_keyboard.Key.home,
             pynput_keyboard.Key.ctrl_l,
             pynput_keyboard.Key.ctrl_r,
             pynput_keyboard.Key.alt_l,
             pynput_keyboard.Key.alt_r,
             pynput_keyboard.Key.alt_gr,
         ):
-            self._fired = False
+            self._shutdown_fired = False
+            self._overlay_toggle_fired = False

--- a/desktop/hotkeys.py
+++ b/desktop/hotkeys.py
@@ -6,10 +6,6 @@ from pynput import keyboard as pynput_keyboard
 class ShutdownBus(QObject):
     shutdown_requested = Signal()
     command_overlay_toggle_requested = Signal()
-    command_character_typed = Signal(str)
-    command_backspace_requested = Signal()
-    command_enter_requested = Signal()
-    command_escape_requested = Signal()
 
 
 class GlobalHotkeyManager:
@@ -19,8 +15,6 @@ class GlobalHotkeyManager:
         self._pressed = set()
         self._shutdown_fired = False
         self._overlay_toggle_fired = False
-        self._command_overlay_active = False
-        self._command_text_capture_active = False
 
     def start(self) -> None:
         if self._listener is not None:
@@ -35,17 +29,9 @@ class GlobalHotkeyManager:
         self._pressed.clear()
         self._shutdown_fired = False
         self._overlay_toggle_fired = False
-        self._command_overlay_active = False
-        self._command_text_capture_active = False
 
     def force_kill(self) -> None:
         os._exit(0)
-
-    def set_command_overlay_active(self, active: bool) -> None:
-        self._command_overlay_active = bool(active)
-
-    def set_command_text_capture_active(self, active: bool) -> None:
-        self._command_text_capture_active = bool(active)
 
     def _on_press(self, key) -> None:
         self._pressed.add(key)
@@ -67,32 +53,6 @@ class GlobalHotkeyManager:
             self._overlay_toggle_fired = True
             self.bus.command_overlay_toggle_requested.emit()
             return
-
-        if not self._command_overlay_active or ctrl_down or alt_down:
-            return
-
-        if key == pynput_keyboard.Key.esc:
-            self.bus.command_escape_requested.emit()
-            return
-
-        if key == pynput_keyboard.Key.enter:
-            self.bus.command_enter_requested.emit()
-            return
-
-        if not self._command_text_capture_active:
-            return
-
-        if key == pynput_keyboard.Key.backspace:
-            self.bus.command_backspace_requested.emit()
-            return
-
-        if key == pynput_keyboard.Key.space:
-            self.bus.command_character_typed.emit(" ")
-            return
-
-        char = getattr(key, "char", None)
-        if isinstance(char, str) and char.isprintable():
-            self.bus.command_character_typed.emit(char)
 
     def _on_release(self, key) -> None:
         self._pressed.discard(key)

--- a/desktop/hotkeys.py
+++ b/desktop/hotkeys.py
@@ -19,7 +19,8 @@ class GlobalHotkeyManager:
         self._pressed = set()
         self._shutdown_fired = False
         self._overlay_toggle_fired = False
-        self._command_mode_active = False
+        self._command_overlay_active = False
+        self._command_text_capture_active = False
 
     def start(self) -> None:
         if self._listener is not None:
@@ -34,13 +35,17 @@ class GlobalHotkeyManager:
         self._pressed.clear()
         self._shutdown_fired = False
         self._overlay_toggle_fired = False
-        self._command_mode_active = False
+        self._command_overlay_active = False
+        self._command_text_capture_active = False
 
     def force_kill(self) -> None:
         os._exit(0)
 
-    def set_command_mode_active(self, active: bool) -> None:
-        self._command_mode_active = bool(active)
+    def set_command_overlay_active(self, active: bool) -> None:
+        self._command_overlay_active = bool(active)
+
+    def set_command_text_capture_active(self, active: bool) -> None:
+        self._command_text_capture_active = bool(active)
 
     def _on_press(self, key) -> None:
         self._pressed.add(key)
@@ -63,7 +68,7 @@ class GlobalHotkeyManager:
             self.bus.command_overlay_toggle_requested.emit()
             return
 
-        if not self._command_mode_active or ctrl_down or alt_down:
+        if not self._command_overlay_active or ctrl_down or alt_down:
             return
 
         if key == pynput_keyboard.Key.esc:
@@ -72,6 +77,9 @@ class GlobalHotkeyManager:
 
         if key == pynput_keyboard.Key.enter:
             self.bus.command_enter_requested.emit()
+            return
+
+        if not self._command_text_capture_active:
             return
 
         if key == pynput_keyboard.Key.backspace:

--- a/desktop/interaction_overlay_model.py
+++ b/desktop/interaction_overlay_model.py
@@ -119,6 +119,16 @@ class CommandOverlayModel:
         self.status_kind = "idle"
         self.status_text = ""
 
+    def set_input_text(self, text: str):
+        if not self.visible or self.phase != "entry":
+            return
+
+        self.input_text = text or ""
+        self.status_kind = "idle"
+        self.status_text = ""
+        self.pending_action = None
+        self.pending_matches = ()
+
     def backspace(self):
         if not self.visible or self.phase != "entry" or not self.input_armed:
             return
@@ -149,10 +159,9 @@ class CommandOverlayModel:
 
         if self.phase == "entry":
             if not self.input_armed:
-                self.input_armed = True
                 self.status_kind = "idle"
-                self.status_text = ""
-                return ("input_armed", None)
+                self.status_text = "Click inside the command box to begin typing."
+                return ("awaiting_click_arm", None)
 
             if not normalize_command_text(self.input_text):
                 self.status_kind = "idle"

--- a/desktop/interaction_overlay_model.py
+++ b/desktop/interaction_overlay_model.py
@@ -1,0 +1,196 @@
+import os
+import re
+import subprocess
+from dataclasses import dataclass
+from pathlib import Path
+
+
+ROOT_DIR = Path(__file__).resolve().parent.parent
+
+
+@dataclass(frozen=True)
+class CommandAction:
+    id: str
+    title: str
+    target_kind: str
+    target: str
+    aliases: tuple[str, ...]
+
+
+DEFAULT_COMMAND_ACTIONS = (
+    CommandAction(
+        id="open_jarvis_workspace",
+        title="Open Jarvis Workspace",
+        target_kind="folder",
+        target=str(ROOT_DIR),
+        aliases=("open jarvis workspace", "open workspace", "open jarvis folder"),
+    ),
+    CommandAction(
+        id="open_jarvis_docs",
+        title="Open Jarvis Docs",
+        target_kind="folder",
+        target=str(ROOT_DIR / "docs"),
+        aliases=("open jarvis docs", "open docs", "open jarvis folder"),
+    ),
+    CommandAction(
+        id="open_windows_explorer",
+        title="Open Windows Explorer",
+        target_kind="app",
+        target="explorer.exe",
+        aliases=("open windows explorer", "open file explorer", "windows explorer"),
+    ),
+)
+
+
+def normalize_command_text(text: str) -> str:
+    normalized = (text or "").strip().casefold()
+    normalized = re.sub(r"\s+", " ", normalized)
+    normalized = re.sub(r"[.!?]+$", "", normalized)
+    return normalized.strip()
+
+
+def resolve_command_actions(text: str, actions=DEFAULT_COMMAND_ACTIONS):
+    normalized = normalize_command_text(text)
+    if not normalized:
+        return []
+
+    matches = []
+    for action in actions:
+        candidates = (action.title, *action.aliases)
+        if any(normalize_command_text(candidate) == normalized for candidate in candidates):
+            matches.append(action)
+    return matches
+
+
+def launch_command_action(action: CommandAction):
+    if action.target_kind == "app":
+        subprocess.Popen([action.target], shell=False)
+        return
+
+    os.startfile(action.target)
+
+
+class CommandOverlayModel:
+    def __init__(self, actions=DEFAULT_COMMAND_ACTIONS):
+        self.actions = tuple(actions)
+        self.visible = False
+        self.phase = "hidden"
+        self.input_text = ""
+        self.status_kind = "idle"
+        self.status_text = ""
+        self.last_request = ""
+        self.pending_action = None
+        self.pending_matches = ()
+
+    def open(self):
+        self.visible = True
+        self.phase = "entry"
+        self.input_text = ""
+        self.status_kind = "idle"
+        self.status_text = ""
+        self.last_request = ""
+        self.pending_action = None
+        self.pending_matches = ()
+
+    def close(self):
+        self.visible = False
+        self.phase = "hidden"
+        self.input_text = ""
+        self.status_kind = "idle"
+        self.status_text = ""
+        self.last_request = ""
+        self.pending_action = None
+        self.pending_matches = ()
+
+    def toggle(self):
+        if self.visible:
+            self.close()
+        else:
+            self.open()
+
+    def append_text(self, char: str):
+        if not self.visible or self.phase != "entry" or not char:
+            return
+
+        self.input_text += char
+        self.status_kind = "idle"
+        self.status_text = ""
+
+    def backspace(self):
+        if not self.visible or self.phase != "entry":
+            return
+
+        self.input_text = self.input_text[:-1]
+        self.status_kind = "idle"
+        self.status_text = ""
+
+    def escape(self):
+        if not self.visible:
+            return "ignored"
+
+        if self.phase == "confirm":
+            self.phase = "entry"
+            self.status_kind = "idle"
+            self.status_text = ""
+            self.pending_action = None
+            self.pending_matches = ()
+            return "confirm_cancelled"
+
+        self.close()
+        return "closed"
+
+    def submit(self):
+        if not self.visible:
+            return ("ignored", None)
+
+        if self.phase == "entry":
+            self.last_request = self.input_text
+            matches = tuple(resolve_command_actions(self.input_text, self.actions))
+            self.pending_matches = matches
+
+            if len(matches) == 1:
+                self.phase = "confirm"
+                self.pending_action = matches[0]
+                self.status_kind = "ready"
+                self.status_text = ""
+                return ("confirm_ready", matches[0])
+
+            self.pending_action = None
+            if not matches:
+                self.status_kind = "not_found"
+                self.status_text = "No saved action or alias matched that request."
+                return ("not_found", None)
+
+            self.status_kind = "ambiguous"
+            self.status_text = "Multiple saved actions matched that request."
+            return ("ambiguous", matches)
+
+        if self.phase == "confirm" and self.pending_action is not None:
+            return ("execute_confirmed", self.pending_action)
+
+        return ("ignored", None)
+
+    def show_result(self, status_kind: str, status_text: str):
+        self.phase = "result"
+        self.status_kind = status_kind
+        self.status_text = status_text
+
+    def view_payload(self):
+        action = self.pending_action
+        return {
+            "visible": self.visible,
+            "phase": self.phase,
+            "input_text": self.input_text,
+            "status_kind": self.status_kind,
+            "status_text": self.status_text,
+            "typed_request": self.last_request,
+            "pending_action": None
+            if action is None
+            else {
+                "id": action.id,
+                "title": action.title,
+                "target_kind": action.target_kind,
+                "target": action.target,
+            },
+            "ambiguous_titles": [match.title for match in self.pending_matches] if self.status_kind == "ambiguous" else [],
+        }

--- a/desktop/interaction_overlay_model.py
+++ b/desktop/interaction_overlay_model.py
@@ -75,6 +75,7 @@ class CommandOverlayModel:
         self.actions = tuple(actions)
         self.visible = False
         self.phase = "hidden"
+        self.input_armed = False
         self.input_text = ""
         self.status_kind = "idle"
         self.status_text = ""
@@ -85,6 +86,7 @@ class CommandOverlayModel:
     def open(self):
         self.visible = True
         self.phase = "entry"
+        self.input_armed = False
         self.input_text = ""
         self.status_kind = "idle"
         self.status_text = ""
@@ -95,6 +97,7 @@ class CommandOverlayModel:
     def close(self):
         self.visible = False
         self.phase = "hidden"
+        self.input_armed = False
         self.input_text = ""
         self.status_kind = "idle"
         self.status_text = ""
@@ -109,7 +112,7 @@ class CommandOverlayModel:
             self.open()
 
     def append_text(self, char: str):
-        if not self.visible or self.phase != "entry" or not char:
+        if not self.visible or self.phase != "entry" or not self.input_armed or not char:
             return
 
         self.input_text += char
@@ -117,7 +120,7 @@ class CommandOverlayModel:
         self.status_text = ""
 
     def backspace(self):
-        if not self.visible or self.phase != "entry":
+        if not self.visible or self.phase != "entry" or not self.input_armed:
             return
 
         self.input_text = self.input_text[:-1]
@@ -130,6 +133,7 @@ class CommandOverlayModel:
 
         if self.phase == "confirm":
             self.phase = "entry"
+            self.input_armed = True
             self.status_kind = "idle"
             self.status_text = ""
             self.pending_action = None
@@ -144,12 +148,24 @@ class CommandOverlayModel:
             return ("ignored", None)
 
         if self.phase == "entry":
+            if not self.input_armed:
+                self.input_armed = True
+                self.status_kind = "idle"
+                self.status_text = ""
+                return ("input_armed", None)
+
+            if not normalize_command_text(self.input_text):
+                self.status_kind = "idle"
+                self.status_text = ""
+                return ("awaiting_input", None)
+
             self.last_request = self.input_text
             matches = tuple(resolve_command_actions(self.input_text, self.actions))
             self.pending_matches = matches
 
             if len(matches) == 1:
                 self.phase = "confirm"
+                self.input_armed = False
                 self.pending_action = matches[0]
                 self.status_kind = "ready"
                 self.status_text = ""
@@ -172,6 +188,7 @@ class CommandOverlayModel:
 
     def show_result(self, status_kind: str, status_text: str):
         self.phase = "result"
+        self.input_armed = False
         self.status_kind = status_kind
         self.status_text = status_text
 
@@ -180,6 +197,7 @@ class CommandOverlayModel:
         return {
             "visible": self.visible,
             "phase": self.phase,
+            "input_armed": self.input_armed,
             "input_text": self.input_text,
             "status_kind": self.status_kind,
             "status_text": self.status_text,

--- a/desktop/jarvis_desktop_main.py
+++ b/desktop/jarvis_desktop_main.py
@@ -78,7 +78,7 @@ def main():
     if exit_if_startup_abort_requested():
         return 0
 
-    visual_html_path = os.path.join(ROOT_DIR, "jarvis_visual", "jarvis_core_desktop.html")
+    visual_html_path = os.path.join(ROOT_DIR, "jarvis_visual", "jarvis_core.html")
     runtime_milestone("RENDERER_MAIN|VISUAL_HTML_RESOLVED")
     if exit_if_startup_abort_requested():
         return 0

--- a/desktop/jarvis_desktop_main.py
+++ b/desktop/jarvis_desktop_main.py
@@ -113,12 +113,19 @@ def main():
             do_shutdown()
 
     bus.shutdown_requested.connect(do_shutdown)
+    bus.command_overlay_toggle_requested.connect(window.toggle_command_overlay)
+    bus.command_character_typed.connect(window.handle_command_character)
+    bus.command_backspace_requested.connect(window.handle_command_backspace)
+    bus.command_enter_requested.connect(window.handle_command_submit)
+    bus.command_escape_requested.connect(window.handle_command_escape)
+    window.command_mode_changed.connect(hotkeys.set_command_mode_active)
     hotkeys.start()
     runtime_milestone("RENDERER_MAIN|HOTKEYS_STARTED")
     if exit_if_startup_abort_requested(hotkeys):
         return 0
 
     print("Jarvis Desktop Concept 1 - Version 1.02")
+    print("Command Overlay: Ctrl + Alt + Home")
     print("Hotkey: Ctrl + Alt + End")
 
     window.show()

--- a/desktop/jarvis_desktop_main.py
+++ b/desktop/jarvis_desktop_main.py
@@ -114,12 +114,6 @@ def main():
 
     bus.shutdown_requested.connect(do_shutdown)
     bus.command_overlay_toggle_requested.connect(window.toggle_command_overlay)
-    bus.command_character_typed.connect(window.handle_command_character)
-    bus.command_backspace_requested.connect(window.handle_command_backspace)
-    bus.command_enter_requested.connect(window.handle_command_submit)
-    bus.command_escape_requested.connect(window.handle_command_escape)
-    window.command_overlay_visibility_changed.connect(hotkeys.set_command_overlay_active)
-    window.command_text_capture_changed.connect(hotkeys.set_command_text_capture_active)
     hotkeys.start()
     runtime_milestone("RENDERER_MAIN|HOTKEYS_STARTED")
     if exit_if_startup_abort_requested(hotkeys):

--- a/desktop/jarvis_desktop_main.py
+++ b/desktop/jarvis_desktop_main.py
@@ -118,7 +118,8 @@ def main():
     bus.command_backspace_requested.connect(window.handle_command_backspace)
     bus.command_enter_requested.connect(window.handle_command_submit)
     bus.command_escape_requested.connect(window.handle_command_escape)
-    window.command_mode_changed.connect(hotkeys.set_command_mode_active)
+    window.command_overlay_visibility_changed.connect(hotkeys.set_command_overlay_active)
+    window.command_text_capture_changed.connect(hotkeys.set_command_text_capture_active)
     hotkeys.start()
     runtime_milestone("RENDERER_MAIN|HOTKEYS_STARTED")
     if exit_if_startup_abort_requested(hotkeys):

--- a/desktop/jarvis_support_reporting.py
+++ b/desktop/jarvis_support_reporting.py
@@ -23,6 +23,13 @@ def normalize_path(path):
     return os.path.normcase(os.path.normpath(os.path.abspath(path)))
 
 
+def path_is_within(path, parent):
+    try:
+        return os.path.commonpath([normalize_path(path), normalize_path(parent)]) == normalize_path(parent)
+    except ValueError:
+        return False
+
+
 def derive_run_identity(runtime_log_path):
     stem = os.path.splitext(os.path.basename(runtime_log_path))[0]
     if stem.startswith("Runtime_"):
@@ -150,8 +157,37 @@ def build_environment_summary():
     }
 
 
-def ensure_support_bundle_dir(runtime_log_path):
-    support_dir = os.path.join(os.path.dirname(runtime_log_path), SUPPORT_BUNDLE_FOLDER)
+def resolve_user_visible_support_bundle_dir():
+    home_dir = os.path.expanduser("~")
+    local_app_data = os.environ.get("LOCALAPPDATA", "").strip()
+    candidate_dirs = []
+
+    if home_dir:
+        candidate_dirs.append(os.path.join(home_dir, "Documents", "Jarvis Support Bundles"))
+    if local_app_data:
+        candidate_dirs.append(os.path.join(local_app_data, "Jarvis", "Support Bundles"))
+    if home_dir:
+        candidate_dirs.append(os.path.join(home_dir, "Jarvis Support Bundles"))
+
+    for candidate_dir in candidate_dirs:
+        try:
+            os.makedirs(candidate_dir, exist_ok=True)
+            return candidate_dir
+        except OSError:
+            continue
+
+    raise SupportBundleError("Could not create a writable support-bundle folder outside the live logs tree.")
+
+
+def ensure_support_bundle_dir(root_dir, runtime_log_path):
+    runtime_dir = os.path.dirname(runtime_log_path)
+    live_logs_dir = os.path.join(root_dir, "logs")
+    dev_logs_dir = os.path.join(root_dir, "dev", "logs")
+
+    if path_is_within(runtime_dir, live_logs_dir) and not path_is_within(runtime_dir, dev_logs_dir):
+        return resolve_user_visible_support_bundle_dir()
+
+    support_dir = os.path.join(runtime_dir, SUPPORT_BUNDLE_FOLDER)
     os.makedirs(support_dir, exist_ok=True)
     return support_dir
 
@@ -180,7 +216,7 @@ def create_support_bundle(root_dir, runtime_log_path, crash_dir):
         raise SupportBundleError("The runtime log for this report could not be found.")
 
     run_identity = derive_run_identity(runtime_log_path)
-    support_dir = ensure_support_bundle_dir(runtime_log_path)
+    support_dir = ensure_support_bundle_dir(root_dir, runtime_log_path)
     bundle_basename = choose_bundle_basename(support_dir, run_identity)
     staging_dir = os.path.join(support_dir, bundle_basename)
     bundle_path = os.path.join(support_dir, f"{bundle_basename}.zip")

--- a/desktop/workerw_utils.py
+++ b/desktop/workerw_utils.py
@@ -331,3 +331,19 @@ def make_window_noninteractive(hwnd: int) -> None:
         | SWP_NOOWNERZORDER
         | SWP_NOSENDCHANGING,
     )
+
+
+def position_desktop_child(hwnd: int, x: int, y: int, width: int, height: int) -> None:
+    SetWindowPos(
+        hwnd,
+        HWND_BOTTOM,
+        int(x),
+        int(y),
+        int(width),
+        int(height),
+        SWP_NOACTIVATE
+        | SWP_SHOWWINDOW
+        | SWP_FRAMECHANGED
+        | SWP_NOOWNERZORDER
+        | SWP_NOSENDCHANGING,
+    )

--- a/desktop/workerw_utils.py
+++ b/desktop/workerw_utils.py
@@ -252,7 +252,7 @@ def get_workerw():
 def attach_window_to_desktop(hwnd: int) -> bool:
     workerw = get_workerw()
     selection_reason = _LAST_WORKERW_PROBE.get("selection_reason", "none")
-    if not workerw or selection_reason != "next_workerw":
+    if not workerw or selection_reason not in {"next_workerw", "progman_fallback"}:
         return False
 
     # Parent first so the shell owns the window relationship.

--- a/desktop/workerw_utils.py
+++ b/desktop/workerw_utils.py
@@ -251,7 +251,8 @@ def get_workerw():
 
 def attach_window_to_desktop(hwnd: int) -> bool:
     workerw = get_workerw()
-    if not workerw:
+    selection_reason = _LAST_WORKERW_PROBE.get("selection_reason", "none")
+    if not workerw or selection_reason != "next_workerw":
         return False
 
     # Parent first so the shell owns the window relationship.

--- a/desktop/workerw_utils.py
+++ b/desktop/workerw_utils.py
@@ -14,9 +14,12 @@ SetWindowPos = user32.SetWindowPos
 GetWindowLongPtrW = user32.GetWindowLongPtrW
 SetWindowLongPtrW = user32.SetWindowLongPtrW
 GetClassNameW = user32.GetClassNameW
+GetParent = user32.GetParent
+MapWindowPoints = user32.MapWindowPoints
 
 LONG_PTR = ctypes.c_ssize_t
 ULONG_PTR = ctypes.c_size_t
+POINT = wintypes.POINT
 
 SendMessageTimeoutW.argtypes = [
     wintypes.HWND, wintypes.UINT, wintypes.WPARAM, wintypes.LPARAM,
@@ -53,6 +56,10 @@ SetWindowLongPtrW.restype = LONG_PTR
 
 GetClassNameW.argtypes = [wintypes.HWND, wintypes.LPWSTR, ctypes.c_int]
 GetClassNameW.restype = ctypes.c_int
+GetParent.argtypes = [wintypes.HWND]
+GetParent.restype = wintypes.HWND
+MapWindowPoints.argtypes = [wintypes.HWND, wintypes.HWND, ctypes.POINTER(POINT), wintypes.UINT]
+MapWindowPoints.restype = ctypes.c_int
 
 # --- Constants ---
 SMTO_NORMAL = 0x0000
@@ -155,6 +162,7 @@ def get_last_workerw_probe_events():
             f"progman_class={probe.get('progman_class', 'none')}|"
             f"progman_message_sent={probe.get('progman_message_sent', 'false')}|"
             f"progman_message_result={probe.get('progman_message_result', 'none')}|"
+            f"progman_child_workerw={probe.get('progman_child_workerw', 'none')}|"
             f"top_level_window_count={probe.get('top_level_window_count', 0)}"
         ),
         (
@@ -177,6 +185,7 @@ def get_workerw():
     progman_message_sent = False
     progman_message_result = "none"
     selection_reason = "none"
+    progman_child_workerw = None
     if progman:
         result = wintypes.DWORD()
         send_result = SendMessageTimeoutW(
@@ -190,6 +199,7 @@ def get_workerw():
         )
         progman_message_sent = bool(send_result)
         progman_message_result = str(int(result.value))
+        progman_child_workerw = FindWindowExW(progman, None, "WorkerW", None)
 
     workerw = None
     windows = []
@@ -224,15 +234,14 @@ def get_workerw():
             if workerw is None and possible:
                 workerw = possible
                 selection_reason = "next_workerw"
-            elif (
-                workerw is None
-                and not possible
-                and progman
-                and hwnd == progman
-                and window_class == "Progman"
-            ):
-                workerw = hwnd
-                selection_reason = "progman_fallback"
+
+    if workerw is None and progman_child_workerw:
+        workerw = progman_child_workerw
+        selection_reason = "progman_child_workerw"
+
+    if workerw is None and progman:
+        workerw = progman
+        selection_reason = "progman_fallback"
 
     global _LAST_WORKERW_PROBE
     _LAST_WORKERW_PROBE = {
@@ -240,6 +249,7 @@ def get_workerw():
         "progman_class": _window_class(progman),
         "progman_message_sent": "true" if progman_message_sent else "false",
         "progman_message_result": progman_message_result,
+        "progman_child_workerw": _hwnd_token(progman_child_workerw),
         "top_level_window_count": len(windows),
         "shell_hosts": shell_hosts,
         "workerw_candidates": [_hwnd_token(hwnd) for hwnd in workerw_candidates],
@@ -252,7 +262,7 @@ def get_workerw():
 def attach_window_to_desktop(hwnd: int) -> bool:
     workerw = get_workerw()
     selection_reason = _LAST_WORKERW_PROBE.get("selection_reason", "none")
-    if not workerw or selection_reason not in {"next_workerw", "progman_fallback"}:
+    if not workerw or selection_reason not in {"next_workerw", "progman_child_workerw", "progman_fallback"}:
         return False
 
     # Parent first so the shell owns the window relationship.
@@ -334,13 +344,31 @@ def make_window_noninteractive(hwnd: int) -> None:
 
 
 def position_desktop_child(hwnd: int, x: int, y: int, width: int, height: int) -> None:
+    parent = GetParent(hwnd)
+    left = int(x)
+    top = int(y)
+    right = int(x + width)
+    bottom = int(y + height)
+
+    if parent:
+        points = (POINT * 2)()
+        points[0].x = left
+        points[0].y = top
+        points[1].x = right
+        points[1].y = bottom
+        MapWindowPoints(0, parent, points, 2)
+        left = points[0].x
+        top = points[0].y
+        right = points[1].x
+        bottom = points[1].y
+
     SetWindowPos(
         hwnd,
         HWND_BOTTOM,
-        int(x),
-        int(y),
-        int(width),
-        int(height),
+        left,
+        top,
+        max(1, right - left),
+        max(1, bottom - top),
         SWP_NOACTIVATE
         | SWP_SHOWWINDOW
         | SWP_FRAMECHANGED

--- a/dev/jarvis_desktop_launcher_healthy_validation.py
+++ b/dev/jarvis_desktop_launcher_healthy_validation.py
@@ -58,6 +58,15 @@ def hidden_subprocess_kwargs():
     return kwargs
 
 
+def run_hidden_command(args, timeout_seconds=20):
+    return subprocess.run(
+        args,
+        cwd=ROOT_DIR,
+        timeout=timeout_seconds,
+        **hidden_subprocess_kwargs(),
+    )
+
+
 def ensure_dir(path):
     os.makedirs(path, exist_ok=True)
 
@@ -161,6 +170,84 @@ def resolve_base_log_root(log_root_override=None):
     return DEFAULT_BASE_LOG_ROOT
 
 
+def terminate_process_tree(proc):
+    if proc.poll() is not None:
+        return False
+
+    if os.name == "nt":
+        try:
+            run_hidden_command(["taskkill", "/PID", str(proc.pid), "/T", "/F"], timeout_seconds=10)
+        except Exception:
+            pass
+
+        deadline = time.time() + 5.0
+        while time.time() < deadline:
+            if proc.poll() is not None:
+                return True
+            time.sleep(0.1)
+
+    proc.terminate()
+    try:
+        proc.wait(timeout=5)
+    except subprocess.TimeoutExpired:
+        proc.kill()
+        proc.wait(timeout=5)
+    return True
+
+
+def list_renderer_processes_for_log_root(base_log_root):
+    if os.name != "nt":
+        return []
+
+    script = r"""
+$BaseLogRoot = $args[0]
+Get-CimInstance Win32_Process | Where-Object {
+    ($_.Name -eq 'pythonw.exe' -or $_.Name -eq 'python.exe') -and
+    $_.CommandLine -like '*jarvis_desktop_main.py*' -and
+    $_.CommandLine -like ('*' + $BaseLogRoot + '*')
+} | ForEach-Object {
+    '{0}|{1}' -f $_.ProcessId, $_.CommandLine
+}
+"""
+
+    try:
+        result = run_hidden_command(
+            ["powershell", "-NoProfile", "-Command", script, base_log_root],
+            timeout_seconds=15,
+        )
+    except Exception:
+        return []
+
+    processes = []
+    for raw_line in (result.stdout or "").splitlines():
+        line = raw_line.strip()
+        if not line or "|" not in line:
+            continue
+        pid_text, command_line = line.split("|", 1)
+        try:
+            pid = int(pid_text.strip())
+        except ValueError:
+            continue
+        processes.append({"pid": pid, "command_line": command_line.strip()})
+    return processes
+
+
+def cleanup_renderer_processes_for_log_root(base_log_root):
+    before = list_renderer_processes_for_log_root(base_log_root)
+    killed = []
+
+    for process in before:
+        try:
+            run_hidden_command(["taskkill", "/PID", str(process["pid"]), "/F"], timeout_seconds=10)
+            killed.append(process["pid"])
+        except Exception:
+            pass
+
+    time.sleep(0.3)
+    after = list_renderer_processes_for_log_root(base_log_root)
+    return before, killed, after
+
+
 def reports_dir_for(base_log_root):
     return os.path.join(base_log_root, "reports")
 
@@ -238,12 +325,7 @@ def run_validation(log_root_override=None):
     terminated_by_validator = False
     if proc.poll() is None:
         terminated_by_validator = True
-        proc.terminate()
-        try:
-            proc.wait(timeout=5)
-        except subprocess.TimeoutExpired:
-            proc.kill()
-            proc.wait(timeout=5)
+        terminate_process_tree(proc)
 
     stdout_text, stderr_text = proc.communicate()
     exit_code = proc.returncode if exit_code is None else exit_code
@@ -266,6 +348,10 @@ def run_validation(log_root_override=None):
                 os.remove(artifact_path)
         except Exception:
             pass
+
+    residual_renderer_processes_before, residual_renderer_killed, residual_renderer_processes_after = (
+        cleanup_renderer_processes_for_log_root(base_log_root)
+    )
 
     checks = {
         "launcher_default_target_matches_expected": line_status(
@@ -333,6 +419,23 @@ def run_validation(log_root_override=None):
             "seen"
             if normal_exit_complete_seen
             else f"not seen (launcher process closed by validator after evidence capture, exit={exit_code})",
+        ),
+        "no_residual_renderer_processes_for_log_root": line_status(
+            not residual_renderer_processes_after,
+            "none"
+            if not residual_renderer_processes_after
+            else "; ".join(
+                f"{process['pid']}::{process['command_line']}" for process in residual_renderer_processes_after
+            ),
+        ),
+        "residual_renderer_cleanup_optional": line_status(
+            True,
+            "no residual renderer processes detected"
+            if not residual_renderer_processes_before
+            else (
+                f"detected {len(residual_renderer_processes_before)} residual process(es); "
+                f"killed={','.join(str(pid) for pid in residual_renderer_killed) or 'none'}"
+            ),
         ),
     }
 

--- a/jarvis_visual/jarvis_core.js
+++ b/jarvis_visual/jarvis_core.js
@@ -5,6 +5,7 @@ const bctx = backCanvas.getContext("2d");
 const fctx = frontCanvas.getContext("2d");
 const commandOverlay = document.getElementById("command-overlay");
 const commandHint = document.getElementById("command-hint");
+const commandInputShell = document.getElementById("command-input-shell");
 const commandInputText = document.getElementById("command-input-text");
 const commandStatus = document.getElementById("command-status");
 const commandAmbiguous = document.getElementById("command-ambiguous");
@@ -30,6 +31,7 @@ let smoothedVoiceLevel = 0.0;
 let commandOverlayState = {
   visible: false,
   phase: "hidden",
+  input_armed: false,
   input_text: "",
   status_kind: "idle",
   status_text: "",
@@ -1053,8 +1055,15 @@ function renderCommandOverlay() {
 
   const state = commandOverlayState || {};
   const isVisible = Boolean(state.visible);
+  const isInputArmed = Boolean(state.input_armed) && state.phase === "entry";
+  const isLocked = state.phase === "confirm" || state.phase === "result";
   commandOverlay.classList.toggle("visible", isVisible);
   commandOverlay.setAttribute("aria-hidden", isVisible ? "false" : "true");
+
+  if (commandInputShell) {
+    commandInputShell.classList.toggle("is-armed", isInputArmed);
+    commandInputShell.classList.toggle("is-locked", isLocked);
+  }
 
   if (!isVisible) {
     return;
@@ -1069,7 +1078,13 @@ function renderCommandOverlay() {
     if (state.status_kind && state.status_kind !== "idle") {
       commandStatus.classList.add(`status-${state.status_kind}`);
     }
-    commandStatus.textContent = state.status_text || "";
+    if (state.status_text) {
+      commandStatus.textContent = state.status_text;
+    } else if (state.phase === "entry" && !isInputArmed) {
+      commandStatus.textContent = "Press Enter to activate the command box.";
+    } else {
+      commandStatus.textContent = "";
+    }
   }
 
   if (commandAmbiguous) {
@@ -1079,12 +1094,15 @@ function renderCommandOverlay() {
   }
 
   if (commandHint) {
-    commandHint.textContent =
-      state.phase === "confirm"
-        ? "Review the resolved action before execution."
-        : state.phase === "result"
-        ? "Returning to passive desktop mode."
-        : "Type a saved action or alias, then press Enter.";
+    if (state.phase === "confirm") {
+      commandHint.textContent = "Review the resolved action before execution.";
+    } else if (state.phase === "result") {
+      commandHint.textContent = "Returning to passive desktop mode.";
+    } else if (!isInputArmed) {
+      commandHint.textContent = "Press Enter to activate the command box. Esc closes.";
+    } else {
+      commandHint.textContent = "Type a saved action or alias, then press Enter.";
+    }
   }
 
   const action = state.pending_action || null;

--- a/jarvis_visual/jarvis_core.js
+++ b/jarvis_visual/jarvis_core.js
@@ -3,6 +3,16 @@ const backCanvas = document.getElementById("fx-back");
 const frontCanvas = document.getElementById("fx-front");
 const bctx = backCanvas.getContext("2d");
 const fctx = frontCanvas.getContext("2d");
+const commandOverlay = document.getElementById("command-overlay");
+const commandHint = document.getElementById("command-hint");
+const commandInputText = document.getElementById("command-input-text");
+const commandStatus = document.getElementById("command-status");
+const commandAmbiguous = document.getElementById("command-ambiguous");
+const commandConfirmation = document.getElementById("command-confirmation");
+const commandConfirmRequest = document.getElementById("command-confirm-request");
+const commandConfirmTitle = document.getElementById("command-confirm-title");
+const commandConfirmKind = document.getElementById("command-confirm-kind");
+const commandConfirmTarget = document.getElementById("command-confirm-target");
 
 let w = 0;
 let h = 0;
@@ -17,6 +27,16 @@ let bootStartTime = null;
 
 let voiceLevel = 0.0;
 let smoothedVoiceLevel = 0.0;
+let commandOverlayState = {
+  visible: false,
+  phase: "hidden",
+  input_text: "",
+  status_kind: "idle",
+  status_text: "",
+  typed_request: "",
+  pending_action: null,
+  ambiguous_titles: []
+};
 
 const backParticles = [];
 const frontParticles = [];
@@ -1028,6 +1048,67 @@ function drawForegroundSweep() {
   fctx.filter = "none";
 }
 
+function renderCommandOverlay() {
+  if (!commandOverlay) return;
+
+  const state = commandOverlayState || {};
+  const isVisible = Boolean(state.visible);
+  commandOverlay.classList.toggle("visible", isVisible);
+  commandOverlay.setAttribute("aria-hidden", isVisible ? "false" : "true");
+
+  if (!isVisible) {
+    return;
+  }
+
+  if (commandInputText) {
+    commandInputText.textContent = state.input_text || "";
+  }
+
+  if (commandStatus) {
+    commandStatus.className = "command-status";
+    if (state.status_kind && state.status_kind !== "idle") {
+      commandStatus.classList.add(`status-${state.status_kind}`);
+    }
+    commandStatus.textContent = state.status_text || "";
+  }
+
+  if (commandAmbiguous) {
+    const titles = Array.isArray(state.ambiguous_titles) ? state.ambiguous_titles : [];
+    commandAmbiguous.textContent =
+      titles.length > 0 ? `Matches: ${titles.join(" • ")}` : "";
+  }
+
+  if (commandHint) {
+    commandHint.textContent =
+      state.phase === "confirm"
+        ? "Review the resolved action before execution."
+        : state.phase === "result"
+        ? "Returning to passive desktop mode."
+        : "Type a saved action or alias, then press Enter.";
+  }
+
+  const action = state.pending_action || null;
+  const showConfirm = state.phase === "confirm" && action;
+  if (commandConfirmation) {
+    commandConfirmation.hidden = !showConfirm;
+  }
+
+  if (showConfirm) {
+    if (commandConfirmRequest) {
+      commandConfirmRequest.textContent = state.typed_request || "";
+    }
+    if (commandConfirmTitle) {
+      commandConfirmTitle.textContent = action.title || "";
+    }
+    if (commandConfirmKind) {
+      commandConfirmKind.textContent = action.target_kind || "";
+    }
+    if (commandConfirmTarget) {
+      commandConfirmTarget.textContent = action.target || "";
+    }
+  }
+}
+
 function frame(ts) {
   t = ts;
   if (currentState === "boot" && bootStartTime === null) bootStartTime = t;
@@ -1086,6 +1167,12 @@ window.setJarvisVoiceLevel = function(level) {
   voiceLevel = clamp(Number(level) || 0, 0, 1);
 };
 
+window.setCommandOverlayState = function(state) {
+  commandOverlayState = Object.assign({}, commandOverlayState, state || {});
+  renderCommandOverlay();
+};
+
 window.setJarvisState("boot");
 window.setJarvisVoiceLevel(0);
+window.setCommandOverlayState({ visible: false });
 requestAnimationFrame(frame);

--- a/jarvis_visual/jarvis_core_desktop.css
+++ b/jarvis_visual/jarvis_core_desktop.css
@@ -36,7 +36,10 @@ body.desktop-mode #front-bloom {
   z-index: 24;
   display: none;
   align-items: center;
-  justify-content: center;
+  justify-content: flex-start;
+  padding-top: clamp(240px, calc(50vh + min(18vw, 18vh) + 24px), 74vh);
+  padding-inline: 24px;
+  box-sizing: border-box;
   pointer-events: none;
 }
 
@@ -46,6 +49,7 @@ body.desktop-mode #front-bloom {
 
 .command-panel {
   width: min(78vw, 760px);
+  max-width: 760px;
   padding: 22px 24px 20px;
   border: 1px solid rgba(118, 226, 255, 0.22);
   border-radius: 22px;
@@ -88,6 +92,18 @@ body.desktop-mode #front-bloom {
   border-radius: 16px;
   border: 1px solid rgba(118, 226, 255, 0.18);
   background: rgba(6, 18, 30, 0.76);
+  transition: border-color 140ms ease, box-shadow 140ms ease, background 140ms ease;
+}
+
+.command-input-shell.is-armed {
+  border-color: rgba(118, 226, 255, 0.36);
+  background: rgba(7, 22, 36, 0.86);
+  box-shadow: 0 0 0 1px rgba(118, 226, 255, 0.10) inset;
+}
+
+.command-input-shell.is-locked {
+  border-color: rgba(118, 226, 255, 0.24);
+  background: rgba(8, 18, 30, 0.84);
 }
 
 .command-prompt {
@@ -105,8 +121,12 @@ body.desktop-mode #front-bloom {
 }
 
 .command-input-text:empty::before {
-  content: "Type a saved action or alias";
+  content: "Press Enter to activate command entry";
   color: rgba(150, 180, 198, 0.56);
+}
+
+.command-input-shell.is-armed .command-input-text:empty::before {
+  content: "Type a saved action or alias";
 }
 
 .command-caret {
@@ -116,6 +136,13 @@ body.desktop-mode #front-bloom {
   background: rgba(132, 236, 255, 0.82);
   box-shadow: 0 0 12px rgba(132, 236, 255, 0.44);
   animation: caretPulse 1.05s ease-in-out infinite;
+}
+
+.command-input-shell:not(.is-armed) .command-caret,
+.command-input-shell.is-locked .command-caret {
+  opacity: 0.22;
+  box-shadow: none;
+  animation: none;
 }
 
 .command-status {

--- a/jarvis_visual/jarvis_core_desktop.css
+++ b/jarvis_visual/jarvis_core_desktop.css
@@ -29,3 +29,164 @@ body.desktop-mode #pulse {
 body.desktop-mode #front-bloom {
   opacity: 0.18;
 }
+
+#command-overlay {
+  position: absolute;
+  inset: 0;
+  z-index: 24;
+  display: none;
+  align-items: center;
+  justify-content: center;
+  pointer-events: none;
+}
+
+#command-overlay.visible {
+  display: flex;
+}
+
+.command-panel {
+  width: min(78vw, 760px);
+  padding: 22px 24px 20px;
+  border: 1px solid rgba(118, 226, 255, 0.22);
+  border-radius: 22px;
+  background: linear-gradient(180deg, rgba(4, 16, 28, 0.94), rgba(2, 8, 16, 0.92));
+  box-shadow:
+    0 0 0 1px rgba(180, 245, 255, 0.06) inset,
+    0 18px 54px rgba(0, 0, 0, 0.46),
+    0 0 36px rgba(40, 170, 230, 0.14);
+  backdrop-filter: blur(18px);
+  color: rgba(225, 245, 255, 0.96);
+}
+
+.command-kicker {
+  font-size: 12px;
+  letter-spacing: 0.24em;
+  text-transform: uppercase;
+  color: rgba(118, 226, 255, 0.72);
+}
+
+.command-title {
+  margin-top: 8px;
+  font-size: 28px;
+  font-weight: 600;
+  color: rgba(238, 250, 255, 0.96);
+}
+
+.command-hint {
+  margin-top: 10px;
+  font-size: 14px;
+  color: rgba(172, 215, 235, 0.82);
+}
+
+.command-input-shell {
+  margin-top: 18px;
+  min-height: 58px;
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 14px 16px;
+  border-radius: 16px;
+  border: 1px solid rgba(118, 226, 255, 0.18);
+  background: rgba(6, 18, 30, 0.76);
+}
+
+.command-prompt {
+  font-size: 22px;
+  color: rgba(118, 226, 255, 0.84);
+}
+
+.command-input-text {
+  flex: 1;
+  min-width: 0;
+  font-size: 21px;
+  letter-spacing: 0.01em;
+  color: rgba(238, 248, 255, 0.96);
+  word-break: break-word;
+}
+
+.command-input-text:empty::before {
+  content: "Type a saved action or alias";
+  color: rgba(150, 180, 198, 0.56);
+}
+
+.command-caret {
+  width: 10px;
+  height: 24px;
+  border-radius: 999px;
+  background: rgba(132, 236, 255, 0.82);
+  box-shadow: 0 0 12px rgba(132, 236, 255, 0.44);
+  animation: caretPulse 1.05s ease-in-out infinite;
+}
+
+.command-status {
+  margin-top: 14px;
+  min-height: 22px;
+  font-size: 14px;
+  color: rgba(174, 215, 232, 0.88);
+}
+
+.command-status.status-not_found,
+.command-status.status-launch_failed {
+  color: rgba(255, 176, 176, 0.95);
+}
+
+.command-status.status-ambiguous {
+  color: rgba(255, 222, 154, 0.95);
+}
+
+.command-status.status-launch_requested,
+.command-status.status-ready {
+  color: rgba(166, 247, 195, 0.94);
+}
+
+.command-ambiguous {
+  min-height: 20px;
+  font-size: 13px;
+  color: rgba(255, 222, 154, 0.9);
+}
+
+.command-confirmation {
+  margin-top: 18px;
+  padding: 16px 18px 14px;
+  border-radius: 18px;
+  background: rgba(10, 22, 38, 0.86);
+  border: 1px solid rgba(118, 226, 255, 0.14);
+}
+
+.command-confirm-row {
+  display: flex;
+  gap: 14px;
+  margin-top: 8px;
+}
+
+.command-confirm-row:first-child {
+  margin-top: 0;
+}
+
+.command-confirm-row .label {
+  width: 126px;
+  flex: 0 0 auto;
+  font-size: 12px;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: rgba(118, 226, 255, 0.66);
+}
+
+.command-confirm-row .value {
+  flex: 1;
+  min-width: 0;
+  font-size: 15px;
+  color: rgba(236, 247, 255, 0.94);
+  word-break: break-word;
+}
+
+.command-confirm-help {
+  margin-top: 14px;
+  font-size: 13px;
+  color: rgba(172, 215, 235, 0.84);
+}
+
+@keyframes caretPulse {
+  0%, 100% { opacity: 0.28; }
+  50% { opacity: 1; }
+}

--- a/jarvis_visual/jarvis_core_desktop.html
+++ b/jarvis_visual/jarvis_core_desktop.html
@@ -42,6 +42,42 @@
     </div>
   </div>
 
+  <div id="command-overlay" class="command-overlay" aria-hidden="true">
+    <div class="command-panel">
+      <div class="command-kicker">Jarvis Command</div>
+      <div class="command-title">Typed desktop interaction</div>
+      <div class="command-hint" id="command-hint">
+        Type a saved action or alias, then press Enter.
+      </div>
+      <div class="command-input-shell">
+        <span class="command-prompt">&gt;</span>
+        <span id="command-input-text" class="command-input-text"></span>
+        <span class="command-caret"></span>
+      </div>
+      <div id="command-status" class="command-status"></div>
+      <div id="command-ambiguous" class="command-ambiguous"></div>
+      <div id="command-confirmation" class="command-confirmation" hidden>
+        <div class="command-confirm-row">
+          <span class="label">Typed request</span>
+          <span id="command-confirm-request" class="value"></span>
+        </div>
+        <div class="command-confirm-row">
+          <span class="label">Resolved action</span>
+          <span id="command-confirm-title" class="value"></span>
+        </div>
+        <div class="command-confirm-row">
+          <span class="label">Target kind</span>
+          <span id="command-confirm-kind" class="value"></span>
+        </div>
+        <div class="command-confirm-row">
+          <span class="label">Target</span>
+          <span id="command-confirm-target" class="value"></span>
+        </div>
+        <div class="command-confirm-help">Press Enter to confirm or Esc to return.</div>
+      </div>
+    </div>
+  </div>
+
   <script src="jarvis_core.js"></script>
 </body>
 </html>

--- a/jarvis_visual/jarvis_core_desktop.html
+++ b/jarvis_visual/jarvis_core_desktop.html
@@ -49,7 +49,7 @@
       <div class="command-hint" id="command-hint">
         Type a saved action or alias, then press Enter.
       </div>
-      <div class="command-input-shell">
+      <div id="command-input-shell" class="command-input-shell">
         <span class="command-prompt">&gt;</span>
         <span id="command-input-text" class="command-input-text"></span>
         <span class="command-caret"></span>

--- a/main.py
+++ b/main.py
@@ -7,7 +7,6 @@ import ctypes
 import random
 import math
 import datetime
-from ctypes import wintypes
 
 from pynput import keyboard as pynput_keyboard
 
@@ -20,6 +19,8 @@ from PySide6.QtGui import QGuiApplication, QKeyEvent
 from PySide6.QtWebEngineWidgets import QWebEngineView
 
 from Audio.jarvis_voice import JarvisSpeaker
+from desktop.desktop_renderer import DesktopJarvisWindow
+from desktop.workerw_utils import attach_window_to_desktop, make_window_noninteractive
 from desktop.single_instance import (
     NamedSignal,
     SingleInstanceGuard,
@@ -101,101 +102,11 @@ def screen_marker(screen):
 
 
 # ---------------------------
-# Win32 desktop / WorkerW helpers
+# Win32 desktop helpers
 # ---------------------------
-
-user32 = ctypes.windll.user32
-
-SendMessageTimeoutW = user32.SendMessageTimeoutW
-EnumWindows = user32.EnumWindows
-FindWindowW = user32.FindWindowW
-FindWindowExW = user32.FindWindowExW
-SetParent = user32.SetParent
-ShowWindow = user32.ShowWindow
-SetWindowPos = user32.SetWindowPos
-GetWindowLongPtrW = user32.GetWindowLongPtrW
-SetWindowLongPtrW = user32.SetWindowLongPtrW
-
-SMTO_NORMAL = 0x0000
-SW_SHOW = 5
-
-HWND_BOTTOM = 1
-SWP_NOSIZE = 0x0001
-SWP_NOMOVE = 0x0002
-SWP_NOACTIVATE = 0x0010
-SWP_SHOWWINDOW = 0x0040
-SWP_NOOWNERZORDER = 0x0200
-SWP_NOSENDCHANGING = 0x0400
-
-GWL_EXSTYLE = -20
-WS_EX_TOOLWINDOW = 0x00000080
-WS_EX_TRANSPARENT = 0x00000020
-WS_EX_NOACTIVATE = 0x08000000
 
 WM_NCHITTEST = 0x0084
 HTTRANSPARENT = -1
-
-WNDENUMPROC = ctypes.WINFUNCTYPE(ctypes.c_bool, wintypes.HWND, wintypes.LPARAM)
-
-
-def get_workerw():
-    progman = FindWindowW("Progman", None)
-    if progman:
-        result = wintypes.DWORD()
-        SendMessageTimeoutW(
-            progman,
-            0x052C,
-            0,
-            0,
-            SMTO_NORMAL,
-            1000,
-            ctypes.byref(result)
-        )
-
-    workerw = None
-
-    @WNDENUMPROC
-    def enum_windows_proc(hwnd, lParam):
-        nonlocal workerw
-        shell_def_view = FindWindowExW(hwnd, None, "SHELLDLL_DefView", None)
-        if shell_def_view:
-            possible = FindWindowExW(None, hwnd, "WorkerW", None)
-            if possible:
-                workerw = possible
-                return False
-        return True
-
-    EnumWindows(enum_windows_proc, 0)
-    return workerw
-
-
-def attach_window_to_desktop(hwnd):
-    workerw = get_workerw()
-    if not workerw:
-        return False
-
-    SetParent(hwnd, workerw)
-    ShowWindow(hwnd, SW_SHOW)
-    SetWindowPos(
-        hwnd,
-        HWND_BOTTOM,
-        0, 0, 0, 0,
-        SWP_NOMOVE | SWP_NOSIZE | SWP_NOACTIVATE | SWP_SHOWWINDOW | SWP_NOOWNERZORDER | SWP_NOSENDCHANGING
-    )
-    return True
-
-
-def make_window_noninteractive(hwnd):
-    exstyle = GetWindowLongPtrW(hwnd, GWL_EXSTYLE)
-    exstyle |= WS_EX_TRANSPARENT | WS_EX_NOACTIVATE | WS_EX_TOOLWINDOW
-    SetWindowLongPtrW(hwnd, GWL_EXSTYLE, exstyle)
-
-    SetWindowPos(
-        hwnd,
-        HWND_BOTTOM,
-        0, 0, 0, 0,
-        SWP_NOMOVE | SWP_NOSIZE | SWP_NOACTIVATE | SWP_SHOWWINDOW | SWP_NOOWNERZORDER | SWP_NOSENDCHANGING
-    )
 
 
 # ---------------------------
@@ -309,60 +220,6 @@ class BootSideWindow(BaseWindow):
 
     def set_body(self, text):
         self.body.setText(text)
-
-
-class DesktopVisualWindow(BaseWindow):
-    def __init__(self, screen, visual_html_path):
-        super().__init__(screen)
-        self.full_geo = screen.geometry()
-        self.compact_geo = self.compute_compact_geometry()
-
-        self.setStyleSheet("background-color: rgb(0, 0, 0);")
-        self.setGeometry(self.compact_geo)
-
-        root = QVBoxLayout(self)
-        root.setContentsMargins(0, 0, 0, 0)
-        root.setSpacing(0)
-
-        self.webview = QWebEngineView()
-        self.webview.setContextMenuPolicy(Qt.NoContextMenu)
-        self.webview.setFocusPolicy(Qt.NoFocus)
-        self.webview.setStyleSheet("background-color: rgb(0, 0, 0); border: none;")
-        self.webview.load(QUrl.fromLocalFile(os.path.abspath(visual_html_path)))
-
-        root.addWidget(self.webview)
-
-    def compute_compact_geometry(self):
-        g = self.screen_ref.geometry()
-
-        width = int(g.width() * 0.46)
-        height = int(g.height() * 0.68)
-
-        x = g.x() + (g.width() - width) // 2
-        y = g.y() + int((g.height() - height) * 0.40)
-
-        return QRect(x, y, width, height)
-
-    def prepare_desktop_geometry(self):
-        self.compact_geo = self.compute_compact_geometry()
-        self.setGeometry(self.compact_geo)
-
-    def set_visual_state(self, state_name):
-        js = f"window.setJarvisState && window.setJarvisState('{state_name}');"
-        self.webview.page().runJavaScript(js)
-
-    def set_voice_level(self, level):
-        level = max(0.0, min(1.0, float(level)))
-        js = f"window.setJarvisVoiceLevel && window.setJarvisVoiceLevel({level:.4f});"
-        self.webview.page().runJavaScript(js)
-
-    def fade_in(self, start_opacity=0.0, end_opacity=1.0, duration_ms=900):
-        self.setWindowOpacity(start_opacity)
-        self.fade_in_anim = QPropertyAnimation(self, b"windowOpacity")
-        self.fade_in_anim.setDuration(duration_ms)
-        self.fade_in_anim.setStartValue(start_opacity)
-        self.fade_in_anim.setEndValue(end_opacity)
-        self.fade_in_anim.start()
 
 
 class JarvisBootCenterWindow(BaseWindow):
@@ -632,6 +489,7 @@ class JarvisSystem:
         self.command_lock = threading.Lock()
 
         self.hotkeys_pressed = set()
+        self.command_overlay_hotkey_fired = False
         self.hotkey_listener = pynput_keyboard.Listener(
             on_press=self.on_key_press,
             on_release=self.on_key_release
@@ -662,7 +520,11 @@ class JarvisSystem:
 
         self.left_window = BootSideWindow(self.left_screen, "LEFT MODULE")
         self.boot_center_window = JarvisBootCenterWindow(self.center_screen, visual_html)
-        self.desktop_center_window = DesktopVisualWindow(self.center_screen, visual_html)
+        self.desktop_center_window = DesktopJarvisWindow(
+            self.center_screen,
+            visual_html,
+            event_logger=self.runtime_milestone,
+        )
         self.right_window = BootSideWindow(self.right_screen, "RIGHT MODULE")
 
         self.desktop_center_window.hide()
@@ -720,21 +582,52 @@ class JarvisSystem:
     def on_key_press(self, key):
         self.hotkeys_pressed.add(key)
         try:
+            ctrl_down = (
+                pynput_keyboard.Key.ctrl_l in self.hotkeys_pressed
+                or pynput_keyboard.Key.ctrl_r in self.hotkeys_pressed
+            )
+            alt_down = (
+                pynput_keyboard.Key.alt_l in self.hotkeys_pressed
+                or pynput_keyboard.Key.alt_r in self.hotkeys_pressed
+            )
+
             if (
-                (pynput_keyboard.Key.ctrl_l in self.hotkeys_pressed or pynput_keyboard.Key.ctrl_r in self.hotkeys_pressed)
+                ctrl_down
                 and
-                (pynput_keyboard.Key.alt_l in self.hotkeys_pressed or pynput_keyboard.Key.alt_r in self.hotkeys_pressed)
+                alt_down
                 and
                 pynput_keyboard.Key.end in self.hotkeys_pressed
             ):
                 self.runtime_milestone("BOOT_MAIN|HOTKEY_SHUTDOWN_TRIGGERED")
                 self.emit_bus(self.bus.shutdown_requested)
+
+            if (
+                ctrl_down
+                and
+                alt_down
+                and
+                pynput_keyboard.Key.home in self.hotkeys_pressed
+                and
+                not self.command_overlay_hotkey_fired
+            ):
+                self.command_overlay_hotkey_fired = True
+                if getattr(self.desktop_center_window, "desktop_mode", False):
+                    self.runtime_milestone("BOOT_MAIN|HOTKEY_COMMAND_OVERLAY_TRIGGERED")
+                    self.desktop_center_window.toggle_command_overlay()
         except Exception:
             pass
 
     def on_key_release(self, key):
         if key in self.hotkeys_pressed:
             self.hotkeys_pressed.remove(key)
+        if key in (
+            pynput_keyboard.Key.home,
+            pynput_keyboard.Key.ctrl_l,
+            pynput_keyboard.Key.ctrl_r,
+            pynput_keyboard.Key.alt_l,
+            pynput_keyboard.Key.alt_r,
+        ):
+            self.command_overlay_hotkey_fired = False
 
     def shutdown_interface(self):
         if self.shutdown_in_progress:
@@ -1216,10 +1109,7 @@ class JarvisSystem:
         self.runtime_milestone("BOOT_MAIN|DESKTOP_STATE_COMMITTED|state=dormant")
 
     def reinforce_desktop_mode(self):
-        hwnd = int(self.desktop_center_window.winId())
-        attach_window_to_desktop(hwnd)
-        make_window_noninteractive(hwnd)
-        self.desktop_center_window.lower()
+        self.desktop_center_window.reinforce_desktop_mode()
 
     def mark_desktop_settled(self):
         if self.desktop_settled_logged:

--- a/main.py
+++ b/main.py
@@ -1057,7 +1057,13 @@ class JarvisSystem:
     def begin_desktop_handoff(self):
         desktop_reveal_delay_ms = 140
         desktop_state_commit_delay_ms = 220
-        desktop_settle_delay_ms = desktop_reveal_delay_ms + desktop_state_commit_delay_ms + 320
+        # Let the renderer own its bounded post-attach stabilization passes so
+        # the Boot handoff does not keep re-positioning the desktop child for
+        # several extra seconds after transition begins.
+        desktop_settle_delay_ms = max(
+            desktop_reveal_delay_ms + desktop_state_commit_delay_ms + 320,
+            1150,
+        )
 
         self.desktop_center_window.prepare_desktop_geometry()
         self.desktop_center_window.setWindowOpacity(1.0)
@@ -1066,11 +1072,6 @@ class JarvisSystem:
         self.runtime_milestone("BOOT_MAIN|DESKTOP_SHOWN")
 
         self.desktop_center_window.enable_desktop_mode()
-        self.reinforce_desktop_mode()
-        QTimer.singleShot(300, self.reinforce_desktop_mode)
-        QTimer.singleShot(900, self.reinforce_desktop_mode)
-        QTimer.singleShot(2200, self.reinforce_desktop_mode)
-        QTimer.singleShot(5000, self.reinforce_desktop_mode)
         QTimer.singleShot(desktop_settle_delay_ms, self.mark_desktop_settled)
 
         self.boot_center_window.enter_background_visual_mode()


### PR DESCRIPTION
## Summary

This PR delivers the validated `v2.2.1` stabilization line without the later ORIN rebrand work.

## What Changed

### What this PR does

This PR delivers the validated `v2.2.1` stabilization line without the later ORIN rebrand work.

Included in this branch:
- first typed-first `FB-027` desktop interaction slice
- `Ctrl+Alt+Home` command overlay toggle
- typed command entry with explicit confirmation before execution
- minimal direct-action / alias resolution
- brief result state and passive desktop return
- route parity between manual desktop launcher and Boot handoff
- desktop host positioning fixes
- command overlay input-ownership fixes
- reduced Boot desktop handoff reset churn

### What was validated

Validated across both launch routes:
- Route 1: normal desktop launcher path
- Route 2: Boot Jarvis auto-handoff path

Confirmed in the stabilized slice:
- desktop render visibility works in both routes
- `Ctrl+Alt+Home` opens the command overlay
- `Ctrl+Alt+End` shutdown behavior remains unchanged
- command overlay no longer globally captures typing
- command overlay appears below Jarvis and centered
- passive desktop behavior returns after overlay close
- Boot handoff no longer shows the earlier long multi-second reset churn

### What this PR does

Included in this branch:
- first typed-first `FB-027` desktop interaction slice
- `Ctrl+Alt+Home` command overlay toggle
- typed command entry with explicit confirmation before execution
- minimal direct-action / alias resolution
- brief result state and passive desktop return
- route parity between manual desktop launcher and Boot handoff
- desktop host positioning fixes
- command overlay input-ownership fixes
- reduced Boot desktop handoff reset churn

### What was validated

Validated across both launch routes:
- Route 1: normal desktop launcher path
- Route 2: Boot Jarvis auto-handoff path

Confirmed in the stabilized slice:
- desktop render visibility works in both routes
- `Ctrl+Alt+Home` opens the command overlay
- `Ctrl+Alt+End` shutdown behavior remains unchanged
- command overlay no longer globally captures typing
- command overlay appears below Jarvis and centered
- passive desktop behavior returns after overlay close
- Boot handoff no longer shows the earlier long multi-second reset churn
