### PR TITLE
FB-027 NCP hardening follow-through and closure sync

### DIFF
--- a/Docs/Main.md
+++ b/Docs/Main.md
@@ -88,6 +88,7 @@ Use these when the task concerns:
 These are the current canonical planning docs for specific active planning areas:
 
 - `docs/boot_access_design.md`
+- `docs/ncp_hardening_assessment.md`
 - `docs/orin_interaction_architecture.md`
 - `docs/ownership_ip_plan.md`
 - `docs/workspace_layout_plan.md`
@@ -95,6 +96,7 @@ These are the current canonical planning docs for specific active planning areas
 Current canonical ownership:
 
 - `boot_access_design.md` is the canonical boot-planning source
+- `ncp_hardening_assessment.md` is the canonical NCP hardening and sequencing source for the active typed-first FB-027 follow-through lane
 - `orin_interaction_architecture.md` is the canonical interaction-planning source
 - `ownership_ip_plan.md` is the canonical ownership / licensing / IP-planning source
 - `workspace_layout_plan.md` is the canonical workspace-planning source

--- a/Docs/architecture.md
+++ b/Docs/architecture.md
@@ -540,3 +540,142 @@ Current guarantees remain unchanged:
 
 The support bundle should remain simple by default.
 Advanced or internal artifacts may be considered only in a later explicitly approved slice.
+
+## Failure-Class / Diagnostics-Surface Contract
+
+This contract defines how current and future Nexus failures should be classified for user-visible handling without silently widening current launcher policy.
+
+The classification rule is:
+
+- classify by survivability and ownership first
+- do not classify only by which subsystem raised the problem
+- do not treat every recoverable issue as a diagnostics popup
+
+Current repo truth supports four meaningful classes:
+
+### Class 1: Expected Non-Success Or Guidance State
+
+Examples may include:
+
+- `not_found`
+- ambiguous choice
+- explicit confirm step
+
+These are not incident surfaces.
+They should remain inline, local, and lightweight.
+
+### Class 2: Contained Recoverable Action Failure
+
+This means a user-visible action failed, but Nexus remains operational and the failure stays contained to the active interaction surface.
+
+Current example:
+
+- NCP `launch_failed` inside the command overlay
+
+Current default behavior for this class should be:
+
+- contained user-visible result inside the active surface
+- clean retry and reset posture
+- relevant runtime trace for the failed action
+- no automatic diagnostics-window escalation
+- no corrupted/error voice behavior
+
+This class may later gain a bounded report affordance if explicitly approved, but that is not implied by this contract.
+
+### Class 3: Recoverable Operational Incident While Nexus Remains Alive
+
+This means something meaningful went against normal expected Nexus behavior, but the persona and runtime remain operational enough to continue guiding the user.
+
+This class is a future planning boundary, not a broadly implemented current behavior.
+
+When later approved for a specific subsystem, this class may use:
+
+- a recoverable diagnostics or reporting surface
+- normal ORIN voice and trace semantics
+- relevant local evidence for user review
+- the existing manual reporting boundary when reporting is exposed
+
+This class must not be treated as permission to send every recoverable issue directly into diagnostics.
+It should be used only for bounded high-signal incidents that merit operator review while the system remains alive.
+
+### Class 4: Fatal Launcher / Runtime / Persona Failure
+
+This means Nexus can no longer be treated as normally operational for the current run.
+
+Current examples include:
+
+- launcher-owned instability exhaustion
+- repeated startup-abort exhaustion
+- repeated identical crash exhaustion
+- equivalent renderer or launcher failure states that reuse the current diagnostics completion path
+
+Current default behavior for this class should remain:
+
+- launcher-owned diagnostics completion path
+- diagnostics UI
+- launcher/runtime truth surfaces
+- corrupted/error voice behavior where currently defined
+
+### Surface Mapping
+
+The current recommended surface mapping is:
+
+- Class 1 -> inline or contained guidance only
+- Class 2 -> inline or contained recoverable failure only
+- Class 3 -> recoverable diagnostics or reporting surface when later explicitly approved for a bounded incident class
+- Class 4 -> existing launcher-owned diagnostics completion path
+
+This contract does not by itself authorize new diagnostics triggers or UI surfaces.
+It defines the intended shape for future bounded work.
+
+### Voice / Persona Mapping
+
+The current recommended voice split is:
+
+- Class 1 -> usually no voice
+- Class 2 -> no corrupted/error voice; future normal ORIN guidance remains optional and approval-gated
+- Class 3 -> normal ORIN voice and trace semantics when voice is present
+- Class 4 -> corrupted/error voice semantics for launcher-owned fatal or instability completion paths
+
+This preserves the difference between:
+
+- recoverable incidents where Nexus is still functioning
+- failures where the persona/runtime is no longer functioning normally
+
+### Evidence / Reporting Boundary By Failure Class
+
+All classes may write relevant runtime evidence within their owned surfaces.
+
+The current reporting boundary remains:
+
+- local support-bundle generation only
+- local bundle folder open
+- prefilled GitHub issue draft open when available
+- manual user review before sharing
+- manual user attachment and submission
+- no silent or background upload behavior
+
+Current reporting expectations by class are:
+
+- Class 1 -> no diagnostics reporting surface required
+- Class 2 -> trace evidence only by default
+- Class 3 -> may expose a recoverable diagnostics or reporting surface in a later bounded slice
+- Class 4 -> existing diagnostics-window reporting flow
+
+This contract must not be used to smuggle automatic upload, silent collection expansion, or launcher-policy changes into future work.
+
+### Extensibility Rule
+
+Future subsystem additions should map into the existing classes above before proposing a new failure class.
+
+That means future work should:
+
+- prefer survivability and ownership as the classification rule
+- reuse the existing manual-reporting boundary unless a later explicit reporting-policy revision changes it
+- leave room for future recoverable incident classes that do not exist yet
+- allow later re-analysis as new subsystems, voice behaviors, and packaged product layers are added
+
+Only add a new class later if a future subsystem truly cannot fit the four-class model cleanly.
+
+This contract is intentionally conservative.
+It preserves room for later refinement without overfitting current implementation details.

