### PR TITLE
FB-027 rev2 — Add ambiguous-match selection to the ORIN command overlay

### DIFF
--- a/Docs/orin_interaction_architecture.md
+++ b/Docs/orin_interaction_architecture.md
@@ -159,6 +159,35 @@ The purpose of this confirmation is:
 This planning contract does not define the exact UI phrasing, visual layout, or confirmation-control mechanics.
 It only defines the product rule that desktop-mode command execution should be explicitly confirmed before Jarvis runs the resolved action.
 
+### Confirmation Clarity For Paths And Targets
+
+When the resolved action points to a file, folder, URL, app target, or other path-sensitive destination, the confirmation surface should make the destination understandable before execution.
+
+At planning level, that means:
+
+- show enough target detail that the user can tell what will open or run
+- use a compact or truncated path display when the full raw path would be visually noisy
+- avoid hiding the important distinguishing part of the target when multiple similar choices exist
+
+The purpose of this rule is:
+
+- to keep confirmation useful instead of decorative
+- to help the user understand why one match differs from another
+- to reduce accidental launches when multiple choices are similar
+
+## Nexus-Era User-Facing Naming Rule
+
+For Nexus Desktop AI / ORIN-era interaction surfaces, user-facing command labels and choices should prefer current Nexus-era naming rather than legacy Jarvis branding unless the user is explicitly interacting with preserved historical context.
+
+This means future command-surface work should trend toward:
+
+- Nexus-facing names for Nexus-facing actions
+- ORIN-facing assistant presentation where assistant identity matters
+- avoiding legacy Jarvis naming in normal Nexus-facing command choices
+
+This is a user-facing interaction rule only.
+It does not authorize historical rewrite of preserved Jarvis release history.
+
 ## Customization Contract
 
 Jarvis customization should allow users to define:
@@ -177,6 +206,18 @@ At planning level, this contract should support user-defined targets like:
 - `Open Work Setup`
 
 without forcing every user into the same built-in command map.
+
+As the interaction model grows, customization should also allow bounded preference control over supported web-facing actions, such as:
+
+- which browser Nexus uses for supported search or web actions
+- which user-approved external web destination should be used when more than one valid route exists
+
+Those later capabilities should remain:
+
+- user-controlled
+- explicit
+- privacy-aware
+- downstream of the same shared action model rather than separate hardcoded pathways
 
 ## Release-Stage Model
 
@@ -236,9 +277,11 @@ At planning level, the Full release may later expand into:
 
 - wake-word voice invocation
 - stronger voice parity with typed commands
+- optional spoken response or confirmation support for more hands-free interaction
 - richer saved routines and environment profiles
 - more advanced customization surfaces
 - import/export or sharing of user-defined actions
+- bounded user-approved external-assistant or web handoff actions if they remain privacy-aware and clearly inspectable
 - future plugin capability if the shared action model proves stable enough
 
 These later additions should remain downstream of the same shared action system rather than becoming parallel products.

--- a/Docs/orin_vision.md
+++ b/Docs/orin_vision.md
@@ -133,6 +133,20 @@ Jarvis should behave conservatively first:
 Jarvis should not behave like a script.
 Jarvis should behave like a system that understands its own state.
 
+## Privacy And User Control Direction
+
+As Nexus Desktop AI grows beyond the first pre-Beta command slices, privacy and user control should remain first-class product constraints rather than later add-ons.
+
+At planning level, that means future Nexus-era behavior should prefer:
+
+- explicit user choice over hidden third-party routing
+- user-visible control over supported browser or web-destination preferences
+- minimizing unnecessary third-party tracking exposure where practical
+- clear user understanding of when Nexus is invoking a local action versus handing off to an external web or assistant surface
+
+This direction does not authorize immediate implementation of browser-routing features, tracking-blocking mechanics, or external-assistant integrations.
+It exists to preserve the intended product posture for later bounded planning and implementation work.
+
 ## Product Direction Reminder
 
 The current desktop launcher path is a foundation layer, not the final identity of the product.

