### PR TITLE
FB-027 follow-through

### DIFF
--- a/Docs/Main.md
+++ b/Docs/Main.md
@@ -56,6 +56,7 @@ Use these when the task concerns:
 - backlog control
 - orchestration ownership
 - prompt or workflow governance, including batched-workstream execution rules
+- grouped-workstream branch strategy and multi-developer workflow boundaries
 
 ### Canonical Workstream Docs
 
@@ -180,6 +181,14 @@ For prompt-governance or workflow-governance tasks, prompts should usually inclu
 - `docs/user_test_summary_guidance.md`
 
 Add other canonical docs only if the governance wording depends on them.
+
+This governance lane includes:
+
+- user-test-summary handling rules
+- backlog-control rules
+- batched-workstream execution rules
+- grouped-workstream branch strategy for `pre-Beta`
+- multi-developer workflow and GitHub/tooling governance boundaries
 
 ## When To Add Closeout Docs
 

--- a/Docs/codex_modes.md
+++ b/Docs/codex_modes.md
@@ -212,6 +212,38 @@ Backlog sync remains controlled:
 - only the exact active workstream truth may be synced
 - unrelated backlog cleanup must stay separate
 
+## Grouped Workstream Branch Rule
+
+For `pre-Beta` planning, Codex may recommend or use a grouped workstream branch when:
+
+- the work belongs to one clear category or subsystem
+- several related ideas are better handled as one lane than as disconnected micro-branches
+- the lane is suitable for multi-developer coordination
+- each actual revision inside the branch can still stay narrow and validated
+
+Examples of valid grouped workstream branches:
+
+- interaction
+- UI / UX
+- workflow / GitHub infrastructure
+- diagnostics / tooling
+
+A grouped workstream branch does not authorize one broad patch.
+
+Instead, it means:
+
+- one branch may host a sequence of approved narrow slices
+- each slice inside that branch still needs clear scope and verification
+- unrelated ideas should still be split out even if they are all deferred work
+
+At `Beta` and later, the default recommendation should usually shift toward:
+
+- issue-specific branches
+- bug-fix branches
+- single-idea branches
+
+unless a grouped branch remains clearly justified.
+
 ---
 
 ## Shared Rules Across Both Modes

--- a/Docs/codex_modes.md
+++ b/Docs/codex_modes.md
@@ -233,7 +233,9 @@ A grouped workstream branch does not authorize one broad patch.
 Instead, it means:
 
 - one branch may host a sequence of approved narrow slices
+- one focused branch may also carry multiple small related patches when they all serve the same project-focus lane
 - each slice inside that branch still needs clear scope and verification
+- each small patch inside that branch must still stay narrow, validated, and within the same subsystem boundary
 - unrelated ideas should still be split out even if they are all deferred work
 
 At `Beta` and later, the default recommendation should usually shift toward:

--- a/Docs/development_rules.md
+++ b/Docs/development_rules.md
@@ -16,6 +16,42 @@
 4. No blind iteration
 5. Run a post-revision Analyze pass before recommending the next revision
 
+## Workstream Organization
+
+During `pre-Beta`, the project may organize work through grouped workstreams by category or subsystem when that is the clearest way to support multi-developer progress.
+
+Examples may include:
+
+- interaction work
+- UI / UX work
+- diagnostics / tooling work
+- release-prep or repo-admin work
+- workflow or GitHub-infrastructure work
+
+This grouping rule does not replace one-fix-per-revision discipline.
+
+It means:
+
+- the branch or workstream may group related ideas under one coherent lane
+- each approved revision or patch inside that lane must still stay narrow, validated, and architecture-safe
+- unrelated categories must not be silently mixed just because they are all "nice to do"
+
+The purpose of grouped workstreams is:
+
+- clearer backlog-to-branch mapping
+- cleaner multi-developer coordination
+- less churn from fragmenting every release into isolated micro-branches when the work is obviously part of one coherent lane
+
+Until `Beta`, grouped workstreams are allowed when they remain coherent by subsystem and end-state.
+
+At `Beta` and later, the default planning posture should shift back toward narrower:
+
+- issue branches
+- bug-fix branches
+- single-idea follow-through branches
+
+unless a grouped workstream is explicitly justified.
+
 ## Change Discipline
 
 - Changes must be minimal and isolated