--- a/Docs/feature_backlog.md
+++ b/Docs/feature_backlog.md
@@ -665,6 +665,12 @@ Out of Scope:
 Notes:
 The first coherent manual reporting flow is now implemented as a privacy-safe diagnostics-window `Report Issue` action. It generates a local support bundle, writes the manifest, opens a prefilled GitHub issue page for manual completion, keeps attachment and submission manual, and includes a crash log only when the runtime-to-crash match is trustworthily determinable. The support bundle remains simple by default, with advanced/internal artifacts included only if explicitly needed later. The repo now also includes a contained offscreen validator for the production diagnostics `Report Issue` path that verifies support-bundle creation, manifest/manual-submission contract fields, and GitHub issue-prefill URL plus open-attempt handling without changing production behavior. That validator is now reachable through a dedicated VBS launcher and a report-aware lane in the accepted PySide dev toolkit.
 
+Current approved future follow-through above the same reporting boundary:
+
+- a bounded UX confirmation/warning step may later be added ahead of the `Report Issue` action so the user is explicitly told that a local support bundle will be created, the bundle folder will open, a GitHub issue draft will open, and final attachment/submission remain manual
+- that confirmation follow-through should preserve the existing privacy-safe manual reporting contract rather than redesigning diagnostics policy or introducing automatic upload behavior
+- broader recoverable-incident diagnostics triggering remains separate failure-class work and should not be folded into `FB-017` by default
+
 ---
 
 ### [ID: FB-018] Voice-path regression validation harness
@@ -1493,6 +1499,68 @@ Out of Scope:
 
 Notes:
 Current branch-local evidence indicates the helper is useful for internal startup debugging, but it should remain clearly separate from normal runtime behavior and should only be kept long-term if it stays harness-gated, low-noise, and bounded to developer investigation needs.
+
+---
+
+### [ID: FB-034] Recoverable incident diagnostics surface and failure-class follow-through
+
+Status: Deferred
+Priority: Medium
+Suggested Version: TBD
+Suggested Revision: rev1
+Release Stage: pre-Beta
+
+Description:
+Define a later bounded follow-through for recoverable incidents that should surface diagnostics or reporting while Nexus remains operational, without collapsing those incidents into the fatal launcher diagnostics path.
+
+Why it matters:
+Current repo truth now distinguishes between contained recoverable action failures, future recoverable operational incidents, and fatal launcher/runtime/persona failures. Without a tracked follow-through item, later work could drift into ad hoc diagnostics triggers, inconsistent voice behavior, or silent reporting-policy expansion.
+
+Proposed Change:
+Use the failure-class / diagnostics-surface contract in `docs/architecture.md` as the planning baseline for a later bounded slice that:
+
+- selects one recoverable high-signal incident class only
+- decides whether that class should stay inline or surface a recoverable diagnostics/reporting view
+- preserves the existing manual-reporting boundary
+- keeps fatal launcher/runtime diagnostics completion behavior separate
+- uses normal ORIN voice/trace semantics for recoverable incidents when voice is present
+
+Likely Files Affected:
+- C:/Nexus Desktop AI/Docs/architecture.md
+- C:/Nexus Desktop AI/Docs/orchestration.md
+- C:/Nexus Desktop AI/desktop/desktop_renderer.py
+- C:/Nexus Desktop AI/desktop/orin_desktop_launcher.pyw
+- C:/Nexus Desktop AI/desktop/orin_diagnostics.pyw
+- C:/Nexus Desktop AI/desktop/orin_support_reporting.py
+- C:/Nexus Desktop AI/Audio/orin_voice.py
+- C:/Nexus Desktop AI/Audio/orin_error_voice.py
+
+Scope:
+- failure-class follow-through for recoverable incidents
+- bounded recoverable diagnostics/reporting surface planning and later implementation
+- normal-versus-error voice role split by failure class
+- preserving manual-reporting boundaries while broadening incident-class clarity
+
+Out of Scope:
+- treating every recoverable issue as a diagnostics popup
+- silent or background upload behavior
+- fully automatic GitHub submission
+- launcher retry, escalation, threshold, or fatal diagnostics-entry policy redesign
+- broad diagnostics UI redesign
+- broad voice redesign unrelated to failure-class semantics
+- automatic continuation of the current NCP hardening lane
+
+Notes:
+Current source-of-truth ownership now lives in `docs/architecture.md`.
+That contract is intentionally conservative:
+
+- contained recoverable action failures such as current NCP `launch_failed` remain inline by default
+- recoverable diagnostics or reporting surfaces are future bounded work, not automatic current behavior
+- fatal launcher/runtime/persona failures keep the existing launcher-owned diagnostics completion path
+- later implementation should begin with one bounded recoverable incident class rather than a blanket new diagnostics trigger
+
+This item should remain separate from `FB-027` and `FB-017`.
+It is cross-system planning work, not a pure NCP hardening slice and not only a `Report Issue` UX refinement.
 
 ---
 

--- a/Docs/feature_backlog.md
+++ b/Docs/feature_backlog.md
@@ -1149,6 +1149,18 @@ Current branch-local follow-through above that same foundation now also includes
 
 These branch-local follow-through items remain part of the same staged `FB-027` interaction lane rather than separate backlog items.
 
+Current NCP hardening and sequencing truth for that same follow-through now lives in `docs/ncp_hardening_assessment.md`.
+That document should be treated as the canonical reference for:
+
+- what is complete enough now in the typed-first NCP hardening lane
+- what is mostly hardened but still under-validated
+- what still remains a meaningful near-term hardening candidate
+
+Current repo truth remains conservative:
+
+- NCP hardening is still FB-027 follow-through, not a separate backlog item
+- `launch_failed` user-visible failure-state predictability is the current validation-first candidate, not an automatic patch target
+
 Release-stage mapping:
 
 - `pre-Beta`: first typed-first interaction foundation slice is now implemented in `v2.2.1 rev1`; later pre-Beta work remains limited to additional interaction-model follow-through above the same desktop overlay foundation

