### PR TITLE
FB-028 relocate launcher history state out of root logs

### DIFF
--- a/Docs/architecture.md
+++ b/Docs/architecture.md
@@ -142,7 +142,10 @@ Current root-owned live launcher surfaces remain under `C:/Jarvis/logs` only for
 - launcher-generated `Runtime_*.txt`
 - matching live crash logs under `C:/Jarvis/logs/crash`
 - launcher control/status files when relevant
-- the current launcher-owned historical state file until a later approved relocation moves it elsewhere
+
+Launcher-owned historical state no longer lives under the root logs tree during normal runtime.
+It now resolves under `%LOCALAPPDATA%/Nexus Desktop AI/state/jarvis_history_v1.jsonl`, while contained harness runs may still keep historical state under the contained harness log root to preserve isolation.
+This relocation does not change runtime log, crash log, or support-bundle locations.
 
 Dev/test/worker/toolkit evidence does not belong in the live root logs tree.
 That evidence must write under `C:/Jarvis/dev/logs/<lane>/...` and must not introduce new artifact families or new subfolders under `C:/Jarvis/logs` or `C:/Jarvis/logs/crash` without explicit approval.

--- a/Docs/development_rules.md
+++ b/Docs/development_rules.md
@@ -141,7 +141,9 @@ After every revision, review:
   - launcher-generated `Runtime_*.txt`
   - matching live crash logs
   - launcher control/status files when relevant
-  - the current launcher-owned historical state file `jarvis_history_v1.jsonl` until a later explicitly approved relocation slice moves it
+- launcher-owned historical state is no longer a root-owned live surface
+- normal runtime historical state now resolves under `%LOCALAPPDATA%/Nexus Desktop AI/state/jarvis_history_v1.jsonl`
+- contained harness runs may still keep historical state under the contained harness log root to preserve harness isolation
 - dev/test/worker/toolkit evidence must write under `C:/Jarvis/dev/logs/<lane>/...`
 - no new dev/test/worker evidence roots, new subfolders, or new artifact families may be introduced under `C:/Jarvis/logs` or `C:/Jarvis/logs/crash` without explicit user approval
 

--- a/Docs/feature_backlog.md
+++ b/Docs/feature_backlog.md
@@ -1190,9 +1190,9 @@ This item must be staged by slice rather than treated as one single blanket stag
 
 ### [ID: FB-028] Relocate launcher history state out of root logs
 
-Status: Deferred  
+Status: Active  
 Priority: Medium  
-Suggested Version: TBD  
+Suggested Version: v1.2.3-prebeta  
 Suggested Revision: rev1  
 Release Stage: pre-Beta  
 
@@ -1203,14 +1203,13 @@ Why it matters:
 `jarvis_history_v1.jsonl` is not a runtime log, crash artifact, or dev evidence root. Keeping it in `C:/Jarvis/logs` makes internal cross-run state look like user-facing log clutter and conflicts with the current root-logs governance rule that the live root logs tree should stay reserved for already-approved launcher/runtime truth surfaces only.
 
 Proposed Change:
-Later bounded relocation slice:
+Current active lane truth:
 
-- choose a non-user-facing launcher-owned state root outside `C:/Jarvis/logs` and outside `C:/Jarvis/dev/logs`, preferably `%LOCALAPPDATA%/Jarvis/state`
-- patch the launcher history-path helper to read and write there
-- add a one-time migration from the existing root `C:/Jarvis/logs/jarvis_history_v1.jsonl` if present
-- preserve fail-safe degradation if migration or new-state writes fail
-- update the contained history harness and any other history-path consumers
-- sync the governing docs after the relocation lands
+- normal runtime history now resolves under `%LOCALAPPDATA%/Nexus Desktop AI/state/jarvis_history_v1.jsonl`
+- successful migration no longer leaves the legacy root-log history file exposed after the new state-root copy succeeds
+- fail-safe degradation remains in place if migration or new-state writes fail
+- contained history harness and direct consumers now follow the relocated path contract while contained runs remain isolated under the contained harness log root
+- runtime logs, crash logs, and support-bundle locations remain unchanged
 
 Likely Files Affected:
 - C:/Jarvis/desktop/jarvis_desktop_launcher.pyw

