### PR TITLE
Release FB-035 as v1.2.7-prebeta

### DIFF
--- a/Docs/feature_backlog.md
+++ b/Docs/feature_backlog.md
@@ -1517,7 +1517,7 @@ Released in `v1.2.4-prebeta`.
 
 ### [ID: FB-034] Recoverable incident diagnostics surface and failure-class follow-through
 
-Status: Active
+Status: Implemented (v1.2.6-prebeta)
 Priority: Medium
 Suggested Version: v1.2.6-prebeta
 Suggested Revision: rev2
@@ -1530,12 +1530,12 @@ Why it matters:
 Current repo truth now includes one bounded recoverable-operational-incident path in `v1.2.2-prebeta`, but that does not authorize automatic continuation into broader diagnostics triggers, reporting-policy expansion, or voice-path widening. A deferred follow-through item keeps future work explicit and revalidatable.
 
 Proposed Change:
-Current active lane target:
+Implemented lane truth:
 
 - select one recoverable high-signal incident class only: repeated identical `launch_failed` for the same action in a still-running session
 - make the current Class 2-to-Class 3 boundary explicit enough in renderer evidence that the branch would still read as a meaningful recoverable-diagnostics milestone if squashed and merged on its own
 - preserve the existing local/manual support-bundle and issue-draft boundary
-- keep directly coupled same-incident follow-through on this branch only when it is still required to make that repeated identical `launch_failed` milestone feel complete
+- keep directly coupled same-incident follow-through on the same lane only when it is still required to make that repeated identical `launch_failed` milestone feel complete
 - keep fatal launcher/runtime diagnostics completion behavior separate and unchanged
 - defer any broader recoverable diagnostics surface, voice, or launcher-policy follow-through until later evidence justifies it
 
@@ -1562,7 +1562,55 @@ Out of Scope:
 - automatic continuation of the current NCP hardening lane
 
 Notes:
-Current active-lane evidence already includes one bounded shipped Class 3 example in `v1.2.2-prebeta`, so this lane should stay scoped to that same repeated identical `launch_failed` incident class first, allow only directly coupled same-incident follow-through needed to make the milestone feel complete, and avoid broader diagnostics widening.
+Released in `v1.2.6-prebeta`.
+
+The current released lane now keeps repeated identical `launch_failed` as the one selected recoverable incident class, makes the Class 2/Class 3 boundary explicit in renderer evidence, preserves the local/manual support-bundle and issue-draft boundary, and keeps report artifacts on truthful latest-public-prerelease context.
+
+---
+
+### [ID: FB-035] Support-report release-context fallback hardening
+
+Status: Active
+Priority: Medium
+Suggested Version: v1.2.7-prebeta
+Suggested Revision: rev1
+Release Stage: pre-Beta
+
+Description:
+Harden support-report release-context derivation so generated support bundles and issue drafts keep reporting the latest released public prerelease even when `.git` metadata is unavailable.
+
+Why it matters:
+Current support-reporting truth already uses live tags when `.git` is available, but the roadmap fallback can still select a higher planned prerelease target instead of the latest released public prerelease. That would stamp support artifacts with an unreleased baseline in packaged or metadata-poor workspaces, which weakens diagnostics triage accuracy.
+
+Proposed Change:
+Current active lane target:
+
+- keep the lane scoped to release-context fallback hardening only
+- derive fallback release truth from released-prerelease canon instead of from any highest planned prerelease tag
+- preserve existing support-bundle contents, privacy posture, and manual-reporting boundary
+- prove both `git`-present and `git`-unavailable paths carry the same truthful latest-public-prerelease context in generated report artifacts
+
+Likely Files Affected:
+- C:/Nexus Desktop AI/Docs/feature_backlog.md
+- C:/Nexus Desktop AI/Docs/prebeta_roadmap.md
+- C:/Nexus Desktop AI/desktop/orin_support_reporting.py
+- C:/Nexus Desktop AI/dev/orin_recoverable_launch_failed_validation.py
+
+Scope:
+- support-report release-context fallback hardening
+- released-prerelease canon parsing for fallback truth
+- narrow validation for `git`-present and `git`-unavailable report-artifact context
+
+Out of Scope:
+- new incident classes
+- reporting-policy changes
+- upload-behavior changes
+- diagnostics UI redesign
+- launcher retry or escalation redesign
+- voice-path work
+
+Notes:
+This lane carries the actionable Codex review finding from PR `#46`: the roadmap fallback should not choose a higher planned prerelease target when `.git` metadata is unavailable. Keep it hardening-only and stop before broader diagnostics or reporting follow-through.
 
 ---
 