--- a/Docs/feature_backlog.md
+++ b/Docs/feature_backlog.md
@@ -1165,7 +1165,7 @@ That document should be treated as the canonical reference for:
 Current repo truth remains conservative:
 
 - NCP hardening is still FB-027 follow-through, not a separate backlog item
-- `launch_failed` user-visible failure-state predictability is the current validation-first candidate, not an automatic patch target
+- the approved NCP hardening lane is now runtime-complete enough for branch-level closure review, with no current repo-truth need for another automatic NCP hardening patch
 
 Release-stage mapping:
 

--- a/Docs/ncp_hardening_assessment.md
+++ b/Docs/ncp_hardening_assessment.md
@@ -1,0 +1,164 @@
+# NCP Hardening Assessment
+
+## Purpose
+
+This document is the canonical hardening assessment for the current FB-027 Nexus Command Prompt (NCP) follow-through lane.
+
+Its purpose is to:
+
+- preserve the current NCP hardening truth outside chat history
+- distinguish what is complete enough now from what is only helper-strong
+- record the conservative next-step recommendation for the current branch state
+- give future FB-027 backlog wording a stable truth reference without changing backlog state in the same pass
+
+This document is an assessment and sequencing reference.
+It does not replace `docs/feature_backlog.md`, and it does not authorize automatic scope expansion.
+
+## Scope Boundary For NCP Hardening
+
+For current repo truth, NCP hardening means typed-first reliability follow-through for the current desktop command surface.
+
+That includes:
+
+- keyboard ownership and containment inside the visible overlay
+- focus and reopen behavior
+- transition stability across `entry`, `choose`, `confirm`, and `result`
+- predictable reset and retry posture after success, back-out, or non-success outcomes
+- stable user-visible failure-state behavior for the currently implemented command surface
+- helper and regression validation for the exact typed-interaction risks already discovered
+
+That does not include:
+
+- voice integration
+- Action Studio or later customization surfaces
+- shortcut customization beyond the already implemented bounded desktop hotkeys
+- command-set expansion
+- broad UI polish or redesign
+- broad architectural rewrite without a reproduced bug that requires it
+
+## NCP Hardening Subsystems
+
+The current meaningful NCP hardening areas are:
+
+- input ownership and capture stability
+- focus and reopen behavior
+- `entry` / `choose` / `confirm` transition integrity
+- `Enter` / digit / `Esc` containment guarantees
+- no-mirroring / no-underlay-leak guarantees
+- result-state reset and reopen predictability
+- non-success-path predictability
+- target clarity and execution clarity
+- visual state consistency of the NCP surface
+- helper and regression validation coverage
+
+## Complete Enough Now
+
+`Complete enough now` means good enough by current repo truth and live evidence for the current pre-Beta branch state, not theoretical perfection.
+
+The following areas are complete enough now:
+
+- input ownership and capture stability for the regression family already discovered
+- no-mirroring / no-underlay-leak guarantees for the currently validated typed paths
+- `Enter` / digit / `Esc` containment guarantees for the currently validated typed paths
+- focus and reopen behavior for the success-path and cancel/retry flows already exercised
+- `entry` / `choose` / `confirm` transition integrity for the current typed command surface
+- result-state reset and clean reopen behavior for the validated success path
+- target clarity and execution clarity for the current command set
+- visual state consistency of the NCP surface, including compact reset after backing out of expanded states
+
+Current repo truth supports this classification because the merged overlay-usability lane and the current hardening branch already closed:
+
+- mirrored typing and underlay leakage regressions
+- first-`Enter` and second-`Enter` containment failures
+- delayed ambiguous number-selection failure without manual refocus
+- caret / visual state mismatch after focus leaves the NCP
+- `Esc` cancel-and-retry reliability issues
+- layout reset after `Esc` from `choose` / `confirm`
+- success-path clean result close / reopen reset
+- stale retry-state carry-over for current non-success back-out flows
+
+## Mostly Hardened But Under-Validated
+
+`Mostly hardened but under-validated` means the model, runtime, or helper evidence is stronger than the current live user-validation depth.
+
+The clearest current case is:
+
+- `launch_failed` result handling and retry/reset posture
+
+Why it belongs here:
+
+- helper coverage already exercises failure-result clearing and clean reopen/reset behavior
+- the current model and renderer state cleanup path is conservative
+- but this path has not been closed by the same level of fresh live user validation as the success-path and cancel/retry slices
+
+The helper / regression surface itself is also stronger than the live validation depth for some failure-oriented paths.
+That is useful and intentional, but it should not be mistaken for equal-weight user confirmation.
+
+## Still Needs Hardening
+
+No currently reproduced runtime bug forces another NCP patch at the moment.
+
+The only meaningful near-term candidate that still belongs in this lane is:
+
+- `launch_failed` user-visible failure-state predictability
+
+This should be treated as a validation-first candidate, not as an automatically approved new patch.
+
+The current question is not whether a broader failure system should be redesigned.
+The current question is only whether the visible `launch_failed` path feels as reset-clean and predictable as the now-validated success path.
+
+## Not In Work Yet
+
+These items are relevant to future NCP follow-through but are not active work right now:
+
+- broader non-success-path polish beyond a reproduced issue
+- branch-level readiness and closure review after the `launch_failed` validation-first decision
+- any later slice that is only justified if new live evidence reopens a typed-interaction regression
+
+## Not Ready Yet Due To Future Integration Dependencies
+
+These items are NCP-adjacent, but they should wait because later product layers are not yet ready:
+
+- voice-parity behavior above the same interaction model
+- Action Studio and later customization surfaces
+- broader shared-action-model expansion beyond the current typed-first hardening lane
+- later installable / packaged interaction behavior that depends on future Beta-stage delivery
+
+Future voice should build on the same interaction model as typed interaction.
+That does not make voice part of current NCP hardening.
+
+## Current Recommended Next Step
+
+The current recommended next step is:
+
+1. do not patch automatically
+2. do one validation-first step for `launch_failed` user-visible failure-state predictability
+3. if that validation passes, move to branch-level readiness / closure review for `feature/fb-027-ncp-hardening`
+
+This is the conservative next step because current repo truth does not show a newly reproduced failure.
+It shows one remaining area where helper confidence still leads live validation depth.
+
+## What Should Wait Until Later
+
+The following should stay out of the current NCP hardening lane:
+
+- voice integration
+- Action Studio
+- shortcut customization
+- `Shift+Home` or other QoL extras
+- broader UI polish
+- command expansion
+- broad architectural rewrites without a reproduced bug
+
+## How This Document Should Be Used Relative To The Relevant FB-027 Backlog Item
+
+This document should be used as the canonical NCP hardening reference for future FB-027 follow-through wording.
+
+That means:
+
+- `docs/feature_backlog.md` should remain the controlling backlog file
+- future approved FB-027 backlog updates may point to this assessment instead of restating the full hardening map
+- backlog wording should stay concise and should not duplicate this document unless a later approved slice materially changes the assessment
+
+Backlog changes remain approval-gated.
+This document exists so future backlog carry-forward can reference one stable source of truth instead of relying on chat history.