--- a/Docs/prebeta_roadmap.md
+++ b/Docs/prebeta_roadmap.md
@@ -143,9 +143,24 @@ While release debt exists:
 
 This is the current best provisional sequencing horizon from live repo truth after the live `v1.2.2-prebeta` release.
 
-No active non-doc implementation lane is selected yet from this released baseline.
+The current active non-doc implementation lane is now:
 
-The next implementation branch should be chosen by a fresh next-lane analysis from updated shared canon rather than by automatic continuation of the just-closed `feature/fb-034-recoverable-diagnostics` lane.
+- `feature/fb-028-history-state-relocation`
+
+That lane was selected by fresh next-lane analysis from the released `v1.2.2-prebeta` baseline rather than by automatic continuation of the closed `feature/fb-034-recoverable-diagnostics` lane.
+
+## Current Active Lane
+
+### `feature/fb-028-history-state-relocation`
+
+- status: `active`
+- lane type: `implementation`
+- release floor: `patch prerelease`
+- target version: `v1.2.3-prebeta`
+- release state: `active delta`
+- purpose: relocate launcher-owned historical state out of the live root `logs` tree without changing historical-memory semantics or widening logs/reporting policy
+- milestone target: move launcher-owned historical state out of the live root `logs` tree into a dedicated non-user-facing launcher-owned state root, with migration and clean fallback, without changing historical-memory semantics or widening logs/reporting policy
+- minimum merge-ready threshold: launcher history resolves to a dedicated state root outside live root `logs`; successful migration no longer leaves the legacy root-log history file exposed; failure to migrate or write still degrades cleanly to the last non-historical behavior; contained history harness and direct consumers follow the relocated path contract; validation proves history writes no longer spill into live root `logs`; runtime logs, crash logs, and support-bundle locations remain unchanged
 
 ## Recently Closed Or Superseded Lanes
 

--- a/desktop/orin_desktop_launcher.pyw
+++ b/desktop/orin_desktop_launcher.pyw
@@ -361,12 +361,17 @@ def normalize_history_run_id(run_id):
 
 
 def prepare_history_storage_path(path=None, legacy_path=None):
-    path = os.path.abspath(path or history_file(harness_log_root=os.environ.get("JARVIS_HARNESS_LOG_ROOT", "")))
+    harness_log_root = os.environ.get("JARVIS_HARNESS_LOG_ROOT", "")
+    path = os.path.abspath(path or history_file(harness_log_root=harness_log_root))
     parent_dir = os.path.dirname(path)
     if not parent_dir:
         raise ValueError("History storage path has no parent directory.")
 
-    migrate_history_file_if_needed(path, legacy_path or legacy_history_file_path())
+    resolved_legacy_path = legacy_path
+    if resolved_legacy_path is None:
+        resolved_legacy_path = legacy_history_file_path(log_dir=harness_log_root or DEFAULT_LOG_DIR)
+
+    migrate_history_file_if_needed(path, resolved_legacy_path)
     os.makedirs(parent_dir, exist_ok=True)
     if os.path.isdir(path):
         raise IsADirectoryError(f"History storage path is a directory: {path}")

--- a/desktop/orin_desktop_launcher.pyw
+++ b/desktop/orin_desktop_launcher.pyw
@@ -5,6 +5,7 @@ import sys
 import time
 import re
 import json
+import shutil
 import subprocess
 import datetime
 import platform
@@ -52,6 +53,9 @@ CONSECUTIVE_STARTUP_ABORT_THRESHOLD = 2
 CONSECUTIVE_IDENTICAL_CRASH_THRESHOLD = 2
 HISTORY_SCHEMA_VERSION = 1
 HISTORY_STABILITY_WINDOW_SIZE = 5
