### PR TITLE
[codex] Limit direct PR opening to docs-only branches

### DIFF
--- a/Docs/codex_modes.md
+++ b/Docs/codex_modes.md
@@ -433,6 +433,18 @@ Codex should instead return:
 
 If actual file review is needed, the file should be reviewed outside Codex by uploading it for inspection.
 
+## Pull Request Opening Boundary
+
+Codex may open or submit a pull request directly only for an approved docs-only branch.
+
+For code branches or mixed code/docs branches, Codex may:
+
+- perform PR-readiness analysis
+- provide the exact PR title and PR body
+- provide merge and release posture guidance
+
+For those non-docs-only branches, Codex should stop short of opening the PR.
+
 ---
 
 ## Backlog-Control Reminder


### PR DESCRIPTION
## Summary

This PR adds a narrow workflow-governance rule to the source of truth.

## What Changed

### Changes

It makes explicit that Codex may open or submit a pull request directly only for an approved docs-only branch.

### Included Scope

- add a `Pull Request Opening Boundary` section to `Docs/codex_modes.md`
- allow Codex to keep doing PR-readiness analysis, exact PR drafting, and merge/release posture guidance for code or mixed branches
- require Codex to stop short of opening the PR for non-docs-only branches

### Why

This keeps GitHub execution authority aligned with the project’s existing scope-control and governance boundaries.

### Changes

### Included Scope

- add a `Pull Request Opening Boundary` section to `Docs/codex_modes.md`
- allow Codex to keep doing PR-readiness analysis, exact PR drafting, and merge/release posture guidance for code or mixed branches
- require Codex to stop short of opening the PR for non-docs-only branches

### Why