--- a/Docs/ncp_hardening_assessment.md
+++ b/Docs/ncp_hardening_assessment.md
@@ -63,6 +63,7 @@ The following areas are complete enough now:
 - focus and reopen behavior for the success-path and cancel/retry flows already exercised
 - `entry` / `choose` / `confirm` transition integrity for the current typed command surface
 - result-state reset and clean reopen behavior for the validated success path
+- `launch_failed` result handling and retry/reset posture for the current typed command surface
 - target clarity and execution clarity for the current command set
 - visual state consistency of the NCP surface, including compact reset after backing out of expanded states
 
@@ -76,36 +77,22 @@ Current repo truth supports this classification because the merged overlay-usabi
 - layout reset after `Esc` from `choose` / `confirm`
 - success-path clean result close / reopen reset
 - stale retry-state carry-over for current non-success back-out flows
+- `launch_failed` visible failure-result handling, clean reopen/reset posture, and retry cleanliness for the current command surface
 
 ## Mostly Hardened But Under-Validated
 
 `Mostly hardened but under-validated` means the model, runtime, or helper evidence is stronger than the current live user-validation depth.
 
-The clearest current case is:
+No currently meaningful NCP subsystem remains in this category for the active branch scope.
 
-- `launch_failed` result handling and retry/reset posture
-
-Why it belongs here:
-
-- helper coverage already exercises failure-result clearing and clean reopen/reset behavior
-- the current model and renderer state cleanup path is conservative
-- but this path has not been closed by the same level of fresh live user validation as the success-path and cancel/retry slices
-
-The helper / regression surface itself is also stronger than the live validation depth for some failure-oriented paths.
-That is useful and intentional, but it should not be mistaken for equal-weight user confirmation.
+The helper / regression surface may still be stronger than the live validation depth for some future failure-oriented or cross-system paths.
+That is useful and intentional, but it is no longer the gating question for the current NCP hardening lane.
 
 ## Still Needs Hardening
 
 No currently reproduced runtime bug forces another NCP patch at the moment.
 
-The only meaningful near-term candidate that still belongs in this lane is:
-
-- `launch_failed` user-visible failure-state predictability
-
-This should be treated as a validation-first candidate, not as an automatically approved new patch.
-
-The current question is not whether a broader failure system should be redesigned.
-The current question is only whether the visible `launch_failed` path feels as reset-clean and predictable as the now-validated success path.
+No currently meaningful near-term NCP hardening candidate remains inside this lane before branch-level closure review.
 
 Broader failure-class, diagnostics-surface, reporting, or voice-role contract work now belongs to `docs/architecture.md` rather than this NCP hardening doc.
 That later cross-system work should not be treated as an automatic continuation of the current typed-first NCP hardening lane.
@@ -115,7 +102,6 @@ That later cross-system work should not be treated as an automatic continuation 
 These items are relevant to future NCP follow-through but are not active work right now:
 
 - broader non-success-path polish beyond a reproduced issue
-- branch-level readiness and closure review after the `launch_failed` validation-first decision
 - any later slice that is only justified if new live evidence reopens a typed-interaction regression
 
 ## Not Ready Yet Due To Future Integration Dependencies
@@ -135,11 +121,10 @@ That does not make voice part of current NCP hardening.
 The current recommended next step is:
 
 1. do not patch automatically
-2. do one validation-first step for `launch_failed` user-visible failure-state predictability
-3. if that validation passes, move to branch-level readiness / closure review for `feature/fb-027-ncp-hardening`
+2. treat the approved NCP hardening lane as runtime-complete enough for its current scope
+3. move to branch-level readiness / closure review for `feature/fb-027-ncp-hardening`
 
-This is the conservative next step because current repo truth does not show a newly reproduced failure.
-It shows one remaining area where helper confidence still leads live validation depth.
+This is the conservative next step because the latest returned live user validation closed the `launch_failed` validation-first question without reopening a new NCP runtime bug.
 
 ## What Should Wait Until Later
 

--- a/Docs/ncp_hardening_assessment.md
+++ b/Docs/ncp_hardening_assessment.md
@@ -107,6 +107,9 @@ This should be treated as a validation-first candidate, not as an automatically 
 The current question is not whether a broader failure system should be redesigned.
 The current question is only whether the visible `launch_failed` path feels as reset-clean and predictable as the now-validated success path.
 
+Broader failure-class, diagnostics-surface, reporting, or voice-role contract work now belongs to `docs/architecture.md` rather than this NCP hardening doc.
+That later cross-system work should not be treated as an automatic continuation of the current typed-first NCP hardening lane.
+
 ## Not In Work Yet
 
 These items are relevant to future NCP follow-through but are not active work right now:

--- a/Docs/orchestration.md
+++ b/Docs/orchestration.md
@@ -123,6 +123,16 @@ The renderer is responsible for:
 - cooperative response to launcher control signals
 - clean shutdown behavior
 