+HISTORY_FILENAME = "jarvis_history_v1.jsonl"
+HISTORY_STATE_DIRNAME = "Nexus Desktop AI"
+HISTORY_STATE_SUBDIR = "state"
 ADVISORY_CONFIDENCE_DIRECT_EVIDENCE = "direct_evidence"
 ADVISORY_CONFIDENCE_PATTERN_EVIDENCE = "pattern_evidence"
 
@@ -284,8 +288,68 @@ def select_diagnostics_priority(failure_stability):
     return ""
 
 
-def history_file():
-    return os.path.join(LOG_DIR, "jarvis_history_v1.jsonl")
+def legacy_history_file_path(log_dir=DEFAULT_LOG_DIR):
+    return os.path.join(os.path.abspath(log_dir), HISTORY_FILENAME)
+
+
+def history_state_root(log_dir=LOG_DIR, harness_log_root=None, local_app_data=None, home_dir=None):
+    resolved_harness_log_root = (harness_log_root or "").strip()
+    if resolved_harness_log_root:
+        return os.path.abspath(log_dir)
+
+    resolved_local_app_data = local_app_data
+    if resolved_local_app_data is None:
+        resolved_local_app_data = os.environ.get("LOCALAPPDATA", "")
+    resolved_local_app_data = resolved_local_app_data.strip()
+    if resolved_local_app_data:
+        return os.path.join(
+            os.path.abspath(resolved_local_app_data),
+            HISTORY_STATE_DIRNAME,
+            HISTORY_STATE_SUBDIR,
+        )
+
+    resolved_home_dir = home_dir
+    if resolved_home_dir is None:
+        resolved_home_dir = os.path.expanduser("~")
+    resolved_home_dir = resolved_home_dir.strip()
+    if resolved_home_dir:
+        return os.path.join(
+            os.path.abspath(resolved_home_dir),
+            "AppData",
+            "Local",
+            HISTORY_STATE_DIRNAME,
+            HISTORY_STATE_SUBDIR,
+        )
+
+    raise ValueError("No launcher-owned state root is available for historical memory storage.")
+
+
+def history_file(log_dir=LOG_DIR, harness_log_root=None, local_app_data=None, home_dir=None):
+    state_root = history_state_root(
+        log_dir=log_dir,
+        harness_log_root=harness_log_root,
+        local_app_data=local_app_data,
+        home_dir=home_dir,
+    )
+    return os.path.join(state_root, HISTORY_FILENAME)
+
+
+def migrate_history_file_if_needed(target_path, legacy_path):
+    resolved_target_path = os.path.abspath(target_path)
+    resolved_legacy_path = os.path.abspath(legacy_path)
+
+    if resolved_target_path == resolved_legacy_path:
+        return
+    if os.path.exists(resolved_target_path):
+        return
+    if not os.path.isfile(resolved_legacy_path):
+        return
+
+    target_parent_dir = os.path.dirname(resolved_target_path)
+    if not target_parent_dir:
+        raise ValueError("Historical state target path has no parent directory.")
+    os.makedirs(target_parent_dir, exist_ok=True)
+    shutil.copy2(resolved_legacy_path, resolved_target_path)
 
 
 def history_timestamp():
@@ -296,11 +360,13 @@ def normalize_history_run_id(run_id):
     return strip_label_prefix(run_id, "Run ID: ") or RUN_ID_STEM
 
 
-def prepare_history_storage_path():
-    path = os.path.abspath(history_file())
+def prepare_history_storage_path(path=None, legacy_path=None):
+    path = os.path.abspath(path or history_file(harness_log_root=os.environ.get("JARVIS_HARNESS_LOG_ROOT", "")))
     parent_dir = os.path.dirname(path)
     if not parent_dir:
         raise ValueError("History storage path has no parent directory.")
+
+    migrate_history_file_if_needed(path, legacy_path or legacy_history_file_path())
     os.makedirs(parent_dir, exist_ok=True)
     if os.path.isdir(path):
         raise IsADirectoryError(f"History storage path is a directory: {path}")
