### PR TITLE
FB-027 first saved action source seam above the shared action model

### DIFF
--- a/desktop/saved_action_source.py
+++ b/desktop/saved_action_source.py
@@ -1,0 +1,60 @@
+import json
+import os
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+
+DEFAULT_SAVED_ACTION_FILENAME = "saved_actions.json"
+
+
+@dataclass(frozen=True)
+class SavedActionSourcePayload:
+    path: Path
+    actions: tuple[dict[str, Any], ...]
+
+
+def resolve_default_saved_action_source_path() -> Path:
+    local_app_data = os.environ.get("LOCALAPPDATA", "").strip()
+    if local_app_data:
+        return Path(local_app_data) / "Nexus Desktop AI" / DEFAULT_SAVED_ACTION_FILENAME
+
+    return Path.home() / "AppData" / "Local" / "Nexus Desktop AI" / DEFAULT_SAVED_ACTION_FILENAME
+
+
+def load_saved_action_source(
+    source_path: str | os.PathLike[str] | None = None,
+) -> SavedActionSourcePayload | None:
+    path = (
+        Path(source_path)
+        if source_path is not None
+        else resolve_default_saved_action_source_path()
+    )
+
+    try:
+        if not path.exists() or not path.is_file():
+            return None
+    except OSError:
+        return None
+
+    try:
+        raw_text = path.read_text(encoding="utf-8")
+    except (OSError, UnicodeError):
+        return None
+
+    if not raw_text.strip():
+        return None
+
+    try:
+        payload = json.loads(raw_text)
+    except json.JSONDecodeError:
+        return None
+
+    if not isinstance(payload, dict):
+        return None
+
+    actions = payload.get("actions")
+    if not isinstance(actions, list) or not actions:
+        return None
+
+    return SavedActionSourcePayload(path=path, actions=tuple(actions))

--- a/desktop/shared_action_model.py
+++ b/desktop/shared_action_model.py
@@ -6,6 +6,8 @@ from pathlib import Path
 from typing import Iterable
 from urllib.parse import urlparse, unquote
 
+from .saved_action_source import load_saved_action_source
+
 
 ROOT_DIR = Path(__file__).resolve().parent.parent
 
@@ -55,6 +57,8 @@ DEFAULT_COMMAND_ACTIONS = (
     ),
 )
 
+SUPPORTED_ACTION_TARGET_KINDS = frozenset({"app", "folder", "file", "url"})
+
 
 class CommandActionCatalog:
     def __init__(self, actions: Iterable[CommandAction] = DEFAULT_COMMAND_ACTIONS):
@@ -74,14 +78,115 @@ class CommandActionCatalog:
         return format_command_target_display(target_kind, target, max_length=max_length)
 
 
-DEFAULT_COMMAND_ACTION_CATALOG = CommandActionCatalog()
-
-
 def normalize_command_text(text: str) -> str:
     normalized = (text or "").strip().casefold()
     normalized = re.sub(r"\s+", " ", normalized)
     normalized = re.sub(r"[.!?]+$", "", normalized)
     return normalized.strip()
