### PR TITLE
Enforce version-bearing pre-Beta branch governance

### DIFF
--- a/Docs/Main.md
+++ b/Docs/Main.md
@@ -232,8 +232,8 @@ This governance lane includes:
 
 For reusable human-facing prompt patterns and operator shorthand examples, use `docs/codex_user_guide.md`.
 
-For current near-term roadmap, branch-sequencing, or provisional version-impact questions, use `docs/prebeta_roadmap.md`.
-For grouped `pre-Beta` branch-sizing, minimum merge-ready threshold, or "should this lane stop now?" questions, use `docs/prebeta_roadmap.md` together with `docs/codex_modes.md`.
+For current near-term roadmap, branch-sequencing, or provisional release-floor / target-version questions, use `docs/prebeta_roadmap.md`.
+For grouped `pre-Beta` branch-sizing, minimum merge-ready threshold, release floor, target version, release-debt, or "should this lane stop now?" questions, use `docs/prebeta_roadmap.md` together with `docs/codex_modes.md`.
 That roadmap remains subordinate to:
 
 - `docs/orin_vision.md` for release-stage meaning

--- a/Docs/closeout_guidance.md
+++ b/Docs/closeout_guidance.md
@@ -124,6 +124,8 @@ For the current Nexus pre-Beta line, closeouts should usually be milestone-based
 
 That means:
 
+- a non-doc implementation branch may still justify the next prerelease even when it does not need its own dedicated closeout doc
+- docs-only governance or rebaseline branches remain the common no-release exception
 - do not force a new closeout doc for every small pre-Beta patch release
 - do create a closeout when a meaningful milestone or lane has actually stabilized and future planning will benefit from a fresh baseline
 

--- a/Docs/codex_modes.md
+++ b/Docs/codex_modes.md
@@ -325,7 +325,8 @@ For `pre-Beta`, the default branch strategy should usually prefer focus-group la
 For those `pre-Beta` focus-group lanes:
 
 - merge cadence should follow meaningful lane milestones rather than every tiny follow-through
-- release cadence should follow meaningful lane milestones when a release is appropriate
+- non-doc implementation branches should usually be version-bearing lane milestones rather than merge-only deltas
+- release cadence should follow those implementation-lane milestones and should usually advance by at least the next patch prerelease step unless the user explicitly approves a different posture
 - grouped branches must still be split if the work starts crossing subsystem boundaries or accumulating unrelated fixes
 
 ## Grouped Lane Milestone Gate
@@ -345,6 +346,54 @@ Instead, Codex should continue through additional narrow slices inside the same 
 - or the user explicitly chooses to stop early
 
 If enabling groundwork and the first usable outcome are tightly coupled inside one subsystem and remain low-risk, they should usually stay in the same grouped branch rather than being split into separate micro-branches or premature PRs.
+
+## Grouped Lane Release Floor
+
+For an active `pre-Beta` grouped lane, Codex should also define before implementation:
+
+- the lane type
+- the release floor
+- the target version for non-doc implementation lanes
+
+Use these lane types:
+
+- `docs-only`
+- `implementation`
+- `rebaseline`
+
+Use these release floors:
+
+- `no release`
+- `patch prerelease`
+- `minor prerelease`
+
+Rules:
+
+- `docs-only` branches are the default and preferred `no release` exception
+- `rebaseline` branches may remain `no release` when they are docs-only and are only syncing baseline truth after a release or milestone
+- non-doc `implementation` branches should usually declare at least `patch prerelease`
+- larger subsystem or capability shifts may justify `minor prerelease`
+
+Codex should judge PR-readiness for a non-doc implementation branch against:
+
+- the lane milestone target
+- the minimum merge-ready threshold
+- the declared release floor
+- the declared target version
+
+## Release-Debt Stop Rule
+
+If `main` already contains merged unreleased non-doc implementation work beyond the latest public prerelease, Codex should treat that as release debt.
+
+While release debt exists, Codex should not recommend merging another non-doc implementation branch by default unless:
+
+- the new branch is the intentionally selected version-bearing milestone that resolves that debt
+- or the user explicitly approves stacking more implementation before the next release
+
+When release debt exists, the default next move should usually be:
+
+- release or version-readiness review
+- or a docs-only rebaseline or governance pass that is directly needed to resolve the release decision cleanly
 
 At `Beta` and later, the default recommendation should usually shift toward:
 