+## Diagnostics-Surface Boundary
+
+Within orchestration truth, the launcher-owned diagnostics completion path is for fatal or instability-class launcher and renderer outcomes.
+
+This document should not be read as implying that every recoverable incident in higher interaction layers should open the diagnostics UI.
+
+Contained recoverable failures in interaction surfaces may remain local to those surfaces unless a later explicitly approved failure-class contract says a bounded recoverable incident should surface a separate diagnostics or reporting view.
+
+That later clarification must not silently redesign launcher retry, escalation, threshold, or diagnostics-entry policy.
+
 ## v1.6.0 Evolution (rev10-rev24)
 
 ### rev10-rev12

--- a/desktop/desktop_renderer.py
+++ b/desktop/desktop_renderer.py
@@ -440,9 +440,10 @@ class CommandOverlayPanel(QWidget):
 
         return None
 
-    def show_for_geometry(self, host_geometry: QRect, bounds_geometry: QRect | None = None):
+    def _apply_geometry(self, host_geometry: QRect, bounds_geometry: QRect | None = None):
         width = max(460, min(720, int(host_geometry.width() * 0.72)))
         self.panel.setFixedWidth(width)
+        self.panel.adjustSize()
         self.adjustSize()
 
         x = host_geometry.x() + (host_geometry.width() - self.width()) // 2
@@ -457,8 +458,14 @@ class CommandOverlayPanel(QWidget):
             y = max(min_y, min(y, max_y))
 
         self.move(x, y)
+
+    def show_for_geometry(self, host_geometry: QRect, bounds_geometry: QRect | None = None):
+        self._apply_geometry(host_geometry, bounds_geometry)
         self.show()
         self.raise_()
+
+    def refresh_for_geometry(self, host_geometry: QRect, bounds_geometry: QRect | None = None):
+        self._apply_geometry(host_geometry, bounds_geometry)
 
     def focus_input(self, reason=Qt.ShortcutFocusReason):
         self.raise_()
@@ -791,6 +798,11 @@ class DesktopRuntimeWindow(QWidget):
             )
         )
         self._command_panel.render_payload(payload)
+        if payload.get("visible") and self._command_panel.isVisible():
+            self._command_panel.refresh_for_geometry(
+                self.compute_compact_geometry(),
+                self.screen_ref.availableGeometry(),
+            )
 
     def _arm_overlay_input_capture(self, seconds: float = 0.65):
         self._overlay_input_capture_until = time.monotonic() + max(0.0, seconds)
@@ -1058,7 +1070,7 @@ class DesktopRuntimeWindow(QWidget):
             if self._overlay_local_input_engaged:
                 self._command_panel.focus_input()
             else:
-                self._arm_overlay_input_capture()
+                self._refresh_overlay_input_capture(seconds=5.0)
             self._log_event("RENDERER_MAIN|COMMAND_DISAMBIGUATION_CANCELLED")
             return
 
@@ -1066,7 +1078,7 @@ class DesktopRuntimeWindow(QWidget):
             if self._overlay_local_input_engaged:
                 self._command_panel.focus_input()
             else:
-                self._arm_overlay_input_capture()
+                self._refresh_overlay_input_capture(seconds=5.0)
             self._log_event("RENDERER_MAIN|COMMAND_CONFIRM_CANCELLED")
             return
 

--- a/desktop/interaction_overlay_model.py
+++ b/desktop/interaction_overlay_model.py
@@ -285,8 +285,12 @@ class CommandOverlayModel:
     def show_result(self, status_kind: str, status_text: str):
         self.phase = "result"
         self.input_armed = False
+        self.input_text = ""
         self.status_kind = status_kind
         self.status_text = status_text
+        self.last_request = ""
+        self.pending_action = None
+        self.pending_matches = ()
 
     def view_payload(self):
         action = self.pending_action

--- a/desktop/interaction_overlay_model.py
+++ b/desktop/interaction_overlay_model.py
@@ -177,6 +177,7 @@ class CommandOverlayModel:
             return
 
         self.input_text += char
+        self.last_request = ""
         self.status_kind = "idle"
         self.status_text = ""
 
@@ -185,6 +186,7 @@ class CommandOverlayModel:
             return
 
         self.input_text = text or ""
+        self.last_request = ""
         self.status_kind = "idle"
         self.status_text = ""
         self.pending_action = None
@@ -195,6 +197,7 @@ class CommandOverlayModel:
             return
 
         self.input_text = self.input_text[:-1]
+        self.last_request = ""
         self.status_kind = "idle"
         self.status_text = ""
 
@@ -205,6 +208,7 @@ class CommandOverlayModel:
         if self.phase == "choose":
             self.phase = "entry"
             self.input_armed = True
+            self.last_request = ""
             self.status_kind = "idle"
             self.status_text = ""
             self.pending_action = None
@@ -214,6 +218,7 @@ class CommandOverlayModel:
         if self.phase == "confirm":
             self.phase = "entry"
             self.input_armed = True
+            self.last_request = ""
             self.status_kind = "idle"
             self.status_text = ""
             self.pending_action = None

--- a/dev/orin_overlay_input_capture_helper.py
+++ b/dev/orin_overlay_input_capture_helper.py
@@ -158,6 +158,23 @@ class _FakeBus:
         self.command_overlay_escape_requested = _RecorderSignal(self.events, "escape")
 
 