@@ -278,3 +314,52 @@ Codex assists in managing it, but the user retains final authority over:
 - prioritization
 - status changes
 - completion
+
+## Backlog Grouping And Planning Rule
+
+When planning future work, Codex may scan the backlog for related ideas by type or subsystem so the user can choose a more organized workstream model.
+
+Examples:
+
+- several UI / UX ideas grouped into one UI / UX lane
+- several interaction-surface ideas grouped into one interaction lane
+- several workflow / tooling ideas grouped into one infrastructure lane
+
+Codex may:
+
+- identify clusters of related ideas
+- recommend a grouped workstream branch
+- suggest which items should travel together versus stay separate
+
+Codex may not:
+
+- silently reorder backlog items into categories
+- silently relabel backlog status or priority
+- silently create a new grouped workstream in backlog truth without approval
+
+Grouped-workstream planning must still preserve:
+
+- backlog control
+- explicit user approval
+- clear subsystem boundaries
+- minimal per-revision scope inside the larger lane
+
+## GitHub / Tooling Expansion Rule
+
+Potential GitHub follow-through such as:
+
+- repo scripts
+- helper automation
+- bots
+- workflow tooling
+- multi-developer coordination helpers
+
+should be treated as explicit infrastructure work, not as silent side work attached to product slices.
+
+Codex may recommend those expansions when they materially improve project organization, validation, or collaboration.
+
+Codex must not silently add them without:
+
+- a clear explanation of why they are worth adding
+- a recommendation for where they belong
+- explicit user approval for the resulting workstream

--- a/Docs/orin_interaction_architecture.md
+++ b/Docs/orin_interaction_architecture.md
@@ -86,6 +86,26 @@ The current preferred default hotkey is:
 
 That hotkey should be treated as a planning-level default, not a permanently fixed non-configurable rule.
 
+### Alternate Desktop Hotkey Direction
+
+For current Nexus-era desktop interaction, the default desktop hotkeys remain:
+
+- `Ctrl+Alt+Home` for the quick command overlay
+- `Ctrl+Alt+End` for the current desktop shutdown path
+
+Future interaction follow-through should preserve room for:
+
+- one alternate user-usable binding for opening and closing the quick command overlay
+- one alternate user-usable binding for the current desktop shutdown path
+
+The purpose of this direction is:
+
+- to reduce dependence on one exact physical-key path
+- to support broader usability across keyboards and user preference
+- to leave room for later bounded shortcut follow-through without forcing a full shortcut-customization system immediately
+
+This direction does not authorize immediate implementation of configurable shortcut management or a broad keybinding system.
+
 ### 3. Action Studio
 
 The customization surface is the place where the user defines and edits saved actions, aliases, routines, and profiles.

--- a/Docs/user_test_summary_guidance.md
+++ b/Docs/user_test_summary_guidance.md
@@ -90,6 +90,15 @@ This separation is important:
 - test-result evidence should stay readable as test evidence
 - new ideas should still be captured for later digestion
 
+User additions should also be treated as raw inputs rather than final canon wording.
+
+That means Codex should:
+
+- preserve the user's original request or concern faithfully
+- refine or clarify the idea when helpful using repo truth, current architecture boundaries, and the product vision
+- avoid changing the intended meaning of the user's request while improving precision, scope clarity, or terminology
+- explicitly distinguish between the user's raw idea and Codex's refined recommendation when summarizing follow-through
+
 ## Digest Rule After Submission
 
 After the user returns a filled `User Test Summary.txt`, Codex must explicitly digest it before recommending the next move.
@@ -103,11 +112,68 @@ That digest should separate:
 - what belongs to the current slice
 - what should be deferred into backlog or future source-of-truth consideration
 
+That digest should also include:
+
+- whether each new idea aligns with the current product vision and architecture boundaries
+- whether Codex recommends refining the user's wording before any truth-doc or backlog carry-forward
+- whether the idea is best treated as:
+  - current-slice follow-through
+  - future source-of-truth clarification
+  - future backlog candidate
+  - not currently recommended
+
+Codex should use project truth when refining ideas, including:
+
+- `docs/orin_vision.md`
+- `docs/architecture.md`
+- the canonical doc for the active workstream
+- any directly relevant closeout or planning doc
+
 Codex must not:
 
 - ignore newly introduced user requests
 - treat every new idea as automatically in scope for the current patch
 - leave the file unanalyzed after the user submits it
