### PR TITLE
Refresh post-v1.2.1 pre-Beta roadmap

### DIFF
--- a/Docs/feature_backlog.md
+++ b/Docs/feature_backlog.md
@@ -1158,6 +1158,8 @@ Current merged follow-through above that same foundation now also includes:
 - strict built-in fallback when the saved-action source is missing, unreadable, empty, or invalid
 - conservative saved-action validation for supported target kinds plus id/title/alias collision rejection against built-ins or other saved actions
 - a first restart-based starter bootstrap path for `saved_actions.json` inside the saved-action source layer
+- built-in direct actions to open the default saved-actions file and its containing folder from the current typed command surface
+- backward-compatible preservation of unrelated valid saved actions when legacy saved-actions file or folder helpers collide with those built-ins
 - starter-file auto-creation only for the default runtime path, while explicit custom source paths remain conservative and fallback-only
 
 These merged follow-through items remain part of the same staged `FB-027` interaction lane rather than separate backlog items.
@@ -1173,8 +1175,8 @@ Current repo truth remains conservative:
 
 - NCP hardening is still FB-027 follow-through, not a separate backlog item
 - the approved NCP hardening lane is now closed on `main`, with no current repo-truth need for another automatic NCP hardening patch
-- the shared-action-model, saved-action-source, and starter-bootstrap follow-through slices are also now merged on `main`
-- the next pre-Beta interaction step, if resumed later, should start above the current shared action model and saved-action bootstrap foundation rather than reopening NCP hardening by inertia
+- the shared-action-model, saved-action-source, starter-bootstrap, and first saved-action-usability follow-through slices are now merged on `main`, with that saved-action usability milestone shipped in `v1.2.1-prebeta`
+- the next pre-Beta interaction step, if resumed later, should start above the current shared action model, saved-action bootstrap, and released saved-actions access foundation rather than reopening NCP hardening by inertia
 
 Release-stage mapping:
 

--- a/Docs/orin_interaction_architecture.md
+++ b/Docs/orin_interaction_architecture.md
@@ -305,7 +305,11 @@ The repo now also includes:
 - the first reusable shared action model underneath the typed command surface
 - the first bounded non-UI saved-action source seam above that shared action model
 - the first restart-based starter bootstrap path for `saved_actions.json` at the default runtime source location
+- built-in direct actions to open the default saved-actions file and its containing folder from the same typed command surface
+- backward-compatible preservation of unrelated valid saved actions when legacy saved-actions file or folder helpers collide with those built-ins
 - preserved exact-match resolution semantics and the existing typed-first confirm-before-execute contract while those architectural seams were introduced
+
+Current merged repo truth now reaches the first coherent saved-action usability milestone above that starter-bootstrap baseline.
 
 ## Beta Release Direction
 

--- a/Docs/prebeta_roadmap.md
+++ b/Docs/prebeta_roadmap.md
@@ -141,9 +141,21 @@ While release debt exists:
 
 ## Current Near-Term Roadmap Horizon
 
-This is the current best provisional sequencing horizon from live repo truth after the merged post-`v1.2.0-prebeta` follow-through on `main`.
+This is the current best provisional sequencing horizon from live repo truth after the live `v1.2.1-prebeta` release.
 
-### 1. `feature/prebeta-roadmap-rebaseline`
+### 1. `feature/fb-034-recoverable-diagnostics`
+
+- status: `candidate`
+- lane type: `implementation`
+- release floor: `patch prerelease`
+- target version: `v1.2.2-prebeta`
+- purpose: first bounded recoverable diagnostics and reporting lane if later analysis confirms it is the right next subsystem milestone
+
+## Recently Closed Or Superseded Lanes
+
+These entries remain here only long enough to keep the post-`v1.2.1-prebeta` transition explicit.
+
+### `feature/prebeta-roadmap-rebaseline`
 
 - status: `merged`
 - lane type: `docs-only`
@@ -151,40 +163,34 @@ This is the current best provisional sequencing horizon from live repo truth aft
 - release state: `closed`
 - purpose: docs-only governance and planning reset so near-term sequencing and provisional version-impact planning have one canonical interface
 
-### 2. `feature/fb-027-saved-action-usability`
+### `feature/fb-027-saved-action-usability`
 