+def _assert_clean_entry_baseline(window, message_prefix="overlay"):
+    _assert(window._command_model.phase == "entry", f"{message_prefix} should reopen in entry phase")
+    _assert(window._command_model.input_armed, f"{message_prefix} should reopen with input armed")
+    _assert(window._command_model.input_text == "", f"{message_prefix} should reopen with no stale input text")
+    _assert(window._command_model.last_request == "", f"{message_prefix} should reopen with no stale typed request")
+    _assert(window._command_model.pending_action is None, f"{message_prefix} should reopen with no stale pending action")
+    _assert(window._command_model.pending_matches == (), f"{message_prefix} should reopen with no stale pending matches")
+    _assert(window._command_model.status_kind == "idle", f"{message_prefix} should reopen with idle status")
+    _assert(window._command_model.status_text == "", f"{message_prefix} should reopen with no stale status text")
+    _assert(window._command_panel.last_payload.get("phase") == "entry", f"{message_prefix} payload should reopen in entry phase")
+    _assert(window._command_panel.last_payload.get("input_text", "") == "", f"{message_prefix} payload should reopen with no stale input")
+    _assert(window._command_panel.last_payload.get("typed_request", "") == "", f"{message_prefix} payload should reopen with no stale typed request")
+    _assert(window._command_panel.last_payload.get("pending_action") is None, f"{message_prefix} payload should reopen with no pending action")
+    _assert(window._command_panel.last_payload.get("ambiguous_matches") == [], f"{message_prefix} payload should reopen with no stale choices")
+    _assert(window._command_panel.last_payload.get("status_kind") == "idle", f"{message_prefix} payload should reopen idle")
+
+
 def _test_first_open_capture_allows_typing():
     window = _make_window()
     window.open_command_overlay()
@@ -405,6 +422,79 @@ def _test_confirm_cancel_refreshes_panel_layout_after_return_to_entry():
     )
 
 
+def _test_launch_requested_result_clears_transient_state_immediately():
+    window = _make_window()
+    original_launch = renderer_mod.launch_command_action
+    renderer_mod.launch_command_action = lambda _action: None
+    try:
+        window.open_command_overlay()
+        window._command_model.input_text = "open file explorer"
+        window.handle_command_submit(source="fallback")
+        window.handle_command_submit(source="fallback")
+        _assert(window._command_model.phase == "result", "successful launch should enter result state")
+        _assert(window._command_model.input_text == "", "result state should clear stale input text immediately")
+        _assert(window._command_model.last_request == "", "result state should clear stale typed request immediately")
+        _assert(window._command_model.pending_action is None, "result state should clear stale pending action immediately")
+        _assert(window._command_model.pending_matches == (), "result state should clear stale pending matches immediately")
+        _assert(window._command_panel.last_payload.get("pending_action") is None, "result payload should not retain confirm metadata")
+        _assert(window._command_panel.last_payload.get("typed_request", "") == "", "result payload should not retain typed request metadata")
+    finally:
+        renderer_mod.launch_command_action = original_launch
+
+
+def _test_launch_requested_timeout_close_and_reopen_is_clean():
+    window = _make_window()
+    original_launch = renderer_mod.launch_command_action
+    renderer_mod.launch_command_action = lambda _action: None
+    try:
+        window.open_command_overlay()
+        window._command_model.input_text = "open file explorer"
+        window.handle_command_submit(source="fallback")
+        window.handle_command_submit(source="fallback")
+        window._close_command_overlay_after_result()
+        window.open_command_overlay()
+        _assert_clean_entry_baseline(window, "launch-requested reopen")
+    finally:
+        renderer_mod.launch_command_action = original_launch
+
+
+def _test_launch_failed_result_clears_transient_state_and_reopen_is_clean():
+    window = _make_window()
+    original_launch = renderer_mod.launch_command_action
+    renderer_mod.launch_command_action = lambda _action: (_ for _ in ()).throw(RuntimeError("boom"))
+    try:
+        window.open_command_overlay()
+        window._command_model.input_text = "open file explorer"
+        window.handle_command_submit(source="fallback")
+        window.handle_command_submit(source="fallback")
+        _assert(window._command_model.phase == "result", "launch failure should enter result state")
+        _assert(window._command_model.status_kind == "launch_failed", "launch failure should surface launch_failed status")
+        _assert(window._command_model.input_text == "", "launch-failed result should clear stale input text immediately")
+        _assert(window._command_model.last_request == "", "launch-failed result should clear stale typed request immediately")
+        _assert(window._command_model.pending_action is None, "launch-failed result should clear stale pending action immediately")
+        window._close_command_overlay_after_result()
+        window.open_command_overlay()
+        _assert_clean_entry_baseline(window, "launch-failed reopen")
+    finally:
+        renderer_mod.launch_command_action = original_launch
+
+
+def _test_manual_result_close_and_reopen_is_clean():
+    window = _make_window()
+    original_launch = renderer_mod.launch_command_action
+    renderer_mod.launch_command_action = lambda _action: None
+    try:
+        window.open_command_overlay()
+        window._command_model.input_text = "open file explorer"
+        window.handle_command_submit(source="fallback")
+        window.handle_command_submit(source="fallback")
+        window.close_command_overlay()
+        window.open_command_overlay()
+        _assert_clean_entry_baseline(window, "manual-close reopen")
+    finally:
+        renderer_mod.launch_command_action = original_launch
+
+
 def _test_ambiguous_choose_confirm_execute_path():
     window = _make_window()
     launches = []
@@ -488,6 +578,15 @@ def _test_hotkey_grace_stands_down_after_manual_local_engagement():
     _assert(not bus.events, "launch grace should not keep forwarding typing after real local input ownership is established")
 
 
+def _test_shutdown_hotkey_still_emits_shutdown():
+    bus = _FakeBus()
+    manager = hotkeys_mod.GlobalHotkeyManager(bus)
+    manager._on_press(pynput_keyboard.Key.ctrl_l)
+    manager._on_press(pynput_keyboard.Key.alt_l)
+    manager._on_press(pynput_keyboard.KeyCode.from_char("2"))
+    _assert(("shutdown", ()) in bus.events, "shutdown hotkey should still emit shutdown after reset hardening changes")
+
+
 def _test_fallback_text_is_suppressed_underlay_and_forwarded():
     bus = _FakeBus()
     manager = hotkeys_mod.GlobalHotkeyManager(bus)
@@ -552,12 +651,17 @@ def main():
         ("confirm cancel rearms capture for human retry", _test_confirm_cancel_rearms_capture_for_human_retry_delay),
         ("choose cancel refreshes layout after return to entry", _test_choose_cancel_refreshes_panel_layout_after_return_to_entry),
         ("confirm cancel refreshes layout after return to entry", _test_confirm_cancel_refreshes_panel_layout_after_return_to_entry),