+
+## Approval Rule For Carry-Forward
+
+Ideas surfaced through a returned `User Test Summary.txt` must not be silently added to:
+
+- `docs/feature_backlog.md`
+- canonical planning docs
+- active source-of-truth docs that materially expand planned behavior
+
+until Codex first provides the user with:
+
+- a concise digest of the relevant test evidence
+- a summary of the extracted ideas
+- any recommended refinement to align the idea with repo truth, product vision, or architecture boundaries
+- a clear recommendation for where the idea belongs
+
+and the user explicitly approves that carry-forward.
+
+This approval rule exists even when the idea is good.
+
+The purpose is:
+
+- to preserve user control over backlog and canon growth
+- to avoid silent scope expansion from live testing feedback
+- to make sure Codex analyzes and refines ideas before proposing them as truth
+
+Directly supportive truth-doc updates for the active approved code task may still be bundled into the same workstream when the user has already approved that truth pass, but new ideas discovered during testing remain approval-gated.
+
+## Historical Summary Review Rule
+
+When the user explicitly asks Codex to revisit earlier `User Test Summary` submissions, Codex should review any recoverable prior summaries or directly preserved returned evidence before recommending new carry-forward.
+
+That review should separate:
+
+- what older summary artifacts are still recoverable
+- what ideas were already carried into canon or code
+- what ideas appear to have been missed
+- which missed ideas should now be proposed for approval-gated carry-forward
+
+If older summaries are no longer recoverable from the local environment, Codex should say so clearly and rely only on the evidence still available rather than pretending a historical review was complete.
 
 ## Required Dev Toolkit Metadata
 

--- a/desktop/desktop_renderer.py
+++ b/desktop/desktop_renderer.py
@@ -400,8 +400,15 @@ class CommandOverlayPanel(QWidget):
             index = int(match.get("index", -1))
             title = match.get("title", "")
             target_kind = match.get("target_kind", "")
-            button = QPushButton(f"{index + 1}. {title} ({target_kind})", self.ambiguous_choices_frame)
+            target_display = match.get("target_display") or match.get("target", "")
+            button_text = f"{index + 1}. {title}"
+            if target_display:
+                button_text += f"\n{target_kind}: {target_display}"
+            elif target_kind:
+                button_text += f"\n{target_kind}"
+            button = QPushButton(button_text, self.ambiguous_choices_frame)
             button.setProperty("choiceRole", "ambiguous")
+            button.setToolTip(match.get("target", ""))
             button.clicked.connect(lambda _checked=False, idx=index: self.ambiguous_match_selected.emit(idx))
             self.ambiguous_choices_layout.addWidget(button)
         self.ambiguous_choices_frame.setVisible(bool(matches))
@@ -454,7 +461,7 @@ class CommandOverlayPanel(QWidget):
 
         titles = payload.get("ambiguous_titles") or []
         if phase == "choose" and titles:
-            self.ambiguous_label.setText("Multiple saved actions matched your request.")
+            self.ambiguous_label.setText("Multiple saved actions matched your request. Review the destination detail below.")
         else:
             self.ambiguous_label.setText(f"Matches: {' | '.join(titles)}" if titles else "")
         self._populate_ambiguous_choice_buttons(payload.get("ambiguous_matches") or [])
@@ -466,7 +473,8 @@ class CommandOverlayPanel(QWidget):
             self.confirm_request_value.setText(payload.get("typed_request", ""))
             self.confirm_title_value.setText(action.get("title", ""))
             self.confirm_kind_value.setText(action.get("target_kind", ""))
-            self.confirm_target_value.setText(action.get("target", ""))
+            self.confirm_target_value.setText(action.get("target_display") or action.get("target", ""))
+            self.confirm_target_value.setToolTip(action.get("target", ""))
 
 
 class DesktopRuntimeWindow(QWidget):

--- a/desktop/interaction_overlay_model.py
+++ b/desktop/interaction_overlay_model.py
@@ -3,6 +3,7 @@ import re
 import subprocess
 from dataclasses import dataclass
 from pathlib import Path
+from urllib.parse import urlparse, unquote
 
 
 ROOT_DIR = Path(__file__).resolve().parent.parent
@@ -68,6 +69,48 @@ def launch_command_action(action: CommandAction):
         return
 
     os.startfile(action.target)