--- a/Docs/user_test_summary_guidance.md
+++ b/Docs/user_test_summary_guidance.md
@@ -5,7 +5,7 @@
 This document is the canonical source-of-truth guidance for when Jarvis work should produce:
 
 - a user-facing `User Test Summary` in the response
-- a desktop `.txt` test-instructions file for the user
+- the desktop `User Test Summary.txt` file for the user
 
 It exists so future Codex work follows one consistent manual-test handoff model instead of recreating that behavior ad hoc in chat history.
 
@@ -21,21 +21,24 @@ Create a `User Test Summary` whenever the active task results in a user-visible 
 
 Do not add a separate `User Test Summary` for purely internal analysis or for docs-only work that does not require the user to run anything.
 
-## When A Desktop `.txt` Test File Is Needed
+## When The Desktop `User Test Summary.txt` File Is Needed
 
-Create a desktop `.txt` test-instructions file when:
+Create or update the desktop `User Test Summary.txt` file when:
 
 - the user explicitly asks for one
 - the manual test steps are long enough that a durable desktop copy will help
 - the task depends on a multi-step launch or validation flow that the user is likely to follow outside the chat window
 - the task uses a Dev Toolkit lane or helper and the exact launch/test metadata must be preserved cleanly
 
-The desktop `.txt` file should:
+The desktop file should:
 
 - mirror the user-facing manual steps given in the response
-- use a clear slice- or workstream-based filename
 - be written to the desktop location the user actually sees
 - prefer the visible OneDrive desktop path when the machine uses a OneDrive-backed desktop
+- use one uniform filename:
+  - `C:\Users\anden\OneDrive\Desktop\User Test Summary.txt`
+- be treated as the rolling current test handoff file rather than creating a new filename for each slice
+- be overwritten or refreshed with the newest test instructions whenever a new user-visible test handoff replaces the old one
 
 ## Required Dev Toolkit Metadata
 
@@ -46,7 +49,7 @@ If the user is asked to run a Dev Toolkit instruction, the `User Test Summary` m
 - `Test / Helper`
 - `Delay`
 
-The desktop `.txt` file should carry the same four fields exactly when it is created for a Dev Toolkit run.
+The desktop `User Test Summary.txt` file should carry the same four fields exactly when it is created or refreshed for a Dev Toolkit run.
 
 For Dev Toolkit runs, these fields must be copied from the visible Dev Toolkit dropdown selections exactly as shown in the UI.
 
@@ -64,15 +67,19 @@ Do not replace these four fields with paraphrases such as:
 
 If a Dev Toolkit run is part of the handoff, the user-facing steps should also tell the user which exact dropdown options to choose before launching the lane.
 
-## Filename Guidance
+## Desktop File Convention
 
-Use a clear slice- or workstream-based desktop filename, for example:
+Use one stable desktop filename for user-facing manual test handoff:
 
-- `Nexus_Desktop_AI_Slice1_User_Test_Summary.txt`
-- `ORIN_Boot_Path_Slice2_User_Test_Summary.txt`
-- `Dev_Toolkit_Boot_Helper_User_Test_Summary.txt`
+- `C:\Users\anden\OneDrive\Desktop\User Test Summary.txt`
 
-Prefer stable, readable filenames over generic names like `test.txt` or `notes.txt`.
+Do not create a new slice-specific or workstream-specific desktop filename unless the user explicitly asks for a separate durable record.
+
+Default rule:
+
+- one rolling desktop file
+- same visible filename every time
+- newest active manual-test instructions replace the previous contents
 
 ## Response Rule
 
@@ -84,7 +91,8 @@ When a `User Test Summary` is needed:
 - avoid redundant adjacent steps that sound like the same action unless the second step clearly explains the additional verification target
 - when two nearby steps are related but not identical, state the distinction directly so the user knows whether the second step means "launch it" versus "confirm a separate behavior after launch"
 
-When a desktop `.txt` file is also created:
+When the desktop `User Test Summary.txt` file is also created or refreshed:
 
 - keep the response summary and desktop file aligned
 - do not let the desktop file contain extra hidden requirements that were not shown to the user in the response
+- reference the same desktop file path in the response rather than inventing a new filename for the current slice