@@ -357,7 +423,7 @@ def validate_history_record(record):
 
 def load_history_records():
     try:
-        history_path = os.path.abspath(history_file())
+        history_path = prepare_history_storage_path()
         if not os.path.exists(history_path):
             return []
         if os.path.isdir(history_path):

--- a/desktop/orin_desktop_launcher.pyw
+++ b/desktop/orin_desktop_launcher.pyw
@@ -349,7 +349,32 @@ def migrate_history_file_if_needed(target_path, legacy_path):
     if not target_parent_dir:
         raise ValueError("Historical state target path has no parent directory.")
     os.makedirs(target_parent_dir, exist_ok=True)
-    shutil.copy2(resolved_legacy_path, resolved_target_path)
+
+    migration_temp_path = resolved_target_path + ".migrating"
+    if os.path.exists(migration_temp_path):
+        if os.path.isfile(migration_temp_path):
+            os.remove(migration_temp_path)
+        else:
+            raise IsADirectoryError(f"Historical state migration temp path is a directory: {migration_temp_path}")
+
+    target_created = False
+    try:
+        shutil.copy2(resolved_legacy_path, migration_temp_path)
+        os.replace(migration_temp_path, resolved_target_path)
+        target_created = True
+        os.remove(resolved_legacy_path)
+    except Exception:
+        if os.path.isfile(migration_temp_path):
+            try:
+                os.remove(migration_temp_path)
+            except Exception:
+                pass
+        if target_created and os.path.isfile(resolved_target_path) and os.path.isfile(resolved_legacy_path):
+            try:
+                os.remove(resolved_target_path)
+            except Exception:
+                pass
+        raise
 
 
 def history_timestamp():

--- a/desktop/orin_history_harness_runner.py
+++ b/desktop/orin_history_harness_runner.py
@@ -323,6 +323,10 @@ def validate_history_path_contract(workspace_root):
         "Runtime history copy-forward did not preserve the legacy history contents.",
     )
     assert_true(
+        not fake_legacy_history_path.exists(),
+        f"Legacy runtime history path remained exposed after successful migration: {fake_legacy_history_path}",
+    )
+    assert_true(
         live_log_snapshot_before == live_log_snapshot_after,
         "Normal runtime history preparation wrote to or modified the live production logs tree.",
     )

--- a/desktop/orin_history_harness_runner.py
+++ b/desktop/orin_history_harness_runner.py
@@ -10,7 +10,7 @@ from pathlib import Path
 
 
 ROOT_DIR = Path(__file__).resolve().parents[1]
-LAUNCHER_SCRIPT = Path(__file__).with_name("jarvis_desktop_launcher.pyw")
+LAUNCHER_SCRIPT = Path(__file__).with_name("orin_desktop_launcher.pyw")
 LIVE_LOG_DIR = ROOT_DIR / "logs"
 HISTORY_FILENAME = "jarvis_history_v1.jsonl"
 HISTORY_STABILITY_WINDOW_SIZE = 5
@@ -214,7 +214,7 @@ def resolve_workspace_root(raw_value):
     return workspace_root
 
 
-def load_launcher_probe_namespace(workspace_root):
+def load_launcher_probe_namespace(workspace_root, harness_log_root=None, local_app_data=None):
     probe_root = workspace_root / "_launcher_confidence_probe"
     probe_log_root = probe_root / "logs"
     probe_root.mkdir(parents=True, exist_ok=True)
@@ -224,12 +224,20 @@ def load_launcher_probe_namespace(workspace_root):
         "JARVIS_HARNESS_TARGET_SCRIPT",
         "JARVIS_HARNESS_DISABLE_DIAGNOSTICS",
         "JARVIS_HARNESS_DISABLE_VOICE",
+        "LOCALAPPDATA",
     )
     original_env = {name: os.environ.get(name) for name in env_names}
