### PR TITLE
Tighten grouped lane execution governance

### DIFF
--- a/Docs/Main.md
+++ b/Docs/Main.md
@@ -233,6 +233,7 @@ This governance lane includes:
 For reusable human-facing prompt patterns and operator shorthand examples, use `docs/codex_user_guide.md`.
 
 For current near-term roadmap, branch-sequencing, or provisional version-impact questions, use `docs/prebeta_roadmap.md`.
+For grouped `pre-Beta` branch-sizing, minimum merge-ready threshold, or "should this lane stop now?" questions, use `docs/prebeta_roadmap.md` together with `docs/codex_modes.md`.
 That roadmap remains subordinate to:
 
 - `docs/orin_vision.md` for release-stage meaning

--- a/Docs/codex_modes.md
+++ b/Docs/codex_modes.md
@@ -328,6 +328,24 @@ For those `pre-Beta` focus-group lanes:
 - release cadence should follow meaningful lane milestones when a release is appropriate
 - grouped branches must still be split if the work starts crossing subsystem boundaries or accumulating unrelated fixes
 
+## Grouped Lane Milestone Gate
+
+For an active `pre-Beta` grouped workstream branch, Codex should define before implementation:
+
+- the lane milestone target
+- the minimum merge-ready threshold
+- the tightly coupled groundwork that still belongs inside the same branch
+
+Codex should not treat the first validated revision inside that branch as PR-ready by default.
+
+Instead, Codex should continue through additional narrow slices inside the same branch until:
+
+- the declared minimum merge-ready threshold is reached
+- a real blocker appears
+- or the user explicitly chooses to stop early
+
+If enabling groundwork and the first usable outcome are tightly coupled inside one subsystem and remain low-risk, they should usually stay in the same grouped branch rather than being split into separate micro-branches or premature PRs.
+
 At `Beta` and later, the default recommendation should usually shift toward:
 
 - issue-specific branches

--- a/Docs/prebeta_roadmap.md
+++ b/Docs/prebeta_roadmap.md
@@ -80,6 +80,19 @@ Handling rule:
 - move closed or superseded items out of the active near-term horizon once they stop helping next-lane planning
 - keep detailed implementation truth in `docs/feature_backlog.md`, not here
 
+## Lane Milestone Fields
+
+For each `active` grouped lane, and for the current best next `candidate` when one is named here, include:
+
+- `milestone target`
+- `minimum merge-ready threshold`
+
+These fields are still provisional planning guidance.
+
+They do not guarantee that a lane will continue unchanged if live repo truth shifts or a blocker appears.
+
+They do require Codex to judge PR-readiness against the lane milestone rather than against the first clean internal revision.
+
 ## Refresh Triggers
 
 Refresh this roadmap when:
@@ -87,6 +100,7 @@ Refresh this roadmap when:
 - a meaningful milestone merges to `main`
 - a public prerelease is cut
 - a docs-only rebaseline materially changes the planning baseline
+- the current best next lane changes lifecycle state between `candidate`, `active`, `merged`, `closed`, `deferred`, or `superseded`
 - `main` materially advances beyond the latest public release and this roadmap no longer matches live repo truth
 
 This roadmap should usually be refreshed by one narrow docs-only governance or rebaseline pass rather than by ad hoc wording drift across multiple unrelated branches.
@@ -97,15 +111,17 @@ This is the current best provisional sequencing horizon from live repo truth aft
 
 ### 1. `feature/prebeta-roadmap-rebaseline`
 
-- status: `active`
+- status: `merged`
 - version impact: `no release`
 - purpose: docs-only governance and planning reset so near-term sequencing and provisional version-impact planning have one canonical interface
 
 ### 2. `feature/fb-027-saved-action-usability`
 
-- status: `candidate`
+- status: `active`
 - version impact: `candidate patch prerelease`
 - purpose: grouped FB-027 usability follow-through above the current shared-action, saved-action-source, and starter-bootstrap baseline
+- milestone target: the first coherent saved-action usability milestone above the current starter-bootstrap baseline
+- minimum merge-ready threshold: the current command surface can do more than create the starter file; it must also help the user reach or use that source in a practical bounded way without widening into Action Studio, live reload, or broader interaction redesign
 
 ### 3. `feature/prebeta-v1.2.1-rebaseline`
 


### PR DESCRIPTION
## Summary

This PR closes the execution-governance gap that was still allowing grouped pre-Beta lanes to be treated like chains of tiny stopping points.

## What Changed

### Changes

It keeps the fix narrow and docs-only by:
- adding a grouped lane milestone gate to `Docs/codex_modes.md`
- updating `Docs/prebeta_roadmap.md` so active/candidate lanes carry milestone fields and stronger lifecycle refresh guidance
- updating `Docs/Main.md` so grouped pre-Beta “should this lane stop now?” questions route to the right canon pair

### Included Scope

- update `Docs/codex_modes.md` with a grouped lane milestone gate
- update `Docs/prebeta_roadmap.md` with:
  - lane milestone fields
  - stronger lifecycle refresh handling
  - current lane lifecycle sync
- update `Docs/Main.md` with one routing sentence for grouped pre-Beta branch-sizing / stop-now questions

### Merge Intent

This PR is merge-only.

It is not intended as an immediate release cut by itself, because it is a docs-only execution-governance refinement and roadmap maintenance sync, not a new public milestone.

### Changes

It keeps the fix narrow and docs-only by:
- adding a grouped lane milestone gate to `Docs/codex_modes.md`
- updating `Docs/prebeta_roadmap.md` so active/candidate lanes carry milestone fields and stronger lifecycle refresh guidance
- updating `Docs/Main.md` so grouped pre-Beta “should this lane stop now?” questions route to the right canon pair

### Included Scope

- update `Docs/codex_modes.md` with a grouped lane milestone gate
- update `Docs/prebeta_roadmap.md` with:
  - lane milestone fields
  - stronger lifecycle refresh handling
  - current lane lifecycle sync
- update `Docs/Main.md` with one routing sentence for grouped pre-Beta branch-sizing / stop-now questions

### Merge Intent
