### PR TITLE
FB-034 bounded recoverable launch-failure diagnostics path

### DIFF
--- a/Docs/prebeta_roadmap.md
+++ b/Docs/prebeta_roadmap.md
@@ -145,11 +145,13 @@ This is the current best provisional sequencing horizon from live repo truth aft
 
 ### 1. `feature/fb-034-recoverable-diagnostics`
 
-- status: `candidate`
+- status: `active`
 - lane type: `implementation`
 - release floor: `patch prerelease`
 - target version: `v1.2.2-prebeta`
-- purpose: first bounded recoverable diagnostics and reporting lane if later analysis confirms it is the right next subsystem milestone
+- purpose: first bounded recoverable diagnostics and reporting lane above the current Class 2/Class 4 boundary
+- milestone target: the first bounded recoverable-operational-incident milestone while Nexus remains alive, using one explicit incident class and the existing local/manual reporting boundary
+- minimum merge-ready threshold: keep first single `launch_failed` inline, preserve fatal launcher/runtime diagnostics ownership, and add one bounded recoverable path where repeated identical `launch_failed` for the same action prepares a local support bundle and issue draft once without widening into blanket diagnostics or reporting redesign
 
 ## Recently Closed Or Superseded Lanes
 

--- a/desktop/desktop_renderer.py
+++ b/desktop/desktop_renderer.py
@@ -2,6 +2,7 @@ import os
 import ctypes
 import datetime
 import time
