### PR TITLE
Refresh post-v1.2.2 planning baseline

### DIFF
--- a/Docs/architecture.md
+++ b/Docs/architecture.md
@@ -586,7 +586,9 @@ This class may later gain a bounded report affordance if explicitly approved, bu
 
 This means something meaningful went against normal expected Nexus behavior, but the persona and runtime remain operational enough to continue guiding the user.
 
-This class is a future planning boundary, not a broadly implemented current behavior.
+This class is not yet a broadly implemented current behavior.
+
+Current repo truth now includes one bounded desktop example: repeated identical `launch_failed` for the same action in a still-running session may prepare a local support bundle and issue draft once while keeping the local/manual reporting boundary intact.
 
 When later approved for a specific subsystem, this class may use:
 
@@ -622,7 +624,7 @@ The current recommended surface mapping is:
 
 - Class 1 -> inline or contained guidance only
 - Class 2 -> inline or contained recoverable failure only
-- Class 3 -> recoverable diagnostics or reporting surface when later explicitly approved for a bounded incident class
+- Class 3 -> recoverable diagnostics or reporting surface for an explicitly approved bounded incident class
 - Class 4 -> existing launcher-owned diagnostics completion path
 
 This contract does not by itself authorize new diagnostics triggers or UI surfaces.

--- a/Docs/codex_modes.md
+++ b/Docs/codex_modes.md
@@ -407,6 +407,10 @@ unless a grouped branch remains clearly justified.
 
 After a prior workstream branch has been merged, released if applicable, and deleted, the next workstream should start from updated `main` on a fresh branch.
 
+If the first required post-merge or post-release work is a docs-only roadmap, rebaseline, or drift-refresh pass so shared canon matches live repo truth, Codex may create that fresh docs-only branch immediately after verifying the live repo state.
+
+In that case, the docs-only refresh branch itself counts as the first new workstream branch and should land before a new implementation branch is created from the refreshed shared baseline.
+
 Codex should not create that next branch until:
 
 - the live post-merge or post-release repo state has been verified

--- a/Docs/feature_backlog.md
+++ b/Docs/feature_backlog.md
@@ -1515,17 +1515,17 @@ Current branch-local evidence indicates the helper is useful for internal startu
 
 ### [ID: FB-034] Recoverable incident diagnostics surface and failure-class follow-through
 
-Status: Deferred
+Status: Deferred (first bounded recoverable-diagnostics milestone implemented in v1.2.2-prebeta)
 Priority: Medium
 Suggested Version: TBD
-Suggested Revision: rev1
+Suggested Revision: rev2
 Release Stage: pre-Beta
 
 Description:
-Define a later bounded follow-through for recoverable incidents that should surface diagnostics or reporting while Nexus remains operational, without collapsing those incidents into the fatal launcher diagnostics path.
+Track any later bounded follow-through beyond the first shipped recoverable-diagnostics milestone, without collapsing recoverable incidents into the fatal launcher diagnostics path.
 
 Why it matters:
-Current repo truth now distinguishes between contained recoverable action failures, future recoverable operational incidents, and fatal launcher/runtime/persona failures. Without a tracked follow-through item, later work could drift into ad hoc diagnostics triggers, inconsistent voice behavior, or silent reporting-policy expansion.
+Current repo truth now includes one bounded recoverable-operational-incident path in `v1.2.2-prebeta`, but that does not authorize automatic continuation into broader diagnostics triggers, reporting-policy expansion, or voice-path widening. A deferred follow-through item keeps future work explicit and revalidatable.
 
 Proposed Change:
 Use the failure-class / diagnostics-surface contract in `docs/architecture.md` as the planning baseline for a later bounded slice that:
@@ -1566,9 +1566,9 @@ Current source-of-truth ownership now lives in `docs/architecture.md`.
 That contract is intentionally conservative:
 
 - contained recoverable action failures such as current NCP `launch_failed` remain inline by default
-- recoverable diagnostics or reporting surfaces are future bounded work, not automatic current behavior
+- the first bounded shipped Class 3 example now exists in `v1.2.2-prebeta`: repeated identical `launch_failed` for the same action in a still-running session prepares a local support bundle and issue draft once while preserving manual review and submission boundaries
 - fatal launcher/runtime/persona failures keep the existing launcher-owned diagnostics completion path
-- later implementation should begin with one bounded recoverable incident class rather than a blanket new diagnostics trigger
+- any later implementation should remain a fresh bounded incident-class follow-through rather than a blanket new diagnostics trigger or automatic continuation of the released milestone
 
 This item should remain separate from `FB-027` and `FB-017`.
 It is cross-system planning work, not a pure NCP hardening slice and not only a `Report Issue` UX refinement.

--- a/Docs/prebeta_roadmap.md
+++ b/Docs/prebeta_roadmap.md
@@ -141,21 +141,26 @@ While release debt exists:
 
 ## Current Near-Term Roadmap Horizon
 
-This is the current best provisional sequencing horizon from live repo truth after the live `v1.2.1-prebeta` release.
+This is the current best provisional sequencing horizon from live repo truth after the live `v1.2.2-prebeta` release.
 
-### 1. `feature/fb-034-recoverable-diagnostics`
+No active non-doc implementation lane is selected yet from this released baseline.
 
