### PR TITLE
Docs: add the pre-Beta canon freshness gate and refresh post-v1.2.3 governance truth

### DIFF
--- a/Docs/Main.md
+++ b/Docs/Main.md
@@ -205,6 +205,26 @@ That first prompt should explicitly answer:
 - what facts must be carried forward into the new version baseline
 - what repeated prompt content can now be removed because the source-of-truth docs already capture it
 
+### Branch-Start Canon Alignment
+
+For the first prompt on a new non-doc implementation branch after a prior lane has merged or released, prompts should usually include:
+
+- `docs/development_rules.md`
+- `docs/Main.md`
+- `docs/codex_modes.md`
+- the directly relevant planning docs
+- the directly relevant architecture docs
+- the directly relevant implementation truth
+
+That branch-start analysis should explicitly answer:
+
+- what canon from the just-finished lane must now be closed
+- what canon must be activated for the new lane
+- whether the minimum supporting docs sync should land immediately on this new branch before code starts
+
+Do not recommend a separate docs-only roadmap or drift-refresh branch by default for this routine post-release catch-up.
+Instead, carry that closure or activation sync on the new implementation branch unless the user explicitly approves an exception.
+
 ### Governance / Prompt / Workflow Docs Work
 
 For prompt-governance or workflow-governance tasks, prompts should usually include:

--- a/Docs/closeout_guidance.md
+++ b/Docs/closeout_guidance.md
@@ -129,6 +129,14 @@ That means:
 - do not force a new closeout doc for every small pre-Beta patch release
 - do create a closeout when a meaningful milestone or lane has actually stabilized and future planning will benefit from a fresh baseline
 
+For small Nexus `pre-Beta` patch releases that do not justify their own closeout, the default closure path should be:
+
+- carry any branch-truth canon sync on the active implementation branch before PR
+- carry any release-dependent lifecycle closure on the next implementation branch as its first docs-only step
+- do not create a standalone docs-only roadmap or drift-refresh branch by default just to close a small released lane
+
+Use a standalone docs-only exception only when no safe next implementation branch can yet be chosen and the user explicitly approves that exception.
+
 Examples that usually do not need their own closeout:
 
 - tiny usability follow-through

--- a/Docs/closeout_guidance.md
+++ b/Docs/closeout_guidance.md
@@ -60,6 +60,10 @@ After that, the Nexus pre-Beta public release line moved to:
 - `v1.0.1-prebeta`
 - `v1.1.0-prebeta`
 - `v1.1.1-prebeta`
+- `v1.2.0-prebeta`
+- `v1.2.1-prebeta`
+- `v1.2.2-prebeta`
+- `v1.2.3-prebeta`
 
 but no matching closeout series was created for those newer pre-Beta releases.
 
@@ -189,7 +193,7 @@ For the current repo state:
 - closeouts should not be treated as abandoned
 - closeouts should resume when the next meaningful Nexus milestone closes, not automatically after every small patch
 
-If a future planning pass needs a fresh post-`v1.1.1-prebeta` canonical baseline before broader next-lane work, the best move would be:
+If a future planning pass needs a fresh post-`v1.2.3-prebeta` canonical baseline before broader next-lane work, the best move would be:
 
 - one Nexus-era milestone rebaseline or closeout
 

--- a/Docs/codex_modes.md
+++ b/Docs/codex_modes.md
@@ -407,17 +407,63 @@ unless a grouped branch remains clearly justified.
 
 After a prior workstream branch has been merged, released if applicable, and deleted, the next workstream should start from updated `main` on a fresh branch.
 
-If the first required post-merge or post-release work is a docs-only roadmap, rebaseline, or drift-refresh pass so shared canon matches live repo truth, Codex may create that fresh docs-only branch immediately after verifying the live repo state.
+For routine Nexus `pre-Beta` work, standalone docs-only roadmap, rebaseline, or drift-refresh branches should not be the default cleanup path anymore.
 