--- a/Docs/development_rules.md
+++ b/Docs/development_rules.md
@@ -80,6 +80,8 @@ In Jarvis workflow terms:
 
 - one fix per revision means one coherent approved subproblem per revision, not one tiny mechanical fragment
 - minimal isolated changes means the minimal coherent approved change set needed to close that subproblem
+- multiple revisions may still live inside one grouped implementation branch when they are tightly coupled to one milestone
+- except for docs-only governance or rebaseline branches, a `pre-Beta` branch should usually target one version-bearing milestone rather than a merge-only code delta
 
 Use the smallest safe slice for:
 

--- a/Docs/prebeta_roadmap.md
+++ b/Docs/prebeta_roadmap.md
@@ -9,7 +9,7 @@ Use it for:
 - the current near-term roadmap horizon
 - the current best next lane candidates
 - provisional sequencing
-- provisional version-impact planning
+- provisional release-floor and target-version planning
 - roadmap refresh triggers
 - roadmap entry lifecycle/status handling
 
@@ -44,24 +44,43 @@ That means:
 
 If this roadmap conflicts with those docs, those docs win.
 
-## Version-Impact Labels
+## Lane Types, Release Floors, And Release States
 
-Use only these provisional labels in this roadmap:
+Use these lane types in this roadmap:
+
+- `docs-only`
+- `implementation`
+- `rebaseline`
+
+Use these release floors in this roadmap:
 
 - `no release`
-- `candidate patch prerelease`
-- `candidate minor prerelease`
-- `not a release lane / rebaseline only`
+- `patch prerelease`
+- `minor prerelease`
 
-These labels are planning guidance only.
+Use these release states when relevant:
+
+- `active delta`
+- `merged unreleased`
+- `released`
+- `closed`
+
+These fields are planning guidance only.
 
 They do not:
 
 - assign fixed future version numbers
 - guarantee that a listed branch will ship
-- turn a candidate into an approved release
+- turn a release floor into an approved release by itself
 
 Actual release decisions still depend on live repo truth, milestone value, and later readiness review.
+
+Rules:
+
+- `no release` should normally be limited to `docs-only` or docs-only `rebaseline` lanes
+- non-doc `implementation` lanes should usually declare at least `patch prerelease`
+- larger subsystem or capability shifts may justify `minor prerelease`
+- if merged unreleased implementation work already exists on `main`, that should be treated as release debt rather than as normal background drift
 
 ## Entry Lifecycle
 
@@ -84,8 +103,12 @@ Handling rule:
 
 For each `active` grouped lane, and for the current best next `candidate` when one is named here, include:
 
+- `lane type`
 - `milestone target`
 - `minimum merge-ready threshold`
+- `release floor`
+- `target version` for non-doc implementation lanes
+- `release state` when merged implementation work already exists for that lane
 
 These fields are still provisional planning guidance.
 
@@ -101,9 +124,20 @@ Refresh this roadmap when:
 - a public prerelease is cut
 - a docs-only rebaseline materially changes the planning baseline
 - the current best next lane changes lifecycle state between `candidate`, `active`, `merged`, `closed`, `deferred`, or `superseded`
+- the current release-debt posture changes
 - `main` materially advances beyond the latest public release and this roadmap no longer matches live repo truth
 
 This roadmap should usually be refreshed by one narrow docs-only governance or rebaseline pass rather than by ad hoc wording drift across multiple unrelated branches.
+
+## Release-Debt Handling
+
+If `main` already contains merged unreleased non-doc implementation work beyond the latest public prerelease, treat that as release debt.
+
+While release debt exists:
+
+- docs-only governance, rebaseline, or release-support lanes may still proceed when they are directly needed
+- the current best next non-doc move should usually be release review, release prep, or an explicitly approved continuation of the same version-bearing milestone
+- another unrelated non-doc implementation lane should not merge by default
 
 ## Current Near-Term Roadmap Horizon
 
@@ -112,27 +146,35 @@ This is the current best provisional sequencing horizon from live repo truth aft
 ### 1. `feature/prebeta-roadmap-rebaseline`
 
 - status: `merged`
-- version impact: `no release`
+- lane type: `docs-only`
+- release floor: `no release`
+- release state: `closed`
 - purpose: docs-only governance and planning reset so near-term sequencing and provisional version-impact planning have one canonical interface
 
 ### 2. `feature/fb-027-saved-action-usability`
 
 - status: `active`