+
+
+def _normalized_action_phrases(action: CommandAction) -> set[str]:
+    normalized_phrases: set[str] = set()
+    for phrase in (action.title, *action.aliases):
+        normalized = normalize_command_text(phrase)
+        if not normalized:
+            raise ValueError("Action phrases must be non-empty.")
+        normalized_phrases.add(normalized)
+    return normalized_phrases
+
+
+def _require_saved_action_string(record: dict, field_name: str) -> str:
+    value = record.get(field_name)
+    if not isinstance(value, str):
+        raise ValueError(f"Saved action field '{field_name}' must be a string.")
+
+    normalized = value.strip()
+    if not normalized:
+        raise ValueError(f"Saved action field '{field_name}' must not be empty.")
+    return normalized
+
+
+def _coerce_saved_action_aliases(record: dict) -> tuple[str, ...]:
+    aliases = record.get("aliases", ())
+    if aliases in (None, ""):
+        return ()
+
+    if not isinstance(aliases, (list, tuple)):
+        raise ValueError("Saved action aliases must be a list of strings.")
+
+    normalized_aliases: list[str] = []
+    for alias in aliases:
+        if not isinstance(alias, str):
+            raise ValueError("Saved action aliases must contain only strings.")
+        normalized = alias.strip()
+        if not normalized:
+            raise ValueError("Saved action aliases must not be empty.")
+        normalized_aliases.append(normalized)
+
+    return tuple(normalized_aliases)
+
+
+def _command_action_from_saved_record(record: object) -> CommandAction:
+    if not isinstance(record, dict):
+        raise ValueError("Saved action records must be objects.")
+
+    target_kind = _require_saved_action_string(record, "target_kind").casefold()
+    if target_kind not in SUPPORTED_ACTION_TARGET_KINDS:
+        raise ValueError("Saved action target_kind is unsupported.")
+
+    return CommandAction(
+        id=_require_saved_action_string(record, "id"),
+        title=_require_saved_action_string(record, "title"),
+        target_kind=target_kind,
+        target=_require_saved_action_string(record, "target"),
+        aliases=_coerce_saved_action_aliases(record),
+    )
+
+
+def load_saved_command_actions(
+    source_path: str | os.PathLike[str] | None = None,
+) -> tuple[CommandAction, ...]:
+    payload = load_saved_action_source(source_path)
+    if payload is None:
+        return ()
+
+    try:
+        seen_ids = {action.id.casefold() for action in DEFAULT_COMMAND_ACTIONS}
+        seen_phrases: set[str] = set()
+        for action in DEFAULT_COMMAND_ACTIONS:
+            seen_phrases.update(_normalized_action_phrases(action))
+
+        saved_actions: list[CommandAction] = []
+        for record in payload.actions:
+            action = _command_action_from_saved_record(record)
+            normalized_id = action.id.casefold()
+            if normalized_id in seen_ids:
+                raise ValueError("Saved action id collides with an existing action.")
+
+            normalized_phrases = _normalized_action_phrases(action)
+            if normalized_phrases & seen_phrases:
+                raise ValueError("Saved action title or alias collides with an existing action.")
+
+            seen_ids.add(normalized_id)
+            seen_phrases.update(normalized_phrases)
+            saved_actions.append(action)
+
+        return tuple(saved_actions)
+    except ValueError:
+        return ()
+
+
+def build_default_command_action_catalog(
+    source_path: str | os.PathLike[str] | None = None,
+) -> CommandActionCatalog:
+    saved_actions = load_saved_command_actions(source_path)
+    if not saved_actions:
+        return CommandActionCatalog(DEFAULT_COMMAND_ACTIONS)
+
+    return CommandActionCatalog((*DEFAULT_COMMAND_ACTIONS, *saved_actions))
+
+
+DEFAULT_COMMAND_ACTION_CATALOG = build_default_command_action_catalog()
 
 
 def resolve_command_actions(text: str, actions=DEFAULT_COMMAND_ACTIONS):

--- a/desktop/shared_action_model.py
+++ b/desktop/shared_action_model.py
@@ -57,7 +57,7 @@ DEFAULT_COMMAND_ACTIONS = (
     ),
 )
 
-SUPPORTED_ACTION_TARGET_KINDS = frozenset({"app", "folder", "file", "url"})
+SUPPORTED_ACTION_TARGET_KINDS = frozenset({"app", "folder", "file"})
 
 
 class CommandActionCatalog:


### PR DESCRIPTION
## Summary

This PR delivers the next narrow FB-027 interaction-model slice above the merged shared-action-model foundation.

## What Changed

### Changes

It introduces the first bounded non-UI saved-action source seam for direct actions and aliases, then integrates that seam into the shared command action model with strict fallback to the current built-in actions.

The current typed-first NCP behavior is intentionally preserved.

### Included Scope

- add `desktop/saved_action_source.py` as the first non-UI loader seam for saved direct actions
- load saved action records through the shared action model instead of expanding overlay ownership
- validate saved action records conservatively inside the shared action boundary
- reject saved-action id and normalized title/alias collisions against built-ins or other saved actions
- preserve strict built-in fallback when the saved-action source is missing, unreadable, empty, or invalid
- preserve current exact-match title/alias resolution semantics
- preserve current ambiguous, confirm, `not_found`, success, non-success, and `launch_failed` overlay behavior by leaving overlay and renderer behavior unchanged

### Merge Intent

This PR is merge-only.

It is not intended as an immediate release cut by itself, because the branch is a narrow saved-action-source seam above the shared action model rather than a new standalone user-facing milestone.

### Changes

### Included Scope

- add `desktop/saved_action_source.py` as the first non-UI loader seam for saved direct actions
- load saved action records through the shared action model instead of expanding overlay ownership
- validate saved action records conservatively inside the shared action boundary
- reject saved-action id and normalized title/alias collisions against built-ins or other saved actions
- preserve strict built-in fallback when the saved-action source is missing, unreadable, empty, or invalid
- preserve current exact-match title/alias resolution semantics
- preserve current ambiguous, confirm, `not_found`, success, non-success, and `launch_failed` overlay behavior by leaving overlay and renderer behavior unchanged

### Merge Intent