-In that case, the docs-only refresh branch itself counts as the first new workstream branch and should land before a new implementation branch is created from the refreshed shared baseline.
+Instead, canon freshness must be handled in only two required windows:
 
-Codex should not create that next branch until:
+### 1. Branch-Start Canon Alignment Review
 
-- the live post-merge or post-release repo state has been verified
-- the next workstream plan is clearly established
-- the user has approved that next branch path
+Before the first code slice on every new non-doc implementation branch, Codex must run a deep branch-start canon alignment review against:
 
-Once those conditions are met, creating the fresh branch may be the first Workflow-mode step of the new workstream.
+- `docs/Main.md`
+- `docs/development_rules.md`
+- `docs/codex_modes.md`
+- the directly relevant planning docs
+- the directly relevant architecture docs
+- the directly relevant implementation truth
+
+That review must:
+
+- close the just-finished released or merged lane in canon when that closure is now known
+- activate or clarify the new lane in canon when that activation is already known
+- sync only the directly supporting docs needed for the new branch to start from current shared truth
+- land any required docs-only sync as the first commit, or first tightly grouped docs-only commits, on that same new implementation branch before further implementation work
+
+### 2. Pre-PR Canon Freeze Review
+
+Before PR packaging for a non-doc implementation branch, Codex must run a deep canon-freeze review on that same branch.
+
+That review must confirm:
+
+- the roadmap entry matches actual branch truth
+- the backlog item state, suggested version, and suggested revision fields match actual lane truth
+- governing docs reflect any implemented boundary changes now carried by that lane
+- architecture docs reflect any implemented boundary changes now carried by that lane
+- no directly supporting canon needed for merge or release remains stale
+
+If supporting canon is still stale, the required sync must land on the same branch before PR packaging.
+
+### Post-Release Lifecycle Closure Rule
+
+Some facts cannot become true until a public release actually exists. Those facts include:
+
+- latest public prerelease
+- lane `release state: released`
+- lane `status: closed` when that closure depends on the release actually existing
+
+When those release-dependent facts change, Codex should not open a routine standalone docs-only refresh branch by default.
+
+Instead:
+
+- if a new implementation lane is about to begin, Codex should carry the release-closure sync as the first docs-only step on that new implementation branch during the branch-start canon alignment review
+- if no safe next implementation branch can yet be chosen, Codex must say so explicitly and ask for user approval before using any standalone docs-only exception path
+
+This means routine roadmap or drift refresh should happen either:
+
+- before PR on the active implementation branch
+- or at the start of the next implementation branch
+
+It should not be deferred into a separate docs-only branch by default.
 
 ---
 
@@ -478,6 +524,13 @@ Codex should not add a `Not included` section unless:
 
 - the user explicitly asks for one
 - omitting it would create a real scope misunderstanding for the active task
+
+For non-doc implementation branches, PR-readiness output must explicitly state one of:
+
+- `supporting canon already aligned on branch`
+- `supporting canon sync required before PR`
+
+That canon-freshness result is mandatory and must be based on live branch truth, not on prompt framing alone.
 
 In slice-sizing terms:
 

--- a/Docs/development_rules.md
+++ b/Docs/development_rules.md
@@ -28,6 +28,24 @@ If the user gives a brief cue such as:
 
 Codex must still load the default truth baseline from `docs/Main.md`, then add the directly relevant canonical docs and evidence inputs needed for the task.
 
+## Canon Freshness Gate
+
+For routine Nexus `pre-Beta` implementation work:
+
+- do not let supporting canon drift until after release and then clean it up with a separate docs-only refresh branch by default
+- supporting canon for an active lane must be synced on the implementation branch itself before PR packaging
+- if a just-finished released lane needs lifecycle closure in canon, that closure should normally be the first docs-only step on the next implementation branch rather than a standalone docs-only cleanup branch
+- use a standalone docs-only roadmap or drift-refresh branch only as an explicit exception after telling the user why no safe next implementation branch can yet be chosen
+
+Supporting canon means only the directly relevant truth docs for the active lane, such as:
+
+- `docs/prebeta_roadmap.md` for lane lifecycle, release floor, target version, and release state
+- `docs/feature_backlog.md` for per-item state and version truth
+- `docs/development_rules.md` and `docs/architecture.md` for implemented boundary changes
+
+This rule does not authorize broad docs cleanup.
+It only requires the minimum directly supporting canon sync needed so PR-readiness, release-readiness, and next-branch planning all start from current truth.
+
 ## Pre-Patch Investigation Gate
 
 For runtime bugs, behavior regressions, systems investigations, architecture-sensitive work, or readiness/risk analysis that could lead directly to patching, Codex must complete pre-patch investigation before editing.