-    os.environ["JARVIS_HARNESS_LOG_ROOT"] = str(probe_log_root)
+    if harness_log_root is None:
+        os.environ.pop("JARVIS_HARNESS_LOG_ROOT", None)
+    else:
+        os.environ["JARVIS_HARNESS_LOG_ROOT"] = str(harness_log_root)
     os.environ["JARVIS_HARNESS_TARGET_SCRIPT"] = str(probe_root / "probe_renderer.py")
     os.environ["JARVIS_HARNESS_DISABLE_DIAGNOSTICS"] = "1"
     os.environ["JARVIS_HARNESS_DISABLE_VOICE"] = "1"
+    if local_app_data is None:
+        os.environ.pop("LOCALAPPDATA", None)
+    else:
+        os.environ["LOCALAPPDATA"] = str(local_app_data)
 
     try:
         return runpy.run_path(str(LAUNCHER_SCRIPT), run_name="jarvis_launcher_probe")
@@ -239,6 +247,85 @@ def load_launcher_probe_namespace(workspace_root):
                 os.environ.pop(name, None)
             else:
                 os.environ[name] = value
+
+
+def resolve_harness_history_path(workspace_root, log_root):
+    namespace = load_launcher_probe_namespace(
+        workspace_root,
+        harness_log_root=log_root,
+        local_app_data=workspace_root / "_launcher_harness_state_probe" / "LocalAppData",
+    )
+    history_file = namespace["history_file"]
+    return Path(
+        history_file(
+            log_dir=str(log_root),
+            harness_log_root=str(log_root),
+            local_app_data=str(workspace_root / "_launcher_harness_state_probe" / "LocalAppData"),
+            home_dir="",
+        )
+    ).resolve()
+
+
+def validate_history_path_contract(workspace_root):
+    harness_root = workspace_root / "_launcher_history_contract_harness"
+    harness_log_root = harness_root / "logs"
+    harness_history_path = resolve_harness_history_path(workspace_root, harness_log_root)
+    expected_harness_history_path = (harness_log_root / HISTORY_FILENAME).resolve()
+    assert_true(
+        harness_history_path == expected_harness_history_path,
+        f"Harness override history path drifted: expected {expected_harness_history_path}, got {harness_history_path}",
+    )
+
+    runtime_probe_root = workspace_root / "_launcher_history_contract_runtime"
+    runtime_local_app_data = runtime_probe_root / "LocalAppData"
+    runtime_namespace = load_launcher_probe_namespace(
+        workspace_root,
+        harness_log_root=None,
+        local_app_data=runtime_local_app_data,
+    )
+    history_file = runtime_namespace["history_file"]
+    prepare_history_storage_path = runtime_namespace["prepare_history_storage_path"]
+    runtime_history_path = Path(
+        history_file(
+            log_dir=str(LIVE_LOG_DIR),
+            harness_log_root="",
+            local_app_data=str(runtime_local_app_data),
+            home_dir="",
+        )
+    ).resolve()
+
+    assert_true(
+        not is_relative_to(runtime_history_path, LIVE_LOG_DIR),
+        f"Normal runtime history path should not resolve under the live logs tree: {runtime_history_path}",
+    )
+
+    fake_legacy_log_root = runtime_probe_root / "legacy_logs"
+    fake_legacy_history_path = fake_legacy_log_root / HISTORY_FILENAME
+    expected_history_text = '{"schema_version": 1, "synthetic": "history-copy-forward"}\n'
+    write_text(fake_legacy_history_path, expected_history_text)
+
+    live_log_snapshot_before = snapshot_live_log_tree()
+    prepared_history_path = Path(
+        prepare_history_storage_path(
+            path=str(runtime_history_path),
+            legacy_path=str(fake_legacy_history_path),
+        )
+    ).resolve()
+    live_log_snapshot_after = snapshot_live_log_tree()
+
+    assert_true(
+        prepared_history_path == runtime_history_path,
+        f"Prepared runtime history path drifted: expected {runtime_history_path}, got {prepared_history_path}",
+    )
+    assert_true(prepared_history_path.exists(), f"Prepared runtime history path was not created: {prepared_history_path}")
+    assert_true(
+        prepared_history_path.read_text(encoding="utf-8") == expected_history_text,
+        "Runtime history copy-forward did not preserve the legacy history contents.",
+    )
+    assert_true(
+        live_log_snapshot_before == live_log_snapshot_after,
+        "Normal runtime history preparation wrote to or modified the live production logs tree.",
+    )
 
 
 def snapshot_live_log_tree():
