### PR TITLE
Correct pre-Beta baseline tag convention

### DIFF
--- a/Docs/orin_vision.md
+++ b/Docs/orin_vision.md
@@ -114,7 +114,8 @@ The Nexus public release line begins after the preserved Jarvis historical relea
 For the first Nexus public release baseline:
 
 - first public release title: `Nexus Desktop AI — Pre-Beta v1.0.0`
-- first public tag: `v1.0.0-prebeta.1`
+- first public tag: `v1.0.0-prebeta`
+- next release after that: `v1.0.1-prebeta`
 - all `pre-Beta` and `Beta` GitHub releases must be published as prereleases
 - old Jarvis-tagged releases and tags remain preserved as legacy/internal historical records
 - old Jarvis-tagged releases and tags do not define the active Nexus public line

--- a/desktop/orin_support_reporting.py
+++ b/desktop/orin_support_reporting.py
@@ -15,7 +15,7 @@ MANIFEST_FILENAME = "manifest.json"
 VERSION_CLOSEOUT_PATTERN = re.compile(r"^v(\d+)\.(\d+)\.(\d+)_closeout\.md$")
 PLANNED_PUBLIC_RELEASE_LABEL = (
     "Pre-Beta baseline defined; planned first public release: "
-    "Nexus Desktop AI — Pre-Beta v1.0.0 (tag: v1.0.0-prebeta.1)"
+    "Nexus Desktop AI — Pre-Beta v1.0.0 (tag: v1.0.0-prebeta)"
 )
 
 


### PR DESCRIPTION
## Summary

This PR applies the tiny Nexus public-release baseline correction.

## What Changed

### Changes

It updates the repo-side release baseline so it now correctly uses:
- first public tag: `v1.0.0-prebeta`
- next planned release: `v1.0.1-prebeta`

It also removes the outdated `.1` suffix from support/reporting posture.

### Files Changed
- `Docs/orin_vision.md`
- `desktop/orin_support_reporting.py`

### Why
The earlier baseline used the older drafted tag convention `v1.0.0-prebeta.1`, but the approved release scheme is now:
- `v1.0.0-prebeta`
- `v1.0.1-prebeta`
- future pre-Beta releases continue as `vMAJOR.MINOR.PATCH-prebeta`

### Changes

It updates the repo-side release baseline so it now correctly uses:
- first public tag: `v1.0.0-prebeta`
- next planned release: `v1.0.1-prebeta`

### Files Changed
- `Docs/orin_vision.md`
- `desktop/orin_support_reporting.py`

### Why
The earlier baseline used the older drafted tag convention `v1.0.0-prebeta.1`, but the approved release scheme is now:
- `v1.0.0-prebeta`
- `v1.0.1-prebeta`
- future pre-Beta releases continue as `vMAJOR.MINOR.PATCH-prebeta`