+import webbrowser
 
 from PySide6.QtWidgets import (
     QWidget,
@@ -20,6 +21,7 @@ from PySide6.QtWebEngineWidgets import QWebEngineView
 
 from .interaction_overlay_model import CommandOverlayModel
 from .shared_action_model import launch_command_action
+from .orin_support_reporting import SupportBundleError, prepare_manual_issue_report
 from .workerw_utils import (
     attach_window_to_desktop,
     get_last_workerw_probe_events,
@@ -54,6 +56,7 @@ GetParentW = user32.GetParent
 GetParentW.argtypes = [ctypes.wintypes.HWND]
 GetParentW.restype = ctypes.wintypes.HWND
 SW_HIDE = 0
+ROOT_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 
 
 class CommandInputLineEdit(QLineEdit):
@@ -584,12 +587,13 @@ class CommandOverlayPanel(QWidget):
 
 class DesktopRuntimeWindow(QWidget):
 
-    def __init__(self, screen, visual_html_path: str, event_logger=None):
+    def __init__(self, screen, visual_html_path: str, event_logger=None, runtime_log_path: str = ""):
         super().__init__()
 
         self.screen_ref = screen
         self.visual_html_path = os.path.abspath(visual_html_path)
         self.event_logger = event_logger
+        self.runtime_log_path = os.path.abspath(runtime_log_path) if runtime_log_path else ""
         self._overlay_trace_enabled = (os.environ.get("NEXUS_OVERLAY_TRACE") or "").strip().casefold() in {
             "1",
             "true",
@@ -618,6 +622,9 @@ class DesktopRuntimeWindow(QWidget):
         self._overlay_input_capture_until = 0.0
         self._overlay_local_input_engaged = False
         self._overlay_global_capture_suspended = False
+        self._last_launch_failure_action_id = ""
+        self._last_launch_failure_count = 0
+        self._reported_recoverable_launch_failures = set()
 
         # Align the standalone desktop route with the proven Boot handoff window model.
         self.setWindowFlags(Qt.FramelessWindowHint | Qt.WindowStaysOnTopHint)
@@ -1087,13 +1094,89 @@ class DesktopRuntimeWindow(QWidget):
             self._command_panel.hide()
             self._log_event("RENDERER_MAIN|COMMAND_OVERLAY_CLOSED")
 
-    def _show_command_result(self, status_kind: str, status_text: str):
+    def _show_command_result(self, status_kind: str, status_text: str, close_delay_ms: int = 1200):
         self._command_model.show_result(status_kind, status_text)
         self._apply_command_overlay_state()
-        self._result_close_timer.start(1200)
+        self._result_close_timer.start(max(0, int(close_delay_ms)))
 
     def _close_command_overlay_after_result(self):
         self.close_command_overlay()
+
+    def _record_launch_failure(self, action_id: str) -> int:
+        if self._last_launch_failure_action_id == action_id:
+            self._last_launch_failure_count += 1
+        else:
+            self._last_launch_failure_action_id = action_id
+            self._last_launch_failure_count = 1
+        return self._last_launch_failure_count
+
+    def _clear_launch_failure_tracking(self, action_id: str):
+        if self._last_launch_failure_action_id == action_id:
+            self._last_launch_failure_action_id = ""
+            self._last_launch_failure_count = 0
+        self._reported_recoverable_launch_failures.discard(action_id)
+
+    def _prepare_recoverable_launch_failure_report(self, action) -> str | None:
+        failure_count = self._record_launch_failure(action.id)
+        if failure_count < 2:
+            return None
+        if action.id in self._reported_recoverable_launch_failures:
+            return None
+        if not self.runtime_log_path or not os.path.isfile(self.runtime_log_path):
+            self._log_event(
+                f"RENDERER_MAIN|COMMAND_LAUNCH_FAILED_RECOVERABLE_REPORT_SKIPPED|action_id={action.id}|reason=runtime_log_unavailable"
+            )
+            return None
+
+        crash_dir = os.path.join(os.path.dirname(self.runtime_log_path), "crash")
+        self._log_event(
+            f"RENDERER_MAIN|COMMAND_LAUNCH_FAILED_RECOVERABLE_REPORT_BEGIN|action_id={action.id}|count={failure_count}"
+        )
+        try:
+            report_prep = prepare_manual_issue_report(ROOT_DIR, self.runtime_log_path, crash_dir)
+        except SupportBundleError as exc:
+            self._log_event(
+                f"RENDERER_MAIN|COMMAND_LAUNCH_FAILED_RECOVERABLE_REPORT_FAILED|action_id={action.id}|reason={exc}"
+            )
+            return None
+        except Exception as exc:
+            self._log_event(
+                f"RENDERER_MAIN|COMMAND_LAUNCH_FAILED_RECOVERABLE_REPORT_FAILED|action_id={action.id}|reason={exc}"
+            )
+            return None
+
+        bundle_info = report_prep["bundle_info"]
+        issue_url = report_prep["issue_url"]
+        browser_opened = False
+
+        try:
+            os.startfile(os.path.dirname(bundle_info["bundle_path"]))
+            self._log_event(
+                f"RENDERER_MAIN|COMMAND_LAUNCH_FAILED_RECOVERABLE_REPORT_FOLDER_OPENED|action_id={action.id}|bundle={bundle_info['bundle_name']}"
+            )
+        except Exception as exc:
+            self._log_event(
+                f"RENDERER_MAIN|COMMAND_LAUNCH_FAILED_RECOVERABLE_REPORT_FOLDER_FAILED|action_id={action.id}|reason={exc}"
+            )
+
+        if issue_url:
+            try:
+                browser_opened = webbrowser.open(issue_url, new=2)
+            except Exception as exc:
+                self._log_event(
+                    f"RENDERER_MAIN|COMMAND_LAUNCH_FAILED_RECOVERABLE_REPORT_ISSUE_FAILED|action_id={action.id}|reason={exc}"
+                )
+
+        self._reported_recoverable_launch_failures.add(action.id)
+        self._log_event(
+            f"RENDERER_MAIN|COMMAND_LAUNCH_FAILED_RECOVERABLE_REPORT_READY|action_id={action.id}|bundle={bundle_info['bundle_name']}"
+        )
+
+        if browser_opened:
+            return "Launch failed again. Support bundle prepared and issue draft opened; attach the bundle manually."
+        if issue_url:
+            return "Launch failed again. Support bundle prepared; open the issue page manually and attach the bundle."
+        return "Launch failed again. Support bundle prepared; review it locally before filing the report."
 
     def handle_ambiguous_match_selected(self, index: int):
         result, payload = self._command_model.choose_match(index)
@@ -1159,9 +1242,14 @@ class DesktopRuntimeWindow(QWidget):
             launch_command_action(action)
         except Exception as exc:
             self._log_event(f"RENDERER_MAIN|COMMAND_LAUNCH_FAILED|action_id={action.id}")
-            self._show_command_result("launch_failed", f"Launch failed: {exc}")
+            recoverable_status = self._prepare_recoverable_launch_failure_report(action)
+            if recoverable_status:
+                self._show_command_result("launch_failed", recoverable_status, close_delay_ms=2600)
+            else:
+                self._show_command_result("launch_failed", f"Launch failed: {exc}")
             return
 
+        self._clear_launch_failure_tracking(action.id)
         self._log_event(f"RENDERER_MAIN|COMMAND_LAUNCH_REQUEST_SENT|action_id={action.id}")
         self._show_command_result("launch_requested", "Launch request sent.")
 

--- a/desktop/orin_desktop_main.py
+++ b/desktop/orin_desktop_main.py
@@ -89,7 +89,12 @@ def main():
         return 0
 
     screen = app.primaryScreen()
-    window = DesktopRuntimeWindow(screen, visual_html_path, event_logger=runtime_milestone)
+    window = DesktopRuntimeWindow(
+        screen,
+        visual_html_path,
+        event_logger=runtime_milestone,
+        runtime_log_path=RUNTIME_LOG_FILE,
+    )
     runtime_milestone("RENDERER_MAIN|WINDOW_CONSTRUCTED")
     if exit_if_startup_abort_requested():
         return 0

--- a/desktop/orin_diagnostics.pyw
+++ b/desktop/orin_diagnostics.pyw
@@ -11,8 +11,7 @@ from PySide6.QtCore import Qt, QTimer, QPoint, QRect
 from PySide6.QtGui import QFont, QGuiApplication, QTextBlockFormat, QTextCharFormat
 from orin_support_reporting import (
     SupportBundleError,
-    build_issue_prefill_url,
-    create_support_bundle,
+    prepare_manual_issue_report,
 )
 
 ROOT_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
@@ -675,8 +674,7 @@ class DiagnosticsWindow(QWidget):
         self.report_btn.setEnabled(False)
 
         try:
-            bundle_info = create_support_bundle(ROOT_DIR, RUNTIME_LOG_FILE, CRASH_FOLDER)
-            issue_url = build_issue_prefill_url(ROOT_DIR, bundle_info)
+            report_prep = prepare_manual_issue_report(ROOT_DIR, RUNTIME_LOG_FILE, CRASH_FOLDER)
         except SupportBundleError as exc:
             self.append_trace(f"Support bundle creation failed: {exc}")
             diag_event("report_issue", "bundle_failed", exc)
@@ -688,12 +686,10 @@ class DiagnosticsWindow(QWidget):
         finally:
             self.report_btn.setEnabled(True)
 
-        crash_log_label = bundle_info["crash_log_name"] or "not included"
-        self.append_trace("")
-        self.append_trace(f"Support bundle created: {bundle_info['bundle_name']}")
-        self.append_trace(f"Runtime log included: {bundle_info['runtime_log_name']}")
-        self.append_trace(f"Crash log included: {crash_log_label}")
-        self.append_trace("Review the local support bundle before sharing.")
+        bundle_info = report_prep["bundle_info"]
+        issue_url = report_prep["issue_url"]
+        for trace_line in report_prep["trace_lines"]:
+            self.append_trace(trace_line)
 
         try:
             os.startfile(os.path.dirname(bundle_info["bundle_path"]))

--- a/desktop/orin_support_reporting.py
+++ b/desktop/orin_support_reporting.py
@@ -298,3 +298,23 @@ def build_issue_prefill_url(root_dir, bundle_info):
         }
     )
     return f"{issues_new_url}?{query}"
+
+
+def prepare_manual_issue_report(root_dir, runtime_log_path, crash_dir):
+    bundle_info = create_support_bundle(root_dir, runtime_log_path, crash_dir)
+    issue_url = build_issue_prefill_url(root_dir, bundle_info)
+    crash_log_label = bundle_info["crash_log_name"] or "not included"
+
+    return {
+        "bundle_info": bundle_info,
+        "issue_url": issue_url,
+        "trace_lines": [
+            "",
+            f"Support bundle created: {bundle_info['bundle_name']}",
+            f"Runtime log included: {bundle_info['runtime_log_name']}",
+            f"Crash log included: {crash_log_label}",
+            "Review the local support bundle before sharing.",
+        ],
+        "manual_review_required": True,
+        "manual_issue_submission_required": True,
+    }


### PR DESCRIPTION
## Summary

This PR delivers the first bounded FB-034 recoverable-diagnostics milestone.

## What Changed

### Changes

It adds one explicit Class 3 recoverable incident path while Nexus remains operational by reusing the existing local/manual support-reporting boundary, without widening into fatal diagnostics ownership, blanket diagnostics popups, voice work, or reporting-policy redesign.

### Included Scope

- update `desktop/orin_support_reporting.py`
  - add reusable `prepare_manual_issue_report(...)`
  - centralize support-bundle creation, issue-prefill preparation, and manual-review/manual-submission report metadata
- update `desktop/orin_diagnostics.pyw`
  - consume the new manual report-preparation seam
- update `desktop/orin_desktop_main.py`
  - pass the active runtime log path into the desktop runtime window
- update `desktop/desktop_renderer.py`
  - keep first single `launch_failed` inline
  - treat repeated identical `launch_failed` for the same action in a still-running session as the first bounded recoverable incident class
  - prepare a local support bundle and issue draft once for that recoverable path
- update `Docs/prebeta_roadmap.md`
  - mark `feature/fb-034-recoverable-diagnostics` as `active`
  - keep release floor `patch prerelease`
  - keep target version `v1.2.2-prebeta`
  - record the implemented milestone target and minimum merge-ready threshold

### Changes

### Included Scope

- update `desktop/orin_support_reporting.py`
  - add reusable `prepare_manual_issue_report(...)`
  - centralize support-bundle creation, issue-prefill preparation, and manual-review/manual-submission report metadata
- update `desktop/orin_diagnostics.pyw`
  - consume the new manual report-preparation seam
- update `desktop/orin_desktop_main.py`
  - pass the active runtime log path into the desktop runtime window
- update `desktop/desktop_renderer.py`
  - keep first single `launch_failed` inline
  - treat repeated identical `launch_failed` for the same action in a still-running session as the first bounded recoverable incident class
  - prepare a local support bundle and issue draft once for that recoverable path
- update `Docs/prebeta_roadmap.md`
  - mark `feature/fb-034-recoverable-diagnostics` as `active`
  - keep release floor `patch prerelease`
  - keep target version `v1.2.2-prebeta`
  - record the implemented milestone target and minimum merge-ready threshold