--- a/Docs/user_test_summary_guidance.md
+++ b/Docs/user_test_summary_guidance.md
@@ -9,6 +9,8 @@ This document is the canonical source-of-truth guidance for when Jarvis work sho
 
 It exists so future Codex work follows one consistent manual-test handoff model instead of recreating that behavior ad hoc in chat history.
 
+Returned `User Test Summary` files must be treated as active evidence inputs, not as disposable notes.
+
 ## When A User Test Summary Is Needed
 
 Create a `User Test Summary` whenever the active task results in a user-visible validation handoff, especially when the user needs to:
@@ -39,6 +41,73 @@ The desktop file should:
   - `C:\Users\anden\OneDrive\Desktop\User Test Summary.txt`
 - be treated as the rolling current test handoff file rather than creating a new filename for each slice
 - be overwritten or refreshed with the newest test instructions whenever a new user-visible test handoff replaces the old one
+
+## Required Structure For The Desktop File
+
+When the desktop `User Test Summary.txt` file is created or refreshed, it should prefer this structure:
+
+- `Workstream`
+- `What This Test Is Checking`
+- `Expected Outcome`
+- `Test Steps`
+- `Observed Results`
+- `New Ideas / Requests Raised During Testing`
+- `Questions / Confusions Raised During Testing`
+- `Regression Notes`
+
+For any step that expects a user reply, the file should include an explicit response slot directly under that step, such as:
+
+- `Response:`
+- `Notes:`
+
+Do not force the user to guess where feedback should go.
+Do not make the user answer the same validation question again later in a second redundant section.
+
+If a later summary section exists, it should synthesize the step responses rather than repeat the same yes/no prompts.
+
+## User Additions During Testing
+
+User additions raised during testing must not be silently discarded just because they appear inside the `User Test Summary.txt` file.
+
+These additions may include:
+
+- new product ideas
+- new constraints
+- naming concerns
+- hotkey requests
+- privacy expectations
+- clarification requests
+- newly noticed bugs or regressions
+
+Codex should preserve those additions in the file under a clearly separate section such as:
+
+- `New Ideas / Requests Raised During Testing`
+- `Questions / Confusions Raised During Testing`
+- `Regression Notes`
+
+This separation is important:
+
+- test-result evidence should stay readable as test evidence
+- new ideas should still be captured for later digestion
+
+## Digest Rule After Submission
+
+After the user returns a filled `User Test Summary.txt`, Codex must explicitly digest it before recommending the next move.
+
+That digest should separate:
+
+- what passed
+- what failed
+- what remained unclear or confusing
+- what new ideas or requests were introduced during testing
+- what belongs to the current slice
+- what should be deferred into backlog or future source-of-truth consideration
+
+Codex must not:
+
+- ignore newly introduced user requests
+- treat every new idea as automatically in scope for the current patch
+- leave the file unanalyzed after the user submits it
 
 ## Required Dev Toolkit Metadata
 
@@ -88,6 +157,7 @@ When a `User Test Summary` is needed:
 - keep it short and action-oriented
 - include expected results, not just steps
 - explicitly call out anything that is intentionally not part of the current slice
+- keep the step wording concrete enough that the user can tell what visual or runtime outcome they are supposed to confirm
 - avoid redundant adjacent steps that sound like the same action unless the second step clearly explains the additional verification target
 - when two nearby steps are related but not identical, state the distinction directly so the user knows whether the second step means "launch it" versus "confirm a separate behavior after launch"
 
@@ -96,3 +166,4 @@ When the desktop `User Test Summary.txt` file is also created or refreshed:
 - keep the response summary and desktop file aligned
 - do not let the desktop file contain extra hidden requirements that were not shown to the user in the response
 - reference the same desktop file path in the response rather than inventing a new filename for the current slice
+- make sure any prompted user response line has a visible blank line or direct `Response:` slot under it

--- a/desktop/desktop_renderer.py
+++ b/desktop/desktop_renderer.py
@@ -11,6 +11,7 @@ from PySide6.QtWidgets import (
     QLineEdit,
     QHBoxLayout,
     QGridLayout,
+    QPushButton,
 )
 from PySide6.QtCore import Qt, QTimer, QUrl, QRect, Signal
 from PySide6.QtGui import QColor