+
+
+def format_command_target_display(target_kind: str, target: str, max_length: int = 72) -> str:
+    target = (target or "").strip()
+    if not target:
+        return ""
+
+    if target_kind in {"folder", "file"}:
+        path = Path(target)
+        normalized = str(path)
+        if len(normalized) <= max_length:
+            return normalized
+
+        anchor = path.anchor
+        parts = [part for part in path.parts if part and part != anchor]
+        if not parts:
+            return normalized
+
+        tail_parts = parts[-3:] if len(parts) >= 3 else parts
+        tail = "\\".join(tail_parts)
+        if anchor:
+            return f"{anchor}...\\{tail}"
+        return f"...\\{tail}"
+
+    if target_kind == "url":
+        parsed = urlparse(target)
+        if parsed.scheme and parsed.netloc:
+            path = unquote(parsed.path or "")
+            compact = f"{parsed.netloc}{path}"
+            if parsed.query:
+                compact += "?"
+            if len(compact) <= max_length:
+                return compact
+            trimmed = path[-max(0, max_length - len(parsed.netloc) - 4):]
+            return f"{parsed.netloc}...{trimmed}"
+
+    if target_kind == "app":
+        return Path(target).name or target
+
+    if len(target) <= max_length:
+        return target
+    return f"{target[: max_length - 3]}..."
 
 
 class CommandOverlayModel:
@@ -244,6 +287,10 @@ class CommandOverlayModel:
                 "title": action.title,
                 "target_kind": action.target_kind,
                 "target": action.target,
+                "target_display": format_command_target_display(
+                    action.target_kind,
+                    action.target,
+                ),
             },
             "ambiguous_titles": [match.title for match in self.pending_matches] if self.status_kind == "ambiguous" else [],
             "ambiguous_matches": [
@@ -253,6 +300,10 @@ class CommandOverlayModel:
                     "title": match.title,
                     "target_kind": match.target_kind,
                     "target": match.target,
+                    "target_display": format_command_target_display(
+                        match.target_kind,
+                        match.target,
+                    ),
                 }
                 for index, match in enumerate(self.pending_matches)
             ]


### PR DESCRIPTION
## Summary

This PR carries one narrow FB-027 follow-through slice plus directly supportive canon updates.

## What Changed

### Changes

User-visible runtime change:
- improves path-aware target clarity in the typed desktop command overlay
- ambiguous choices now show clearer destination detail for path-sensitive targets
- confirmation now uses a compact/readable target display where helpful
- the existing exact-match -> choose -> confirm -> execute structure remains unchanged
- no action launches without explicit confirmation

Docs/truth carry-forward:
- strengthens User Test Summary handling so returned summaries are treated as active evidence inputs
- requires explicit digest/analysis of user-added ideas before recommending next moves
- requires approval before carrying testing-driven ideas into backlog or expanded canon
- preserves future direction for alternate desktop hotkeys
- clarifies grouped pre-Beta workstream/branch strategy for related small patches

### Files Changed

Runtime:
- desktop/interaction_overlay_model.py
- desktop/desktop_renderer.py

Docs:
- Docs/user_test_summary_guidance.md
- Docs/development_rules.md
- Docs/codex_modes.md
- Docs/Main.md
- Docs/orin_interaction_architecture.md

### Changes

User-visible runtime change:
- improves path-aware target clarity in the typed desktop command overlay
- ambiguous choices now show clearer destination detail for path-sensitive targets
- confirmation now uses a compact/readable target display where helpful
- the existing exact-match -> choose -> confirm -> execute structure remains unchanged
- no action launches without explicit confirmation

Docs/truth carry-forward:
- strengthens User Test Summary handling so returned summaries are treated as active evidence inputs
- requires explicit digest/analysis of user-added ideas before recommending next moves
- requires approval before carrying testing-driven ideas into backlog or expanded canon
- preserves future direction for alternate desktop hotkeys
- clarifies grouped pre-Beta workstream/branch strategy for related small patches

### Files Changed

Runtime:
- desktop/interaction_overlay_model.py
- desktop/desktop_renderer.py

Docs:
- Docs/user_test_summary_guidance.md
- Docs/development_rules.md
- Docs/codex_modes.md
- Docs/Main.md
- Docs/orin_interaction_architecture.md
