### PR TITLE
FB-033 canon-freeze follow-up for merge-stable roadmap and backlog truth

### DIFF
--- a/Docs/feature_backlog.md
+++ b/Docs/feature_backlog.md
@@ -1480,11 +1480,12 @@ Current active lane target:
 
 - keep the startup snapshot path strictly harness-gated and dev-only
 - stabilize the owned trigger/env contract and output location for contained launch investigations
-- add a bounded contained validation path that proves healthy startup capture without spilling artifacts into live root logs or normal runtime state by default
-- defer permanent timing-set decisions, failure-oriented follow-through, and any dedicated dev-launcher surfacing until later evidence justifies them
+- add a bounded contained validation path that proves healthy and failure-oriented startup behavior without spilling artifacts into live root logs or normal runtime state by default
+- defer permanent timing-set decisions and any dedicated dev-launcher surfacing until later evidence justifies them
 
 Likely Files Affected:
 - C:/Nexus Desktop AI/desktop/desktop_renderer.py
+- C:/Nexus Desktop AI/dev/orin_startup_snapshot_harness_validation.py
 - optional directly supportive dev-only launch/test surfaces
 - optional directly supportive canonical docs for dev-only usage guidance
 
@@ -1501,7 +1502,7 @@ Out of Scope:
 - unrelated Dev Toolkit expansion unless explicitly approved later
 
 Notes:
-Current branch-local evidence indicates the helper is useful for internal startup debugging, but it should remain clearly separate from normal runtime behavior and should only be kept long-term if it stays harness-gated, low-noise, and bounded to developer investigation needs.
+Current active-lane evidence indicates the helper is useful for internal startup debugging, but it should remain clearly separate from normal runtime behavior and should only be kept long-term if it stays harness-gated, low-noise, and bounded to developer investigation needs.
 
 ---
 

--- a/Docs/prebeta_roadmap.md
+++ b/Docs/prebeta_roadmap.md
@@ -235,9 +235,9 @@ These entries remain here only long enough to keep the post-`v1.2.3-prebeta` tra
 Current repo truth indicates:
 
 - the latest public prerelease is now `v1.2.3-prebeta`
-- `main` is aligned with that released commit
 - the `feature/fb-028-history-state-relocation` lane is now released and closed
-- the prior release debt between `v1.2.2-prebeta` and `main` is cleared
+- the `feature/fb-033-startup-snapshot-harness-follow-through` lane is the current bounded implementation lane targeting `v1.2.4-prebeta`
+- any merged non-doc work beyond `v1.2.3-prebeta` should be treated as release debt until `v1.2.4-prebeta` is published
 - no new implementation lane became active automatically just because the prior patch milestone released
 - fresh next-lane analysis on that released baseline selected `feature/fb-033-startup-snapshot-harness-follow-through` as the next bounded implementation lane
 


### PR DESCRIPTION
## Summary

This PR is the narrow FB-033 follow-up for the two missed pre-PR canon-freeze items that should have landed before the earlier implementation PR.

## What Changed

### Changes

It does not change the merged FB-033 implementation. It only updates the directly supporting canon so the roadmap and backlog stay true after merge and accurately describe the already-merged bounded FB-033 scope.

### Included Scope

- update `Docs/prebeta_roadmap.md`
  - remove the brittle line that implied `main` stayed aligned with the released `v1.2.3-prebeta` commit
  - replace it with merge-stable wording that treats merged non-doc work beyond `v1.2.3-prebeta` as release debt until `v1.2.4-prebeta` is published
  - keep FB-033 represented as the current bounded implementation lane targeting `v1.2.4-prebeta`
- update `Docs/feature_backlog.md`
  - align the FB-033 entry with the already-merged branch truth
  - reflect that the bounded validation path now covers both healthy and failure-oriented startup behavior
  - list `dev/orin_startup_snapshot_harness_validation.py` as a directly affected file
  - update the note wording so it describes current active-lane evidence rather than branch-local-only evidence

### Why This PR Exists

The earlier FB-033 implementation milestone merged cleanly, but two directly supporting canon lines were still too branch-local and should have been frozen more carefully before PR.

This follow-up closes that gap so the supporting canon now matches merge truth and stays stable through the `v1.2.4-prebeta` release window.

### Changes

### Included Scope

- update `Docs/prebeta_roadmap.md`
  - remove the brittle line that implied `main` stayed aligned with the released `v1.2.3-prebeta` commit
  - replace it with merge-stable wording that treats merged non-doc work beyond `v1.2.3-prebeta` as release debt until `v1.2.4-prebeta` is published
  - keep FB-033 represented as the current bounded implementation lane targeting `v1.2.4-prebeta`
- update `Docs/feature_backlog.md`
  - align the FB-033 entry with the already-merged branch truth
  - reflect that the bounded validation path now covers both healthy and failure-oriented startup behavior
  - list `dev/orin_startup_snapshot_harness_validation.py` as a directly affected file
  - update the note wording so it describes current active-lane evidence rather than branch-local-only evidence

### Why This PR Exists