@@ -103,6 +104,7 @@ class CommandOverlayPanel(QWidget):
     escape_requested = Signal()
     input_text_changed = Signal(str)
     input_armed_changed = Signal(bool)
+    ambiguous_match_selected = Signal(int)
 
     def __init__(self):
         super().__init__(None, Qt.FramelessWindowHint | Qt.Tool)
@@ -171,6 +173,14 @@ class CommandOverlayPanel(QWidget):
         self.ambiguous_label.setObjectName("commandAmbiguous")
         self.ambiguous_label.setWordWrap(True)
         layout.addWidget(self.ambiguous_label)
+
+        self.ambiguous_choices_frame = QFrame(self.panel)
+        self.ambiguous_choices_frame.setObjectName("commandAmbiguousChoices")
+        self.ambiguous_choices_layout = QVBoxLayout(self.ambiguous_choices_frame)
+        self.ambiguous_choices_layout.setContentsMargins(0, 8, 0, 0)
+        self.ambiguous_choices_layout.setSpacing(8)
+        layout.addWidget(self.ambiguous_choices_frame)
+        self.ambiguous_choices_frame.hide()
 
         self.confirmation_frame = QFrame(self.panel)
         self.confirmation_frame.setObjectName("commandConfirmation")
@@ -290,6 +300,22 @@ class CommandOverlayPanel(QWidget):
                 color: rgba(255, 222, 154, 0.90);
                 font-size: 13px;
             }
+            #commandAmbiguousChoices {
+                margin-top: 2px;
+            }
+            QPushButton[choiceRole="ambiguous"] {
+                padding: 10px 14px;
+                border-radius: 14px;
+                border: 1px solid rgba(255, 222, 154, 0.28);
+                background: rgba(32, 24, 10, 180);
+                color: rgba(255, 239, 198, 0.96);
+                text-align: left;
+                font-size: 13px;
+            }
+            QPushButton[choiceRole="ambiguous"]:hover {
+                border: 1px solid rgba(255, 222, 154, 0.44);
+                background: rgba(44, 30, 12, 214);
+            }
             #commandConfirmation {
                 margin-top: 18px;
                 border-radius: 18px;
@@ -361,11 +387,30 @@ class CommandOverlayPanel(QWidget):
     def focus_input(self):
         self.input_line.setFocus(Qt.MouseFocusReason)
 
+    def _clear_ambiguous_choice_buttons(self):
+        while self.ambiguous_choices_layout.count():
+            item = self.ambiguous_choices_layout.takeAt(0)
+            widget = item.widget()
+            if widget is not None:
+                widget.deleteLater()
+
+    def _populate_ambiguous_choice_buttons(self, matches: list[dict]):
+        self._clear_ambiguous_choice_buttons()
+        for match in matches:
+            index = int(match.get("index", -1))
+            title = match.get("title", "")
+            target_kind = match.get("target_kind", "")
+            button = QPushButton(f"{index + 1}. {title} ({target_kind})", self.ambiguous_choices_frame)
+            button.setProperty("choiceRole", "ambiguous")
+            button.clicked.connect(lambda _checked=False, idx=index: self.ambiguous_match_selected.emit(idx))
+            self.ambiguous_choices_layout.addWidget(button)
+        self.ambiguous_choices_frame.setVisible(bool(matches))
+
     def render_payload(self, payload: dict):
         payload = payload or {}
         phase = payload.get("phase", "hidden")
         armed = bool(payload.get("input_armed")) and phase == "entry"
-        locked = phase in {"confirm", "result"}
+        locked = phase in {"choose", "confirm", "result"}
 
         self.input_shell.setProperty("armed", "true" if armed else "false")
         self.input_shell.setProperty("locked", "true" if locked else "false")
@@ -384,6 +429,8 @@ class CommandOverlayPanel(QWidget):
 
         if phase == "confirm":
             self.hint_label.setText("Review the resolved action before execution.")