@@ -302,7 +389,7 @@ def collect_single_file(directory, pattern, required):
 def run_launcher_scenario(scenario_root, renderer_script, seed_history_lines=None, precreate_history_directory=False):
     log_root = scenario_root / "logs"
     log_root.mkdir(parents=True, exist_ok=True)
-    history_path = log_root / HISTORY_FILENAME
+    history_path = resolve_harness_history_path(scenario_root, log_root)
     if precreate_history_directory:
         history_path.mkdir(parents=True, exist_ok=True)
     elif seed_history_lines:
@@ -608,6 +695,7 @@ def main():
     args = parse_args()
     workspace_root = resolve_workspace_root(args.workspace_root)
     validate_internal_confidence_contract(workspace_root)
+    validate_history_path_contract(workspace_root)
 
     healthy_root = prepare_workspace(workspace_root, "healthy_run")
     healthy_renderer = healthy_root / "renderer_ready.py"


### PR DESCRIPTION
## Summary

This PR delivers the first bounded FB-028 history-state relocation milestone.

## What Changed

### Changes

It moves launcher-owned historical state out of the live root `logs` tree for normal runtime, preserves contained harness isolation, keeps runtime/crash/support-bundle locations unchanged, and syncs the directly supporting canon so branch truth and source-of-truth docs match.

### Included Scope

- update `desktop/orin_desktop_launcher.pyw`
  - resolve normal runtime history under `%LOCALAPPDATA%/Nexus Desktop AI/state/jarvis_history_v1.jsonl`
  - preserve contained harness history under the contained harness log root when `JARVIS_HARNESS_LOG_ROOT` is set
  - add safe migration from the legacy root-log history path
  - ensure successful migration no longer leaves the legacy root-log history file exposed
  - preserve clean degradation when migration or history writes fail
- update `desktop/orin_history_harness_runner.py`
  - align the contained direct-consumer contract to the relocated history-path rules
  - validate normal runtime path resolution outside live root `logs`
  - validate contained harness isolation
  - validate successful migration cleanup of the legacy root-log history file
- update supporting canon only where needed
  - `Docs/prebeta_roadmap.md`
  - `Docs/development_rules.md`
  - `Docs/architecture.md`
  - `Docs/feature_backlog.md`

### Merge Intent

This PR is intended as the version-bearing FB-028 patch prerelease milestone targeting provisional `v1.2.3-prebeta`.

It should merge before any unrelated implementation work is started on top of `main`.

### Changes

### Included Scope

- update `desktop/orin_desktop_launcher.pyw`
  - resolve normal runtime history under `%LOCALAPPDATA%/Nexus Desktop AI/state/jarvis_history_v1.jsonl`
  - preserve contained harness history under the contained harness log root when `JARVIS_HARNESS_LOG_ROOT` is set
  - add safe migration from the legacy root-log history path
  - ensure successful migration no longer leaves the legacy root-log history file exposed
  - preserve clean degradation when migration or history writes fail
- update `desktop/orin_history_harness_runner.py`
  - align the contained direct-consumer contract to the relocated history-path rules
  - validate normal runtime path resolution outside live root `logs`
  - validate contained harness isolation
  - validate successful migration cleanup of the legacy root-log history file
- update supporting canon only where needed
  - `Docs/prebeta_roadmap.md`
  - `Docs/development_rules.md`
  - `Docs/architecture.md`
  - `Docs/feature_backlog.md`

### Merge Intent