--- a/Docs/prebeta_roadmap.md
+++ b/Docs/prebeta_roadmap.md
@@ -161,33 +161,44 @@ While release debt exists:
 
 ## Current Near-Term Roadmap Horizon
 
-This is the current best provisional sequencing horizon from live repo truth after the live `v1.2.5-prebeta` release.
+This is the current best provisional sequencing horizon from live repo truth after the live `v1.2.6-prebeta` release.
 
 The just-finished non-doc implementation lane is now:
 
-- `feature/fb-025-boot-desktop-milestone-taxonomy-clarification`
+- `feature/fb-034-recoverable-diagnostics`
 
-That lane is now released and closed at `v1.2.5-prebeta`.
+That lane is now released and closed at `v1.2.6-prebeta`.
 
 ## Current Active Lane
 
-### `feature/fb-034-recoverable-diagnostics`
+### `feature/release-context-fallback-hardening`
 
 - status: `active`
 - lane type: `implementation`
 - release floor: `patch prerelease`
-- target version: `v1.2.6-prebeta`
-- purpose: deliver the smallest worthwhile recoverable-incident milestone that makes the current Class 2/Class 3 boundary explicit for one high-signal incident class without widening diagnostics policy
-- milestone target: keep repeated identical `launch_failed` for the same action as the only selected incident class, make the recoverable Class 2-to-Class 3 boundary explicit enough in renderer evidence that the branch would still read as a meaningful recoverable-diagnostics milestone if squashed and merged by itself, and preserve the existing local/manual reporting boundary without broad diagnostics UI work
-- minimum merge-ready threshold: one incident class only; no launcher retry or escalation redesign; no blanket recoverable diagnostics popup behavior; no broad diagnostics UI redesign; no voice-path work required for this milestone; fatal launcher/runtime diagnostics path unchanged; manual reporting boundary unchanged; narrow validation proves the selected class behaves as intended; and the branch is strong enough to justify `patch prerelease` rather than reading as setup or bookkeeping only
-- milestone value statement: if squashed today, this branch should still clearly read as the first worthwhile recoverable-diagnostics milestone above the current Class 2/Class 4 boundary rather than as only a marker rename, validation stub, or preparatory fragment
-- expected same-branch follow-through: keep directly coupled follow-through on this branch only when it is still required to make the selected repeated `launch_failed` milestone feel complete, but stop before broader diagnostics classes, UI redesign, retry-policy work, or voice-path expansion
+- target version: `v1.2.7-prebeta`
+- purpose: harden support-report release-context derivation so support bundles and issue drafts keep reporting the latest public prerelease truth even when `.git` metadata is unavailable
+- milestone target: derive release-context fallback truth from released-prerelease canon rather than from the highest planned prerelease tag, and prove both the `git`-present and `git`-unavailable report-artifact paths carry the same truthful latest-public-prerelease context
+- minimum merge-ready threshold: no new incident classes; no reporting-policy or upload-behavior changes; no diagnostics UI widening; no launcher retry or escalation redesign; no voice-path work; fallback logic derives latest released prerelease truth from canon instead of any highest planned prerelease tag; narrow validation proves both `git`-present and `git`-unavailable paths carry truthful release context; and the branch is strong enough to justify `patch prerelease` rather than reading as a parser tweak without proof
+- milestone value statement: if squashed today, this branch should still read as a worthwhile support-report hardening milestone that prevents unreleased-baseline drift in generated support artifacts rather than as only a tiny parser edit or review-note follow-up
+- expected same-branch follow-through: keep only directly coupled fallback parsing and release-context validation on this branch while needed to make the hardening milestone feel complete, but stop before broader reporting UX, diagnostics policy, or additional incident-class work
 
 This branch begins with the required canon-alignment step on the same implementation branch rather than through a separate standalone docs-only refresh branch.
 
 ## Recently Closed Or Superseded Lanes
 