+        elif phase == "choose":
+            self.hint_label.setText("Choose the intended saved action, then confirm it before launch.")
         elif phase == "result":
             self.hint_label.setText("Returning to passive desktop mode.")
         else:
@@ -406,7 +453,11 @@ class CommandOverlayPanel(QWidget):
             self.status_label.setText("")
 
         titles = payload.get("ambiguous_titles") or []
-        self.ambiguous_label.setText(f"Matches: {' | '.join(titles)}" if titles else "")
+        if phase == "choose" and titles:
+            self.ambiguous_label.setText("Multiple saved actions matched your request.")
+        else:
+            self.ambiguous_label.setText(f"Matches: {' | '.join(titles)}" if titles else "")
+        self._populate_ambiguous_choice_buttons(payload.get("ambiguous_matches") or [])
 
         action = payload.get("pending_action") or {}
         show_confirm = phase == "confirm" and bool(action)
@@ -440,6 +491,7 @@ class DesktopRuntimeWindow(QWidget):
         self._command_panel.escape_requested.connect(self.handle_command_escape)
         self._command_panel.input_text_changed.connect(self.handle_command_text_changed)
         self._command_panel.input_armed_changed.connect(self.handle_command_input_armed_changed)
+        self._command_panel.ambiguous_match_selected.connect(self.handle_ambiguous_match_selected)
         self._result_close_timer = QTimer(self)
         self._result_close_timer.setSingleShot(True)
         self._result_close_timer.timeout.connect(self._close_command_overlay_after_result)
@@ -659,6 +711,7 @@ class DesktopRuntimeWindow(QWidget):
             self.compute_compact_geometry(),
             self.screen_ref.availableGeometry(),
         )
+        self._command_panel.focus_input()
         self._log_event("RENDERER_MAIN|COMMAND_OVERLAY_OPENED")
 
     def close_command_overlay(self):
@@ -691,6 +744,11 @@ class DesktopRuntimeWindow(QWidget):
         result = self._command_model.escape()
         self._apply_command_overlay_state()
 
+        if result == "choice_cancelled":
+            self._command_panel.focus_input()
+            self._log_event("RENDERER_MAIN|COMMAND_DISAMBIGUATION_CANCELLED")
+            return
+
         if result == "confirm_cancelled":
             self._command_panel.focus_input()
             self._log_event("RENDERER_MAIN|COMMAND_CONFIRM_CANCELLED")
@@ -707,6 +765,19 @@ class DesktopRuntimeWindow(QWidget):
 
     def _close_command_overlay_after_result(self):
         self.close_command_overlay()
+
+    def handle_ambiguous_match_selected(self, index: int):
+        result, payload = self._command_model.choose_match(index)
+        self._apply_command_overlay_state()
+
+        if result != "confirm_ready":
+            return
+
+        self._command_panel.setFocus(Qt.ActiveWindowFocusReason)
+        self._log_event(
+            f"RENDERER_MAIN|COMMAND_DISAMBIGUATION_SELECTED|index={index}|action_id={payload.id}"
+        )
+        self._log_event(f"RENDERER_MAIN|COMMAND_CONFIRM_READY|action_id={payload.id}")
 
     def handle_command_submit(self):
         result, payload = self._command_model.submit()

--- a/desktop/interaction_overlay_model.py
+++ b/desktop/interaction_overlay_model.py
@@ -141,6 +141,15 @@ class CommandOverlayModel:
         if not self.visible:
             return "ignored"
 
+        if self.phase == "choose":
+            self.phase = "entry"
+            self.input_armed = True
+            self.status_kind = "idle"
+            self.status_text = ""
+            self.pending_action = None
+            self.pending_matches = ()
+            return "choice_cancelled"
+
         if self.phase == "confirm":
             self.phase = "entry"
             self.input_armed = True
@@ -186,14 +195,31 @@ class CommandOverlayModel:
                 self.status_text = "No saved action or alias matched that request."
                 return ("not_found", None)
 
+            self.phase = "choose"
+            self.input_armed = False
             self.status_kind = "ambiguous"
