### PR TITLE
Close out v2.2.1 and sync FB-027 first slice

### DIFF
--- a/Docs/Main.md
+++ b/Docs/Main.md
@@ -80,6 +80,7 @@ These docs are still valid, but they are not part of the default prompt baseline
 - `docs/v1.9.0_closeout.md`
 - `docs/v2.0_closeout.md`
 - `docs/v2.2.0_closeout.md`
+- `docs/v2.2.1_closeout.md`
 
 Use them when the task depends on:
 

--- a/Docs/feature_backlog.md
+++ b/Docs/feature_backlog.md
@@ -1081,10 +1081,10 @@ This landed as a bounded dev-tools-only intake slice and did not change producti
 
 ### [ID: FB-027] Jarvis interaction surfaces and shared action model
 
-Status: Deferred  
+Status: Deferred (first pre-Beta slice implemented in v2.2.1 rev1)  
 Priority: High  
 Suggested Version: TBD  
-Suggested Revision: rev1  
+Suggested Revision: rev2  
 Release Stage: Slice-staged  
 
 Description:
@@ -1120,9 +1120,19 @@ Out of Scope:
 Notes:
 Current planning truth already lives in `docs/jarvis_interaction_architecture.md`.
 
+Current repo truth now includes the first implemented `pre-Beta` slice in `v2.2.1 rev1`:
+
+- `Ctrl+Alt+Home` opens and closes a dismissible desktop quick-command overlay
+- typed command entry now exists inside the controlled desktop runtime through a local click-armed input surface rather than global printable-key capture
+- a minimal direct-action / alias model resolves exact title-or-alias matches for the first bounded desktop command set
+- one unique match enters explicit confirmation before execution
+- zero-match and ambiguous-match outcomes stay non-executing and visible inside the overlay
+- confirmed execution shows a brief result state and then returns the desktop to passive mode
+- directly supportive route-parity and stability follow-through in the same lane closed desktop host positioning, overlay input-ownership, and Boot-handoff reset-churn issues for the first slice
+
 Release-stage mapping:
 
-- `pre-Beta`: typed-first interaction foundation, including the quick command overlay, natural-language typed entry, minimal shared action model, direct actions and saved aliases, and desktop-mode command confirmation before execution
+- `pre-Beta`: first typed-first interaction foundation slice is now implemented in `v2.2.1 rev1`; later pre-Beta work remains limited to additional interaction-model follow-through above the same desktop overlay foundation
 - `Beta`: packaged and installable user-facing release with practical setup expectations and broader customization beyond the first internal slice
 - `Full`: later wake-word voice invocation, richer routines and profiles, and any future plugin capability if the shared action model proves stable enough
 