-These entries remain here only long enough to keep the post-`v1.2.5-prebeta` transition explicit.
+These entries remain here only long enough to keep the post-`v1.2.6-prebeta` transition explicit.
+
+### `feature/fb-034-recoverable-diagnostics`
+
+- status: `closed`
+- lane type: `implementation`
+- release floor: `patch prerelease`
+- target version: `v1.2.6-prebeta`
+- release state: `released`
+- purpose: deliver the first worthwhile recoverable-incident milestone that makes the current Class 2/Class 3 boundary explicit for one high-signal incident class without widening diagnostics policy
+- milestone target: keep repeated identical `launch_failed` for the same action as the only selected incident class, make the recoverable Class 2-to-Class 3 boundary explicit enough in renderer evidence that the merged lane reads as a meaningful recoverable-diagnostics milestone on its own, and preserve the existing local/manual reporting boundary without broad diagnostics UI work
+- minimum merge-ready threshold: one incident class only; no launcher retry or escalation redesign; no blanket recoverable diagnostics popup behavior; no broad diagnostics UI redesign; no voice-path work for the lane; fatal launcher/runtime diagnostics path unchanged; manual reporting boundary unchanged; narrow validation proves the selected class behaves as intended; and report artifacts carry truthful latest-public-prerelease context
 
 ### `feature/fb-025-boot-desktop-milestone-taxonomy-clarification`
 
@@ -222,17 +233,6 @@ These entries remain here only long enough to keep the post-`v1.2.5-prebeta` tra
 - milestone target: move launcher-owned historical state out of the live root `logs` tree into a dedicated non-user-facing launcher-owned state root, with migration and clean fallback, without changing historical-memory semantics or widening logs/reporting policy
 - minimum merge-ready threshold: launcher history resolves to a dedicated state root outside live root `logs`; successful migration no longer leaves the legacy root-log history file exposed; failure to migrate or write still degrades cleanly to the last non-historical behavior; contained history harness and direct consumers follow the relocated path contract; validation proves history writes no longer spill into live root `logs`; runtime logs, crash logs, and support-bundle locations remain unchanged
 
-### `feature/fb-034-recoverable-diagnostics`
-
-- status: `closed`
-- lane type: `implementation`
-- release floor: `patch prerelease`
-- target version: `v1.2.2-prebeta`
-- release state: `released`
-- purpose: first bounded recoverable diagnostics and reporting lane above the current Class 2/Class 4 boundary
-- milestone target: the first bounded recoverable-operational-incident milestone while Nexus remains alive, using one explicit incident class and the existing local/manual reporting boundary
-- minimum merge-ready threshold: keep first single `launch_failed` inline, preserve fatal launcher/runtime diagnostics ownership, and add one bounded recoverable path where repeated identical `launch_failed` for the same action prepares a local support bundle and issue draft once without widening into blanket diagnostics or reporting redesign
-
 ### `feature/prebeta-roadmap-rebaseline`
 
 - status: `merged`
@@ -263,13 +263,14 @@ These entries remain here only long enough to keep the post-`v1.2.5-prebeta` tra
 
 Current repo truth indicates:
 
-- the latest public prerelease is now `v1.2.5-prebeta`
+- the latest public prerelease is now `v1.2.6-prebeta`
 - the `feature/fb-028-history-state-relocation` lane is now released and closed
 - the `feature/fb-033-startup-snapshot-harness-follow-through` lane is now released and closed
 - the `feature/fb-025-boot-desktop-milestone-taxonomy-clarification` lane is now released and closed