-            self.status_text = "Multiple saved actions matched that request."
+            self.status_text = "Select the intended action below."
             return ("ambiguous", matches)
 
         if self.phase == "confirm" and self.pending_action is not None:
             return ("execute_confirmed", self.pending_action)
 
         return ("ignored", None)
+
+    def choose_match(self, index: int):
+        if not self.visible or self.phase != "choose":
+            return ("ignored", None)
+
+        if index < 0 or index >= len(self.pending_matches):
+            return ("ignored", None)
+
+        action = self.pending_matches[index]
+        self.phase = "confirm"
+        self.input_armed = False
+        self.pending_action = action
+        self.status_kind = "ready"
+        self.status_text = ""
+        return ("confirm_ready", action)
 
     def show_result(self, status_kind: str, status_text: str):
         self.phase = "result"
@@ -220,4 +246,16 @@ class CommandOverlayModel:
                 "target": action.target,
             },
             "ambiguous_titles": [match.title for match in self.pending_matches] if self.status_kind == "ambiguous" else [],
+            "ambiguous_matches": [
+                {
+                    "index": index,
+                    "id": match.id,
+                    "title": match.title,
+                    "target_kind": match.target_kind,
+                    "target": match.target,
+                }
+                for index, match in enumerate(self.pending_matches)
+            ]
+            if self.status_kind == "ambiguous"
+            else [],
         }


### PR DESCRIPTION
## Summary

This PR closes the current `FB-027 rev2` slice with one bounded interaction improvement and the directly supportive testing/canon follow-through that came out of user validation.

## What Changed

### Changes

Included in this branch:
- ambiguous typed-command matches no longer dead-end in the desktop overlay
- the overlay now enters a bounded choose state for ambiguous matches
- the user can select one matched action and then continue through the existing confirmation-before-execution flow
- no action launches without explicit confirmation
- rolling User Test Summary guidance is standardized for ongoing manual validation
- testing-driven interaction and privacy/product direction from the latest user test pass is carried into canon without forcing immediate implementation

### Runtime changes

Primary runtime files changed:
- `desktop/interaction_overlay_model.py`
- `desktop/desktop_renderer.py`

Behavior now confirmed:
- unique match still goes directly to the existing confirmation screen
- ambiguous match now shows a real choose state instead of dead-ending
- selecting one ambiguous match moves into the existing confirmation screen
- `Esc` from the choose state returns to entry with the typed request preserved
- zero-match still does not execute
- no action launches without explicit confirmation

### Supportive doc/canon changes

Supportive truth-carrying updates in this branch:
- `Docs/user_test_summary_guidance.md`
- `Docs/orin_interaction_architecture.md`
- `Docs/orin_vision.md`

These changes stay proportional to the implemented slice and preserve future direction without widening this workstream into broader interaction, voice, plugin, or privacy implementation work.

### Why now

This is the cleanest point to merge because the current slice is coherent, merge-ready, and the remaining follow-ups are separable improvements rather than blockers.

### Changes

Included in this branch:
- ambiguous typed-command matches no longer dead-end in the desktop overlay
- the overlay now enters a bounded choose state for ambiguous matches
- the user can select one matched action and then continue through the existing confirmation-before-execution flow
- no action launches without explicit confirmation
- rolling User Test Summary guidance is standardized for ongoing manual validation
- testing-driven interaction and privacy/product direction from the latest user test pass is carried into canon without forcing immediate implementation

### Runtime changes

Primary runtime files changed:
- `desktop/interaction_overlay_model.py`
- `desktop/desktop_renderer.py`

Behavior now confirmed:
- unique match still goes directly to the existing confirmation screen
- ambiguous match now shows a real choose state instead of dead-ending
- selecting one ambiguous match moves into the existing confirmation screen
- `Esc` from the choose state returns to entry with the typed request preserved
- zero-match still does not execute
- no action launches without explicit confirmation

### Supportive doc/canon changes

Supportive truth-carrying updates in this branch:
- `Docs/user_test_summary_guidance.md`
- `Docs/orin_interaction_architecture.md`
- `Docs/orin_vision.md`

### Why now