-- status: `active`
+- status: `closed`
 - lane type: `implementation`
 - release floor: `patch prerelease`
 - target version: `v1.2.1-prebeta`
-- release state: `merged unreleased`
-- purpose: grouped FB-027 usability follow-through above the current shared-action, saved-action-source, and starter-bootstrap baseline
+- release state: `released`
+- purpose: released FB-027 usability milestone above the current shared-action, saved-action-source, and starter-bootstrap baseline
 - milestone target: the first coherent saved-action usability milestone above the current starter-bootstrap baseline
 - minimum merge-ready threshold: the current command surface can do more than create the starter file; it must also help the user reach or use that source in a practical bounded way, and the resulting lane should be strong enough to justify the declared patch prerelease rather than another merge-only code delta
 
-### 3. `feature/prebeta-v1.2.1-rebaseline`
+### `feature/prebeta-v1.2.1-rebaseline`
 
-- status: `candidate`
+- status: `superseded`
 - lane type: `rebaseline`
 - release floor: `no release`
-- purpose: only if a prior lane becomes release-worthy, do a milestone closure and release-baseline sync pass without treating that branch as a separate public version by itself
-
-### 4. `feature/fb-034-recoverable-diagnostics`
-
-- status: `candidate`
-- lane type: `implementation`
-- release floor: `patch prerelease`
-- target version: `TBD after current release-debt resolution`
-- purpose: first bounded recoverable diagnostics and reporting lane if later analysis confirms it is the right next subsystem milestone
+- purpose: direct release execution plus this roadmap refresh closed the `v1.2.1-prebeta` baseline drift without needing a separate rebaseline branch
 
 ## Current Reading
 
 Current repo truth indicates:
 
-- the latest public prerelease is still `v1.2.0-prebeta`
-- `main` has moved ahead through several merged follow-through slices, including merged unreleased implementation work
-- the next best move is still to prefer milestone-shaped grouped lanes over more micro-branches
-- the current gap between `v1.2.0-prebeta` and `main` should be treated as release debt, not as normal background drift
+- the latest public prerelease is now `v1.2.1-prebeta`
+- `main` is aligned with that released commit
+- the `feature/fb-027-saved-action-usability` lane is now released and closed
+- the prior release debt between `v1.2.0-prebeta` and `main` is cleared
+- broader sequencing may resume from clean post-release truth
+- the current best next implementation candidate from canon is `feature/fb-034-recoverable-diagnostics`, but it remains provisional until the next lane is explicitly selected
 
 That does **not** mean every listed lane should automatically happen.
 It does mean non-doc implementation lanes should be treated as version-bearing milestones rather than as merge-only background follow-through.


### PR DESCRIPTION
## Summary

This PR moves the local-only post-release canon refresh for `v1.2.1-prebeta` onto shared truth.

## What Changed

### Changes

It updates the pre-Beta roadmap and the minimum directly supportive interaction/backlog canon so the repo no longer plans from stale post-release lifecycle state.

### Included Scope

- update `Docs/prebeta_roadmap.md` to reflect:
  - `v1.2.1-prebeta` as the latest public prerelease
  - the `feature/fb-027-saved-action-usability` lane as released and closed
  - the prior release-debt posture as cleared
  - `feature/fb-034-recoverable-diagnostics` as the current best provisional next implementation candidate
- update `Docs/orin_interaction_architecture.md` so the shipped FB-027 saved-actions access milestone is reflected in interaction canon
- update `Docs/feature_backlog.md` so the released saved-actions usability milestone is reflected in backlog truth without changing backlog status or priority fields

### Merge Intent

This PR is docs-only shared-baseline hygiene.

It should merge before any new implementation branch is created so the next lane starts from published canon rather than unpublished local drift.

### Changes

### Included Scope

- update `Docs/prebeta_roadmap.md` to reflect:
  - `v1.2.1-prebeta` as the latest public prerelease
  - the `feature/fb-027-saved-action-usability` lane as released and closed
  - the prior release-debt posture as cleared
  - `feature/fb-034-recoverable-diagnostics` as the current best provisional next implementation candidate
- update `Docs/orin_interaction_architecture.md` so the shipped FB-027 saved-actions access milestone is reflected in interaction canon
- update `Docs/feature_backlog.md` so the released saved-actions usability milestone is reflected in backlog truth without changing backlog status or priority fields

### Merge Intent