--- a/Docs/prebeta_roadmap.md
+++ b/Docs/prebeta_roadmap.md
@@ -155,30 +155,35 @@ While release debt exists:
 
 ## Current Near-Term Roadmap Horizon
 
-This is the current best provisional sequencing horizon from live repo truth after the live `v1.2.2-prebeta` release.
+This is the current best provisional sequencing horizon from live repo truth after the live `v1.2.3-prebeta` release.
 
-The current active non-doc implementation lane is now:
+The just-finished non-doc implementation lane is now:
 
 - `feature/fb-028-history-state-relocation`
 
-That lane was selected by fresh next-lane analysis from the released `v1.2.2-prebeta` baseline rather than by automatic continuation of the closed `feature/fb-034-recoverable-diagnostics` lane.
+That lane is now released and closed at `v1.2.3-prebeta`.
+No new active non-doc implementation lane is declared here yet from current canon.
 
 ## Current Active Lane
 
-### `feature/fb-028-history-state-relocation`
+No active non-doc implementation lane is currently declared here from current canon.
 
-- status: `active`
-- lane type: `implementation`
-- release floor: `patch prerelease`
-- target version: `v1.2.3-prebeta`
-- release state: `active delta`
-- purpose: relocate launcher-owned historical state out of the live root `logs` tree without changing historical-memory semantics or widening logs/reporting policy
-- milestone target: move launcher-owned historical state out of the live root `logs` tree into a dedicated non-user-facing launcher-owned state root, with migration and clean fallback, without changing historical-memory semantics or widening logs/reporting policy
-- minimum merge-ready threshold: launcher history resolves to a dedicated state root outside live root `logs`; successful migration no longer leaves the legacy root-log history file exposed; failure to migrate or write still degrades cleanly to the last non-historical behavior; contained history harness and direct consumers follow the relocated path contract; validation proves history writes no longer spill into live root `logs`; runtime logs, crash logs, and support-bundle locations remain unchanged
+The next implementation lane should be chosen by fresh next-lane analysis from the released `v1.2.3-prebeta` baseline rather than by automatic continuation of the just-finished `feature/fb-028-history-state-relocation` lane.
 
 ## Recently Closed Or Superseded Lanes
 
-These entries remain here only long enough to keep the post-`v1.2.2-prebeta` transition explicit.
+These entries remain here only long enough to keep the post-`v1.2.3-prebeta` transition explicit.
+
+### `feature/fb-028-history-state-relocation`
+
+- status: `closed`
+- lane type: `implementation`
+- release floor: `patch prerelease`
+- target version: `v1.2.3-prebeta`
+- release state: `released`
+- purpose: relocate launcher-owned historical state out of the live root `logs` tree without changing historical-memory semantics or widening logs/reporting policy
+- milestone target: move launcher-owned historical state out of the live root `logs` tree into a dedicated non-user-facing launcher-owned state root, with migration and clean fallback, without changing historical-memory semantics or widening logs/reporting policy
+- minimum merge-ready threshold: launcher history resolves to a dedicated state root outside live root `logs`; successful migration no longer leaves the legacy root-log history file exposed; failure to migrate or write still degrades cleanly to the last non-historical behavior; contained history harness and direct consumers follow the relocated path contract; validation proves history writes no longer spill into live root `logs`; runtime logs, crash logs, and support-bundle locations remain unchanged
 
 ### `feature/fb-034-recoverable-diagnostics`
 