--- a/Docs/v2.2.1_closeout.md
+++ b/Docs/v2.2.1_closeout.md
@@ -1,0 +1,106 @@
+# Jarvis v2.2.1 Closeout
+
+## Version
+
+v2.2.1
+
+## Scope
+
+Contained interaction-foundation and desktop-stability closeout for the `v2.2.1` lane.
+
+This version stayed intentionally contained to:
+
+- the first `pre-Beta` `FB-027` typed-first desktop interaction slice
+- the minimum route-parity and stability follow-through needed to make that slice behave consistently across the normal desktop launcher path and the Boot handoff path
+- exact source-of-truth sync for the merged lane
+
+It did not reopen workspace follow-through, shutdown voice work, taxonomy cleanup, dev-tool upload work, ORIN rebrand work, or broader `FB-027` roadmap slices.
+
+---
+
+## What Is Complete
+
+### `FB-027` First `pre-Beta` Desktop Interaction Slice
+
+* `Ctrl+Alt+Home` now opens and closes a dismissible desktop quick-command overlay
+* the first typed command-entry surface now exists inside desktop mode
+* the current first-slice action model stays intentionally minimal and local:
+  * exact title-or-alias resolution only
+  * direct actions and saved aliases only
+* one unique match enters explicit confirmation before execution
+* zero-match and ambiguous-match outcomes stay non-executing and visible inside the overlay
+* confirmed execution shows a brief result state and then returns the desktop to passive mode
+
+### Route Parity And Stability Follow-Through
+
+* the manual desktop launcher path and the Boot handoff path now share the same stabilized desktop renderer behavior
+* desktop host positioning and route-parity issues for the new interaction surface were closed
+* overlay input ownership now stays local to the desktop command surface rather than relying on global printable-key capture
+* Boot handoff no longer keeps re-positioning the desktop child window through the earlier long reset-churn pattern
+
+### Source-Of-Truth Alignment
+
+* `docs/feature_backlog.md` now records that `FB-027` has landed its first `pre-Beta` slice in `v2.2.1 rev1`
+* `docs/Main.md` can now use this closeout as the latest stable optional closeout baseline for `v2.2.x` sequencing questions
+
+---
+
+## Current Guarantees
+
+* `main.py` remains the dev-only Boot Jarvis harness
+* `launch_jarvis_desktop.vbs` remains the normal manual user launch
+* the controlled desktop path remains:
+  * `desktop/jarvis_desktop_launcher.pyw`
+  * `desktop/jarvis_desktop_main.py`
+* `Ctrl+Alt+End` shutdown behavior remains unchanged
+* the first `FB-027` slice remains typed-first and desktop-local
+* desktop command execution still requires explicit confirmation before launch
+
+---
+
+## What Is Intentionally Not Implemented
+
+* wake-word or speech-to-text implementation
+* voice execution
+* Action Studio
+* routines, profiles, or plugins
+* broader runtime-status/history surfaces beyond the bounded first overlay slice
+* boot/access redesign
+* ORIN rebrand or persona work
+
+---
+
+## Deferred Beyond This Version
+
+* later `pre-Beta` `FB-027` follow-through above the same typed-first desktop interaction foundation
+* `Beta` packaging, installation, and broader customization work
+* later `Full` voice-parity, richer routines/profiles, and any future plugin capability
+* all unrelated deferred lanes that remained untouched by this release line
+
+---
+
+## Final Audit Outcome
+
+The `v2.2.1` lane is coherent across:
+
+* the merged first `FB-027` desktop interaction slice
+* the current interaction canon in `docs/jarvis_interaction_architecture.md`
+* the route-parity and stability follow-through in the shared desktop renderer path
+* the preserved launcher and Boot-entry ownership boundaries
+
+No contradiction remains across those surfaces.
+
+Observed version-level behavior is consistent:
+
+* the first typed-first desktop interaction slice is implemented
+* confirmation-before-execution remains enforced
+* route-parity and desktop-host follow-through remain bounded to the active slice
+* later `FB-027` work remains explicitly deferred rather than implicitly queued
+
+---
+
+## Final Status
+
+`v2.2.1` is complete enough to close out at the current layer.
+
+The next safe move after this closeout is `v2.2.2` lane selection, not automatic continuation inside the `v2.2.1` slice.


### PR DESCRIPTION
## Summary

This is a docs-only post-merge truth-sync pass for the merged `v2.2.1` release line.

## What Changed

### What this PR does

This is a docs-only post-merge truth-sync pass for the merged `v2.2.1` release line.

Included:
- sync `FB-027` in `Docs/feature_backlog.md` to reflect the landed first `pre-Beta` slice
- add `Docs/v2.2.1_closeout.md`
- add the new closeout doc to `Docs/Main.md`

### Why this is needed

`v2.2.1` was merged cleanly and tagged, but the implementation PR intentionally left docs and backlog unchanged.
This PR closes that gap so the source-of-truth docs match the merged release baseline.

### Result

After this PR merges:
- `v2.2.1` will be fully closed out in docs
- `FB-027` will accurately reflect the implemented first slice
- future prompts can use `Docs/v2.2.1_closeout.md` as the latest closeout baseline

### What this PR does

Included:
- sync `FB-027` in `Docs/feature_backlog.md` to reflect the landed first `pre-Beta` slice
- add `Docs/v2.2.1_closeout.md`
- add the new closeout doc to `Docs/Main.md`

### Why this is needed

`v2.2.1` was merged cleanly and tagged, but the implementation PR intentionally left docs and backlog unchanged.
This PR closes that gap so the source-of-truth docs match the merged release baseline.

### Result

After this PR merges:
- `v2.2.1` will be fully closed out in docs
- `FB-027` will accurately reflect the implemented first slice
- future prompts can use `Docs/v2.2.1_closeout.md` as the latest closeout baseline