-- status: `active`
-- lane type: `implementation`
-- release floor: `patch prerelease`
-- target version: `v1.2.2-prebeta`
-- purpose: first bounded recoverable diagnostics and reporting lane above the current Class 2/Class 4 boundary
-- milestone target: the first bounded recoverable-operational-incident milestone while Nexus remains alive, using one explicit incident class and the existing local/manual reporting boundary
-- minimum merge-ready threshold: keep first single `launch_failed` inline, preserve fatal launcher/runtime diagnostics ownership, and add one bounded recoverable path where repeated identical `launch_failed` for the same action prepares a local support bundle and issue draft once without widening into blanket diagnostics or reporting redesign
+The next implementation branch should be chosen by a fresh next-lane analysis from updated shared canon rather than by automatic continuation of the just-closed `feature/fb-034-recoverable-diagnostics` lane.
 
 ## Recently Closed Or Superseded Lanes
 
-These entries remain here only long enough to keep the post-`v1.2.1-prebeta` transition explicit.
+These entries remain here only long enough to keep the post-`v1.2.2-prebeta` transition explicit.
+
+### `feature/fb-034-recoverable-diagnostics`
+
+- status: `closed`
+- lane type: `implementation`
+- release floor: `patch prerelease`
+- target version: `v1.2.2-prebeta`
+- release state: `released`
+- purpose: first bounded recoverable diagnostics and reporting lane above the current Class 2/Class 4 boundary
+- milestone target: the first bounded recoverable-operational-incident milestone while Nexus remains alive, using one explicit incident class and the existing local/manual reporting boundary
+- minimum merge-ready threshold: keep first single `launch_failed` inline, preserve fatal launcher/runtime diagnostics ownership, and add one bounded recoverable path where repeated identical `launch_failed` for the same action prepares a local support bundle and issue draft once without widening into blanket diagnostics or reporting redesign
 
 ### `feature/prebeta-roadmap-rebaseline`
 
@@ -187,12 +192,12 @@ These entries remain here only long enough to keep the post-`v1.2.1-prebeta` tra
 
 Current repo truth indicates:
 
-- the latest public prerelease is now `v1.2.1-prebeta`
+- the latest public prerelease is now `v1.2.2-prebeta`
 - `main` is aligned with that released commit
-- the `feature/fb-027-saved-action-usability` lane is now released and closed
-- the prior release debt between `v1.2.0-prebeta` and `main` is cleared
-- broader sequencing may resume from clean post-release truth
-- the current best next implementation candidate from canon is `feature/fb-034-recoverable-diagnostics`, but it remains provisional until the next lane is explicitly selected
+- the `feature/fb-034-recoverable-diagnostics` lane is now released and closed
+- the prior release debt between `v1.2.1-prebeta` and `main` is cleared
+- no new implementation lane is automatically active just because the prior patch milestone released
+- broader sequencing should resume from a fresh next-lane analysis on this released baseline
 
 That does **not** mean every listed lane should automatically happen.
 It does mean non-doc implementation lanes should be treated as version-bearing milestones rather than as merge-only background follow-through.


### PR DESCRIPTION
## Summary

This PR carries the docs-only work needed after `v1.2.2-prebeta` so the next branch starts from clean published canon instead of stale post-release planning state.

## What Changed

### Changes

It does two narrow things:
- clarifies that a docs-only roadmap / rebaseline / drift-refresh pass may be the first fresh branch after a closed workstream when shared canon needs to catch up to live repo truth
- refreshes the post-`v1.2.2-prebeta` planning baseline so the released FB-034 milestone is closed in canon instead of still looking active

### Included Scope

- update `Docs/codex_modes.md`
  - clarify the branch-start rule for docs-only roadmap / rebaseline / drift-refresh branches
- update `Docs/prebeta_roadmap.md`
  - reflect `v1.2.2-prebeta` as the latest public prerelease
  - mark `feature/fb-034-recoverable-diagnostics` as released and closed
  - clear the prior release-debt posture
  - make explicit that no new implementation lane is automatically active yet
- update `Docs/feature_backlog.md`
  - record that the first bounded recoverable-diagnostics milestone shipped in `v1.2.2-prebeta`
- update `Docs/architecture.md`
  - sync the Class 3 contract so it reflects the first bounded shipped desktop example without widening diagnostics or reporting policy

### Merge Intent

This PR is docs-only shared-baseline hygiene.

It should merge before the next implementation branch is created so the next lane starts from clean published post-`v1.2.2-prebeta` canon rather than stale release-state drift.

### Changes

It does two narrow things:
- clarifies that a docs-only roadmap / rebaseline / drift-refresh pass may be the first fresh branch after a closed workstream when shared canon needs to catch up to live repo truth
- refreshes the post-`v1.2.2-prebeta` planning baseline so the released FB-034 milestone is closed in canon instead of still looking active

### Included Scope

- update `Docs/codex_modes.md`
  - clarify the branch-start rule for docs-only roadmap / rebaseline / drift-refresh branches
- update `Docs/prebeta_roadmap.md`
  - reflect `v1.2.2-prebeta` as the latest public prerelease
  - mark `feature/fb-034-recoverable-diagnostics` as released and closed
  - clear the prior release-debt posture
  - make explicit that no new implementation lane is automatically active yet
- update `Docs/feature_backlog.md`
  - record that the first bounded recoverable-diagnostics milestone shipped in `v1.2.2-prebeta`
- update `Docs/architecture.md`
  - sync the Class 3 contract so it reflects the first bounded shipped desktop example without widening diagnostics or reporting policy

### Merge Intent