@@ -221,10 +226,10 @@ These entries remain here only long enough to keep the post-`v1.2.2-prebeta` tra
 
 Current repo truth indicates:
 
-- the latest public prerelease is now `v1.2.2-prebeta`
+- the latest public prerelease is now `v1.2.3-prebeta`
 - `main` is aligned with that released commit
-- the `feature/fb-034-recoverable-diagnostics` lane is now released and closed
-- the prior release debt between `v1.2.1-prebeta` and `main` is cleared
+- the `feature/fb-028-history-state-relocation` lane is now released and closed
+- the prior release debt between `v1.2.2-prebeta` and `main` is cleared
 - no new implementation lane is automatically active just because the prior patch milestone released
 - broader sequencing should resume from a fresh next-lane analysis on this released baseline
 

--- a/Docs/prebeta_roadmap.md
+++ b/Docs/prebeta_roadmap.md
@@ -127,7 +127,21 @@ Refresh this roadmap when:
 - the current release-debt posture changes
 - `main` materially advances beyond the latest public release and this roadmap no longer matches live repo truth
 
-This roadmap should usually be refreshed by one narrow docs-only governance or rebaseline pass rather than by ad hoc wording drift across multiple unrelated branches.
+This roadmap should usually be refreshed on the active implementation branch before PR, or as the first docs-only step on the next implementation branch after release, rather than being deferred into a standalone docs-only refresh branch by default.
+
+## Canon Freshness Timing
+
+For routine Nexus `pre-Beta` work:
+
+- active-lane truth must be synced on the implementation branch before PR packaging
+- release-dependent lifecycle closure should normally be carried on the next implementation branch as its first docs-only step
+- standalone docs-only roadmap or drift-refresh branches are no longer the default post-release cleanup path
+- if no safe next implementation branch can yet be chosen, Codex must call that out explicitly before requesting any exception path
+
+This roadmap should therefore stay fresh in two normal windows only:
+
+- on the active implementation branch before PR
+- at the start of the next implementation branch after a release, when release-closure facts now need to be recorded
 
 ## Release-Debt Handling
 


### PR DESCRIPTION
## Summary

Updates Docs: add the pre-Beta canon freshness gate and refresh post-v1.2.3 governance truth.

## What Changed

### Changes

- establish the pre-Beta canon-freshness rule so routine canon sync happens on the implementation branch before PR, or as the first docs-only step on the next implementation branch after release
- remove standalone docs-only roadmap/drift-refresh branches as the default cleanup path
- align the governance stack on branch-start canon alignment, pre-PR canon-freeze review, and post-release lifecycle-closure expectations
- refresh stale current-state examples to live post-`v1.2.3-prebeta` truth, including closing `feature/fb-028-history-state-relocation` from canon and updating closeout/rebaseline examples

### Scope
- `Docs/Main.md`
- `Docs/development_rules.md`
- `Docs/codex_modes.md`
- `Docs/closeout_guidance.md`
- `Docs/prebeta_roadmap.md`

### Notes
- docs-only governance/source-of-truth branch
- no implementation code changes
- no README, LICENSE, release, tag, or repo-settings changes

### Changes

- establish the pre-Beta canon-freshness rule so routine canon sync happens on the implementation branch before PR, or as the first docs-only step on the next implementation branch after release
- remove standalone docs-only roadmap/drift-refresh branches as the default cleanup path
- align the governance stack on branch-start canon alignment, pre-PR canon-freeze review, and post-release lifecycle-closure expectations
- refresh stale current-state examples to live post-`v1.2.3-prebeta` truth, including closing `feature/fb-028-history-state-relocation` from canon and updating closeout/rebaseline examples

### Scope
- `Docs/Main.md`
- `Docs/development_rules.md`
- `Docs/codex_modes.md`
- `Docs/closeout_guidance.md`
- `Docs/prebeta_roadmap.md`

### Notes
- docs-only governance/source-of-truth branch
- no implementation code changes
- no README, LICENSE, release, tag, or repo-settings changes