+        ("launch-requested result clears transient state", _test_launch_requested_result_clears_transient_state_immediately),
+        ("launch-requested timeout close reopens clean", _test_launch_requested_timeout_close_and_reopen_is_clean),
+        ("launch-failed result clears and reopens clean", _test_launch_failed_result_clears_transient_state_and_reopen_is_clean),
+        ("manual result close reopens clean", _test_manual_result_close_and_reopen_is_clean),
         ("choose-confirm execute path", _test_ambiguous_choose_confirm_execute_path),
         ("capture expiry", _test_capture_expiry_stands_down_fallback),
         ("line edit focus methods", _test_line_edit_focus_methods_present),
         ("hotkey launch grace", _test_hotkey_launch_grace_bridges_open_gap),
         ("hotkey grace expiry", _test_hotkey_grace_expires_cleanly),
         ("hotkey grace stops after local engagement", _test_hotkey_grace_stands_down_after_manual_local_engagement),
+        ("shutdown hotkey remains available", _test_shutdown_hotkey_still_emits_shutdown),
         ("fallback text suppresses underlay", _test_fallback_text_is_suppressed_underlay_and_forwarded),
         ("fallback submit suppresses underlay", _test_fallback_submit_is_suppressed_underlay_and_forwarded),
         ("win32 text suppression is synchronous", _test_win32_text_suppression_happens_before_callback_delivery),

--- a/dev/orin_overlay_input_capture_helper.py
+++ b/dev/orin_overlay_input_capture_helper.py
@@ -175,6 +175,16 @@ def _assert_clean_entry_baseline(window, message_prefix="overlay"):
     _assert(window._command_panel.last_payload.get("status_kind") == "idle", f"{message_prefix} payload should reopen idle")
 
 
+def _assert_clean_retry_state(window, message_prefix="overlay retry"):
+    _assert(window._command_model.phase == "entry", f"{message_prefix} should be in entry phase")
+    _assert(window._command_model.last_request == "", f"{message_prefix} should not retain stale typed request state")
+    _assert(window._command_model.pending_action is None, f"{message_prefix} should not retain stale pending action state")
+    _assert(window._command_model.pending_matches == (), f"{message_prefix} should not retain stale ambiguous matches")
+    _assert(window._command_panel.last_payload.get("typed_request", "") == "", f"{message_prefix} payload should not retain stale typed request state")
+    _assert(window._command_panel.last_payload.get("pending_action") is None, f"{message_prefix} payload should not retain stale confirm metadata")
+    _assert(window._command_panel.last_payload.get("ambiguous_matches") == [], f"{message_prefix} payload should not retain stale choice metadata")
+
+
 def _test_first_open_capture_allows_typing():
     window = _make_window()
     window.open_command_overlay()
@@ -422,6 +432,46 @@ def _test_confirm_cancel_refreshes_panel_layout_after_return_to_entry():
     )
 
 
+def _test_not_found_retry_edit_clears_stale_request_state():
+    window = _make_window()
+    window.open_command_overlay()
+    window._command_model.input_text = "zzzzzzz"
+    window.handle_command_submit(source="fallback")
+    _assert(window._command_model.status_kind == "not_found", "no-match request should surface not_found status")
+    _assert(window._command_model.last_request == "zzzzzzz", "not_found should record the attempted request before retry")
+    window.handle_command_text_changed("open file explorer")
+    _assert(window._command_model.status_kind == "idle", "editing after not_found should clear the stale not_found status")
+    _assert_clean_retry_state(window, "not-found retry")
+
+
+def _test_ambiguous_back_out_clears_stale_request_state_for_retry():
+    window = _make_window()
+    window.open_command_overlay()
+    window._command_model.input_text = "open nexus folder"
+    window.handle_command_submit(source="fallback")
+    _assert(window._command_model.phase == "choose", "ambiguous request should enter choose state")
+    _assert(window._command_model.last_request == "open nexus folder", "ambiguous request should record the attempted request before back-out")
+    window.handle_command_escape()
+    _assert_clean_retry_state(window, "ambiguous back-out retry")
+    window.handle_command_text_changed("open file explorer")
+    _assert(window._command_model.status_kind == "idle", "retry editing after ambiguous back-out should stay in idle entry state")
+    _assert_clean_retry_state(window, "ambiguous back-out retry after edit")
+
+
+def _test_confirm_back_out_clears_stale_request_state_for_retry():
+    window = _make_window()
+    window.open_command_overlay()
+    window._command_model.input_text = "open file explorer"
+    window.handle_command_submit(source="fallback")
+    _assert(window._command_model.phase == "confirm", "single match should enter confirm state")
+    _assert(window._command_model.last_request == "open file explorer", "confirm path should record the attempted request before back-out")
+    window.handle_command_escape()
+    _assert_clean_retry_state(window, "confirm back-out retry")
+    window.handle_command_text_changed("zzzzzzz")
+    _assert(window._command_model.status_kind == "idle", "retry editing after confirm back-out should stay in idle entry state")
+    _assert_clean_retry_state(window, "confirm back-out retry after edit")
+
+
 def _test_launch_requested_result_clears_transient_state_immediately():
     window = _make_window()
     original_launch = renderer_mod.launch_command_action
@@ -651,6 +701,9 @@ def main():
         ("confirm cancel rearms capture for human retry", _test_confirm_cancel_rearms_capture_for_human_retry_delay),
         ("choose cancel refreshes layout after return to entry", _test_choose_cancel_refreshes_panel_layout_after_return_to_entry),
         ("confirm cancel refreshes layout after return to entry", _test_confirm_cancel_refreshes_panel_layout_after_return_to_entry),
+        ("not-found retry clears stale request state", _test_not_found_retry_edit_clears_stale_request_state),
+        ("ambiguous back-out retry clears stale request state", _test_ambiguous_back_out_clears_stale_request_state_for_retry),
+        ("confirm back-out retry clears stale request state", _test_confirm_back_out_clears_stale_request_state_for_retry),
         ("launch-requested result clears transient state", _test_launch_requested_result_clears_transient_state_immediately),
         ("launch-requested timeout close reopens clean", _test_launch_requested_timeout_close_and_reopen_is_clean),
         ("launch-failed result clears and reopens clean", _test_launch_failed_result_clears_transient_state_and_reopen_is_clean),