-- the prior release debt between `v1.2.4-prebeta` and `main` is cleared
+- the `feature/fb-034-recoverable-diagnostics` lane is now released and closed
+- the prior release debt between `v1.2.5-prebeta` and `main` is cleared
 - no new implementation lane became active automatically just because the prior patch milestone released
-- fresh next-lane analysis on that released baseline selected `feature/fb-034-recoverable-diagnostics` as the next bounded implementation lane
+- fresh next-lane analysis on that released baseline selected `feature/release-context-fallback-hardening` as the next bounded implementation lane
 
 That does **not** mean every listed lane should automatically happen.
 It does mean non-doc implementation lanes should be treated as version-bearing milestones rather than as merge-only background follow-through.

--- a/desktop/orin_support_reporting.py
+++ b/desktop/orin_support_reporting.py
@@ -14,6 +14,14 @@ DEFAULT_GITHUB_ISSUES_NEW_URL = ""
 SUPPORT_BUNDLE_FOLDER = "support_bundles"
 MANIFEST_FILENAME = "manifest.json"
 VERSION_CLOSEOUT_PATTERN = re.compile(r"^v(\d+)\.(\d+)\.(\d+)_closeout\.md$")
+LATEST_PUBLIC_PRERELEASE_LINE_PATTERN = re.compile(
+    r"latest public prerelease(?: is now)?\s*`(v\d+\.\d+\.\d+-prebeta)`",
+    re.IGNORECASE,
+)
+RELEASED_CLOSED_PRERELEASE_LINE_PATTERN = re.compile(
+    r"released and closed at\s*`(v\d+\.\d+\.\d+-prebeta)`",
+    re.IGNORECASE,
+)
 PLANNED_PUBLIC_RELEASE_LABEL = (
     "Pre-Beta baseline defined; planned first public release: "
     "Nexus Desktop AI — Pre-Beta v1.0.0 (tag: v1.0.0-prebeta)"
@@ -95,13 +103,17 @@ def detect_latest_public_prerelease_tag_from_roadmap(root_dir):
     try:
         with open(roadmap_path, "r", encoding="utf-8", errors="ignore") as handle:
             for line in handle:
-                for tag_name in re.findall(r"`(v\d+\.\d+\.\d+-prebeta)`", line):
-                    version = parse_public_prerelease_tag(tag_name)
-                    if version is None:
-                        continue
-                    if best_version is None or version > best_version:
-                        best_tag = tag_name
-                        best_version = version
+                for pattern in (
+                    LATEST_PUBLIC_PRERELEASE_LINE_PATTERN,
+                    RELEASED_CLOSED_PRERELEASE_LINE_PATTERN,
+                ):
+                    for tag_name in pattern.findall(line):
+                        version = parse_public_prerelease_tag(tag_name)
+                        if version is None:
+                            continue
+                        if best_version is None or version > best_version:
+                            best_tag = tag_name
+                            best_version = version
     except OSError:
         return None
 

--- a/dev/orin_recoverable_launch_failed_validation.py
+++ b/dev/orin_recoverable_launch_failed_validation.py
@@ -86,6 +86,13 @@ def extract_issue_draft_body(browser_open_calls):
         return ""
 
     issue_url = browser_open_calls[0]["url"]
+    return extract_issue_body_from_issue_url(issue_url)
+
+
+def extract_issue_body_from_issue_url(issue_url):
+    if not issue_url:
+        return ""
+
     parsed = urllib.parse.urlparse(issue_url)
     query = urllib.parse.parse_qs(parsed.query)
     return query.get("body", [""])[0]
@@ -129,6 +136,9 @@ def run_validation():
     browser_open_calls = []
     original_startfile = renderer_mod.os.startfile
     original_webbrowser_open = renderer_mod.webbrowser.open
+    original_detect_latest_public_prerelease_tag_from_git = (
+        support_reporting_mod.detect_latest_public_prerelease_tag_from_git
+    )
 
     def fake_startfile(path):
         folder_open_calls.append(os.path.abspath(path))
@@ -158,9 +168,24 @@ def run_validation():
 
         renderer_mod.DesktopRuntimeWindow._clear_launch_failure_tracking(window, action.id)
         fourth_status = renderer_mod.DesktopRuntimeWindow._prepare_recoverable_launch_failure_report(window, action)
+
+        support_reporting_mod.detect_latest_public_prerelease_tag_from_git = lambda _root_dir: None
+        roadmap_fallback_report_prep = support_reporting_mod.prepare_manual_issue_report(
+            ROOT_DIR,
+            runtime_log_path,
+            crash_dir,
+        )
+        roadmap_fallback_bundle = roadmap_fallback_report_prep["bundle_info"]["bundle_path"]
+        roadmap_fallback_manifest = inspect_bundle_manifest(roadmap_fallback_bundle)
+        roadmap_fallback_issue_body = extract_issue_body_from_issue_url(
+            roadmap_fallback_report_prep["issue_url"]
+        )
     finally:
         renderer_mod.os.startfile = original_startfile
         renderer_mod.webbrowser.open = original_webbrowser_open
+        support_reporting_mod.detect_latest_public_prerelease_tag_from_git = (
+            original_detect_latest_public_prerelease_tag_from_git
+        )
 
     checks = {
         "first_failure_stays_inline": line_status(
@@ -215,6 +240,24 @@ def run_validation():
         "issue_draft_carries_truthful_release_context": line_status(
             expected_release_context in second_issue_body and "v1.0.0-prebeta" not in second_issue_body,
             second_issue_body or "missing issue draft body",
+        ),
+        "roadmap_fallback_prepares_bundle": line_status(
+            bool(roadmap_fallback_bundle) and os.path.isfile(roadmap_fallback_bundle),
+            roadmap_fallback_bundle or "missing roadmap fallback bundle zip",
+        ),
+        "roadmap_fallback_bundle_manifest_carries_current_public_release_tag": line_status(
+            roadmap_fallback_manifest.get("jarvis_version") == expected_public_release_tag,
+            repr(roadmap_fallback_manifest.get("jarvis_version")),
+        ),
+        "roadmap_fallback_bundle_manifest_carries_truthful_release_context": line_status(
+            roadmap_fallback_manifest.get("release_context") == expected_release_context
+            and "v1.0.0-prebeta" not in roadmap_fallback_manifest.get("release_context", ""),
+            repr(roadmap_fallback_manifest.get("release_context")),
+        ),
+        "roadmap_fallback_issue_draft_carries_truthful_release_context": line_status(
+            expected_release_context in roadmap_fallback_issue_body
+            and "v1.0.0-prebeta" not in roadmap_fallback_issue_body,
+            roadmap_fallback_issue_body or "missing roadmap fallback issue draft body",
         ),
         "third_failure_does_not_reopen_report": line_status(
             third_status is None and len(folder_open_calls) == folder_calls_after_second and len(browser_open_calls) == browser_calls_after_second,


### PR DESCRIPTION
## Summary

This PR delivers FB-035 as the next pre-Beta patch prerelease unit targeting `v1.2.7-prebeta`.

## What Changed

### Changes

- hardens support-report release-context fallback handling
- prevents support bundles and issue drafts from reporting an unreleased higher planned prerelease when `.git` metadata is unavailable
- preserves existing manual reporting boundaries and diagnostics behavior
- keeps the release unit limited to the validated four-file FB-035 delta

### Release Scope
This PR intentionally excludes the broader dirty docs-system/source-of-truth reorganization work currently present only in the local working tree.

### Changes

- hardens support-report release-context fallback handling
- prevents support bundles and issue drafts from reporting an unreleased higher planned prerelease when `.git` metadata is unavailable
- preserves existing manual reporting boundaries and diagnostics behavior
- keeps the release unit limited to the validated four-file FB-035 delta

### Release Scope
This PR intentionally excludes the broader dirty docs-system/source-of-truth reorganization work currently present only in the local working tree.