-- version impact: `candidate patch prerelease`
+- lane type: `implementation`
+- release floor: `patch prerelease`
+- target version: `v1.2.1-prebeta`
+- release state: `merged unreleased`
 - purpose: grouped FB-027 usability follow-through above the current shared-action, saved-action-source, and starter-bootstrap baseline
 - milestone target: the first coherent saved-action usability milestone above the current starter-bootstrap baseline
-- minimum merge-ready threshold: the current command surface can do more than create the starter file; it must also help the user reach or use that source in a practical bounded way without widening into Action Studio, live reload, or broader interaction redesign
+- minimum merge-ready threshold: the current command surface can do more than create the starter file; it must also help the user reach or use that source in a practical bounded way, and the resulting lane should be strong enough to justify the declared patch prerelease rather than another merge-only code delta
 
 ### 3. `feature/prebeta-v1.2.1-rebaseline`
 
 - status: `candidate`
-- version impact: `not a release lane / rebaseline only`
+- lane type: `rebaseline`
+- release floor: `no release`
 - purpose: only if a prior lane becomes release-worthy, do a milestone closure and release-baseline sync pass without treating that branch as a separate public version by itself
 
 ### 4. `feature/fb-034-recoverable-diagnostics`
 
 - status: `candidate`
-- version impact: `candidate patch prerelease`
+- lane type: `implementation`
+- release floor: `patch prerelease`
+- target version: `TBD after current release-debt resolution`
 - purpose: first bounded recoverable diagnostics and reporting lane if later analysis confirms it is the right next subsystem milestone
 
 ## Current Reading
@@ -140,7 +182,9 @@ This is the current best provisional sequencing horizon from live repo truth aft
 Current repo truth indicates:
 
 - the latest public prerelease is still `v1.2.0-prebeta`
-- `main` has moved ahead through several merged follow-through slices
+- `main` has moved ahead through several merged follow-through slices, including merged unreleased implementation work
 - the next best move is still to prefer milestone-shaped grouped lanes over more micro-branches
+- the current gap between `v1.2.0-prebeta` and `main` should be treated as release debt, not as normal background drift
 
-That does **not** mean every listed lane should automatically happen, or that each lane implies a new public version.
+That does **not** mean every listed lane should automatically happen.
+It does mean non-doc implementation lanes should be treated as version-bearing milestones rather than as merge-only background follow-through.


### PR DESCRIPTION
## Summary

This PR tightens the pre-Beta governance canon so non-doc implementation branches are treated as version-bearing milestones rather than merge-only deltas.

## What Changed

### Changes

It closes the process gap that allowed multiple implementation PRs to merge after `v1.2.0-prebeta` without advancing the public version line.

### Included Scope

- update `Docs/development_rules.md` to clarify that multiple revisions may live inside one grouped implementation branch and that non-doc pre-Beta branches should usually target one version-bearing milestone
- update `Docs/codex_modes.md` to add grouped-lane release-floor rules and a release-debt stop rule
- update `Docs/prebeta_roadmap.md` to track lane type, release floor, target version, release state, and release-debt handling
- update `Docs/Main.md` routing so grouped pre-Beta branch-sizing and release-debt questions use the roadmap together with `Docs/codex_modes.md`
- update `Docs/closeout_guidance.md` to clarify that a version-bearing implementation branch does not require a dedicated closeout doc every time

### Merge Intent

This PR is merge-only.

It is not intended as an immediate release cut by itself, because it is a docs-only governance reset that tightens version-bearing branch rules and release-debt handling rather than adding a new user-facing product milestone.

### Changes

### Included Scope

- update `Docs/development_rules.md` to clarify that multiple revisions may live inside one grouped implementation branch and that non-doc pre-Beta branches should usually target one version-bearing milestone
- update `Docs/codex_modes.md` to add grouped-lane release-floor rules and a release-debt stop rule
- update `Docs/prebeta_roadmap.md` to track lane type, release floor, target version, release state, and release-debt handling
- update `Docs/Main.md` routing so grouped pre-Beta branch-sizing and release-debt questions use the roadmap together with `Docs/codex_modes.md`
- update `Docs/closeout_guidance.md` to clarify that a version-bearing implementation branch does not require a dedicated closeout doc every time

### Merge Intent
