### PR TITLE
Add a starter saved-actions bootstrap path

### DIFF
--- a/desktop/saved_action_source.py
+++ b/desktop/saved_action_source.py
@@ -6,6 +6,26 @@ from typing import Any
 
 
 DEFAULT_SAVED_ACTION_FILENAME = "saved_actions.json"
+DEFAULT_SAVED_ACTION_TEMPLATE = {
+    "schema_version": 1,
+    "actions": [],
+    "examples": [
+        {
+            "id": "open_notepad",
+            "title": "Open Notepad",
+            "target_kind": "app",
+            "target": "notepad.exe",
+            "aliases": ["open notepad"],
+        },
+        {
+            "id": "open_downloads",
+            "title": "Open Downloads",
+            "target_kind": "folder",
+            "target": r"C:\Users\YourName\Downloads",
+            "aliases": ["open downloads", "show downloads"],
+        },
+    ],
+}
 
 
 @dataclass(frozen=True)
@@ -22,6 +42,34 @@ def resolve_default_saved_action_source_path() -> Path:
     return Path.home() / "AppData" / "Local" / "Nexus Desktop AI" / DEFAULT_SAVED_ACTION_FILENAME
 
 
+def _default_saved_action_source_text() -> str:
+    return json.dumps(DEFAULT_SAVED_ACTION_TEMPLATE, indent=2) + "\n"
+
+
+def ensure_saved_action_source_bootstrap(
+    source_path: str | os.PathLike[str] | None = None,
+) -> Path | None:
+    path = (
+        Path(source_path)
+        if source_path is not None
+        else resolve_default_saved_action_source_path()
+    )
+
+    try:
+        if path.exists():
+            return path if path.is_file() else None
+    except OSError:
+        return None
+
+    try:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(_default_saved_action_source_text(), encoding="utf-8")
+    except OSError:
+        return None
+
+    return path
+
+
 def load_saved_action_source(
     source_path: str | os.PathLike[str] | None = None,
 ) -> SavedActionSourcePayload | None:
@@ -30,6 +78,13 @@ def load_saved_action_source(
         if source_path is not None
         else resolve_default_saved_action_source_path()
     )
+
+    # Bootstrap only the default runtime source so users get an explicit starter
+    # file without widening fallback behavior for custom or validation-only paths.
+    if source_path is None:
+        bootstrapped_path = ensure_saved_action_source_bootstrap()
+        if bootstrapped_path is not None:
+            path = bootstrapped_path
 
     try:
         if not path.exists() or not path.is_file():


### PR DESCRIPTION
## Summary

This PR delivers the next narrow FB-027 interaction-model slice above the merged shared-action-model and saved-action-source foundation.

## What Changed

### Changes

It adds the first restart-based starter bootstrap path for `saved_actions.json` inside the saved-action source layer so users can get a valid starter file without introducing a UI authoring surface.

The current typed-first NCP behavior is intentionally preserved.

### Included Scope

- add a starter `saved_actions.json` template inside `desktop/saved_action_source.py`
- add a bounded bootstrap helper for the saved-action source path
- auto-create the starter file only for the default runtime path
- keep explicit custom `source_path` calls conservative and fallback-only
- preserve current exact title/alias matching semantics
- preserve current ambiguous, confirm, `not_found`, success, non-success, and `launch_failed` overlay behavior by leaving overlay and renderer behavior unchanged

### Merge Intent

This PR is merge-only.

It is not intended as an immediate release cut by itself, because it is a narrow saved-action bootstrap slice above the current shared-action foundation rather than a new standalone public milestone.

### Changes

### Included Scope

- add a starter `saved_actions.json` template inside `desktop/saved_action_source.py`
- add a bounded bootstrap helper for the saved-action source path
- auto-create the starter file only for the default runtime path
- keep explicit custom `source_path` calls conservative and fallback-only
- preserve current exact title/alias matching semantics
- preserve current ambiguous, confirm, `not_found`, success, non-success, and `launch_failed` overlay behavior by leaving overlay and renderer behavior unchanged

### Merge Intent
