### PR TITLE
FB-027 built-in saved-actions file and folder actions

### DIFF
--- a/desktop/shared_action_model.py
+++ b/desktop/shared_action_model.py
@@ -6,10 +6,15 @@ from pathlib import Path
 from typing import Iterable
 from urllib.parse import urlparse, unquote
 
-from .saved_action_source import load_saved_action_source
+from .saved_action_source import (
+    load_saved_action_source,
+    resolve_default_saved_action_source_path,
+)
 
 
 ROOT_DIR = Path(__file__).resolve().parent.parent
+DEFAULT_SAVED_ACTION_SOURCE_PATH = resolve_default_saved_action_source_path()
+DEFAULT_SAVED_ACTION_SOURCE_FOLDER = DEFAULT_SAVED_ACTION_SOURCE_PATH.parent
 
 
 @dataclass(frozen=True)
@@ -54,6 +59,29 @@ DEFAULT_COMMAND_ACTIONS = (
         target_kind="app",
         target="explorer.exe",
         aliases=("open windows explorer", "open file explorer", "windows explorer"),
+    ),
+    CommandAction(
+        id="open_saved_actions_file",
+        title="Open Saved Actions File",
+        target_kind="file",
+        target=str(DEFAULT_SAVED_ACTION_SOURCE_PATH),
+        aliases=(
+            "open saved actions file",
+            "open saved actions json",
+            "open saved actions config",
+            "edit saved actions file",
+        ),
+    ),
+    CommandAction(
+        id="open_saved_actions_folder",
+        title="Open Saved Actions Folder",
+        target_kind="folder",
+        target=str(DEFAULT_SAVED_ACTION_SOURCE_FOLDER),
+        aliases=(
+            "open saved actions folder",
+            "open saved actions directory",
+            "show saved actions folder",
+        ),
     ),
 )
 


### PR DESCRIPTION
## Summary

This PR delivers the first coherent saved-action usability milestone above the merged shared-action, saved-action-source, and starter-bootstrap baseline.

## What Changed

### Changes

It adds built-in direct actions in the shared action model so the current command surface can open the default `saved_actions.json` file and its containing folder without widening into Action Studio, live reload, or broader interaction redesign.

### Included Scope

- update `desktop/shared_action_model.py`
- add a built-in direct action to open the default `saved_actions.json` file
- add a built-in direct action to open the folder containing that file
- use the existing default saved-action source path logic from `desktop/saved_action_source.py`
- preserve exact title/alias matching semantics
- preserve overlay and renderer behavior unchanged

### Merge Intent

This PR is merge-only.

It is not intended as an immediate release cut by itself, because the lane remains only a candidate patch prerelease and this branch is a narrow saved-action usability milestone rather than an automatic public release boundary.

### Changes

### Included Scope

- update `desktop/shared_action_model.py`
- add a built-in direct action to open the default `saved_actions.json` file
- add a built-in direct action to open the folder containing that file
- use the existing default saved-action source path logic from `desktop/saved_action_source.py`
- preserve exact title/alias matching semantics
- preserve overlay and renderer behavior unchanged

### Merge Intent