--- a/dev/orin_overlay_input_capture_helper.py
+++ b/dev/orin_overlay_input_capture_helper.py
@@ -76,6 +76,7 @@ class _FakePanel:
         self.visible = False
         self.last_payload = None
         self.focus_after_show_calls = 0
+        self.refresh_for_geometry_calls = 0
         self._frame_rect = _FakeRect(100, 100, 400, 220)
 
     def render_payload(self, payload):
@@ -84,6 +85,12 @@ class _FakePanel:
 
     def show_for_geometry(self, *_args, **_kwargs):
         self.visible = True
+
+    def refresh_for_geometry(self, *_args, **_kwargs):
+        self.refresh_for_geometry_calls += 1
+
+    def isVisible(self):
+        return self.visible
 
     def focus_input_after_show(self):
         self.focus_after_show_calls += 1
@@ -342,6 +349,62 @@ def _test_ambiguous_choice_rearms_capture_for_human_confirm_delay():
     )
 
 
+def _test_choice_cancel_rearms_capture_for_human_retry_delay():
+    window = _make_window()
+    window.open_command_overlay()
+    window._command_model.input_text = "open nexus folder"
+    window.handle_command_submit(source="fallback")
+    before = time.monotonic()
+    window.handle_command_escape()
+    remaining = window._overlay_input_capture_until - before
+    _assert(window._command_model.phase == "entry", "Esc from choose should return to entry state")
+    _assert(
+        remaining > 4.0,
+        "choose-cancel should keep fallback capture armed long enough for a human retry",
+    )
+
+
+def _test_confirm_cancel_rearms_capture_for_human_retry_delay():
+    window = _make_window()
+    window.open_command_overlay()
+    window._command_model.input_text = "open file explorer"
+    window.handle_command_submit(source="fallback")
+    before = time.monotonic()
+    window.handle_command_escape()
+    remaining = window._overlay_input_capture_until - before
+    _assert(window._command_model.phase == "entry", "Esc from confirm should return to entry state")
+    _assert(
+        remaining > 4.0,
+        "confirm-cancel should keep fallback capture armed long enough for a human retry",
+    )
+
+
+def _test_choose_cancel_refreshes_panel_layout_after_return_to_entry():
+    window = _make_window()
+    window.open_command_overlay()
+    window._command_model.input_text = "open nexus folder"
+    window.handle_command_submit(source="fallback")
+    before = window._command_panel.refresh_for_geometry_calls
+    window.handle_command_escape()
+    _assert(
+        window._command_panel.refresh_for_geometry_calls > before,
+        "Esc from choose should refresh the overlay panel layout after returning to entry",
+    )
+
+
+def _test_confirm_cancel_refreshes_panel_layout_after_return_to_entry():
+    window = _make_window()
+    window.open_command_overlay()
+    window._command_model.input_text = "open file explorer"
+    window.handle_command_submit(source="fallback")
+    before = window._command_panel.refresh_for_geometry_calls
+    window.handle_command_escape()
+    _assert(
+        window._command_panel.refresh_for_geometry_calls > before,
+        "Esc from confirm should refresh the overlay panel layout after returning to entry",
+    )
+
+
 def _test_ambiguous_choose_confirm_execute_path():
     window = _make_window()
     launches = []
@@ -485,6 +548,10 @@ def main():
         ("confirm-ready rearms capture for human delay", _test_confirm_ready_rearms_capture_for_human_confirm_delay),
         ("ambiguous-ready rearms capture for human choice delay", _test_ambiguous_ready_rearms_capture_for_human_choice_delay),
         ("ambiguous choice rearms capture for human confirm delay", _test_ambiguous_choice_rearms_capture_for_human_confirm_delay),
+        ("choose cancel rearms capture for human retry", _test_choice_cancel_rearms_capture_for_human_retry_delay),
+        ("confirm cancel rearms capture for human retry", _test_confirm_cancel_rearms_capture_for_human_retry_delay),
+        ("choose cancel refreshes layout after return to entry", _test_choose_cancel_refreshes_panel_layout_after_return_to_entry),
+        ("confirm cancel refreshes layout after return to entry", _test_confirm_cancel_refreshes_panel_layout_after_return_to_entry),
         ("choose-confirm execute path", _test_ambiguous_choose_confirm_execute_path),
         ("capture expiry", _test_capture_expiry_stands_down_fallback),
         ("line edit focus methods", _test_line_edit_focus_methods_present),


### PR DESCRIPTION
## Summary

This PR closes the bounded FB-027 NCP hardening follow-through lane on top of the already-merged overlay-usability foundation.

## What Changed

### Changes

The branch completes the typed-first NCP hardening scope by:
- preserving stable input ownership and no-underlay leakage in the validated typed flows
- hardening cancel-and-retry behavior after `Esc`
- restoring compact layout reset after backing out of expanded states
- ensuring clean success-path result close / reopen behavior
- clearing stale request, confirm, and ambiguous state on non-success retry paths
- validating `launch_failed` as a contained recoverable failure with clean retry and reopen behavior

The branch also adds the minimum canon/truth follow-through needed to preserve the final lane state:
- canonical NCP hardening assessment
- minimal Main/backlog routing to that assessment
- failure-class / diagnostics-surface clarification in architecture/orchestration canon

### Changes

The branch completes the typed-first NCP hardening scope by:
- preserving stable input ownership and no-underlay leakage in the validated typed flows
- hardening cancel-and-retry behavior after `Esc`
- restoring compact layout reset after backing out of expanded states
- ensuring clean success-path result close / reopen behavior
- clearing stale request, confirm, and ambiguous state on non-success retry paths
- validating `launch_failed` as a contained recoverable failure with clean retry and reopen behavior

The branch also adds the minimum canon/truth follow-through needed to preserve the final lane state:
- canonical NCP hardening assessment
- minimal Main/backlog routing to that assessment
- failure-class / diagnostics-surface clarification in architecture/orchestration canon
