### PR TITLE
[codex] Rebuild the post-v1.2.7 canon foundation

### DIFF
--- a/Docs/Main.md
+++ b/Docs/Main.md
@@ -1,320 +1,150 @@
-# Jarvis Main
+# Nexus Source-Of-Truth Index
 
 ## Purpose
 
-This document is the source-of-truth index and prompt-baseline map for the Jarvis docs set.
+This document is the routing authority for the merged Nexus Desktop AI canon.
 
 Its job is to:
 
-- define the current source-of-truth structure
-- separate active canonical docs from historical or optional references
-- keep future prompts shorter and more consistent
-- point work toward the right canonical doc without bulk-listing the whole docs tree
+- define the current source-of-truth layers
+- separate ownership between those layers
+- point prompts and reviews toward the right authority docs
+- prevent local branch overlays from being mistaken for merged truth
 
-`Main.md` is an index and routing document.
+`Docs/Main.md` is a routing document.
 It does not replace the authority of the docs it points to.
 
-## How To Use This File
+## Authoritative Baseline
 
-For most Jarvis tasks, prompts should include:
+Use these rules before trusting any planning or governance claim:
 
-- `docs/development_rules.md`
-- `docs/Main.md`
-- only the directly relevant canonical doc or docs for the active workstream
-- only the relevant evidence inputs
+- `origin/main` is the authoritative baseline after merge and release
+- the latest public tag or release is authoritative for released-version truth
+- local unmerged branches, stashes, and docs overlays are reference material only until revalidated against updated `origin/main`
+- if code, logs, and merged docs disagree, validate the live repo truth first and then repair the docs
 
-Add closeout docs, historical docs, or extra planning docs only when they are materially needed for the specific task.
+## Layered Ownership Model
 
-Short prompts may still rely on this baseline.
+Use this ownership split unless a validated source conflict requires a temporary narrower override:
 
-If the user uses a brief cue rather than a full structured prompt, such as:
+- backlog = identity and registry
+- workstream docs = planning, execution, validation, and closure truth for promoted work
+- roadmap = sequencing and release posture
+- rebaselines and closeouts = epoch or milestone summaries
+- incident patterns = generalized reusable lessons
+- bug tracking = backlog-first, with promoted bug docs only when warranted
+- User Test Summary = validation-contract layer owned by the relevant workstream
+- `Docs/Main.md` = routing authority aligned to merged truth
 
-- `Analyze and Report`
-- `Analyze for drift`
-- `Analysis mode`
-- `Workflow mode`
-- `docs-only pass`
-- `reference docs for the following`
+## Analysis-First Prompt Baseline
 
-Codex should treat that cue as shorthand, not as permission to skip the source-of-truth baseline.
+For system analysis, post-release review, branch-start planning, or source-of-truth audit:
 
-Default shorthand behavior:
+1. read `Docs/Main.md`
+2. read `Docs/development_rules.md`
+3. read `Docs/codex_modes.md`
+4. add the directly relevant authority docs for the task
+5. add only the live repo evidence needed to validate current truth
 
-1. load `docs/development_rules.md`
-2. load `docs/Main.md`
-3. infer the directly relevant canonical doc or docs from the active branch, task wording, and current workstream
-4. pull only the evidence inputs needed for that task
-5. ask a clarifying question only if the task is still materially ambiguous after that baseline is applied
+Do not narrow the docs set before the system structure, drift, and authority boundaries are understood.
 
-For the deeper Analysis mode workflow contract and when deep investigative analysis is required, use `docs/codex_modes.md`.
+## Routing Layers
 
-## Current Source-Of-Truth Structure
+### Governance And Prompting
 
-### Core Authoritative Docs
+Use these for workflow posture, prompt framing, lifecycle rules, and execution scaffolding:
 
-These are the default project-governance and product-boundary docs:
+- `Docs/development_rules.md`
+- `Docs/Main.md`
+- `Docs/codex_modes.md`
+- `Docs/orin_task_template.md`
+- `Docs/codex_user_guide.md`
 
-- `docs/development_rules.md`
-- `docs/Main.md`
-- `docs/architecture.md`
-- `docs/orin_vision.md`
-- `docs/orin_display_naming_guidance.md`
-- `docs/feature_backlog.md`
-- `docs/orchestration.md`
-- `docs/codex_modes.md`
-- `docs/orin_task_template.md`
-- `docs/codex_user_guide.md`
-- `docs/closeout_guidance.md`
-- `docs/user_test_summary_guidance.md`
+### Product And Boundary Truth
 
-Within that core set:
+Use these for current product posture, architecture boundaries, and release-stage meaning:
 
-- `docs/orin_vision.md` owns the product-wide meaning of `pre-Beta`, `Beta`, and `Full`
-- `docs/orin_display_naming_guidance.md` owns the display-level ORIN / O.R.I.N. / full-expansion usage pattern
-- `docs/feature_backlog.md` owns per-item or per-slice release-stage assignment
+- `Docs/architecture.md`
+- `Docs/orin_vision.md`
+- `Docs/orchestration.md`
 
-Use these when the task concerns:
+These remain authoritative for their layer even where older naming or path references still need later normalization.
 
-- repo-wide rules
-- architecture boundaries
-- product direction
-- backlog control
-- orchestration ownership
-- prompt or workflow governance, including batched-workstream execution rules
-- grouped-workstream branch strategy and multi-developer workflow boundaries
+### Registry And Sequencing
 
-### Canonical Workstream Docs
+Use these for tracked identity and near-term sequencing:
 
-These are the current canonical planning docs for specific active planning areas:
+- `Docs/feature_backlog.md`
+- `Docs/prebeta_roadmap.md`
 
-- `docs/boot_access_design.md`
-- `docs/ncp_hardening_assessment.md`
-- `docs/orin_interaction_architecture.md`
-- `docs/ownership_ip_plan.md`
-- `docs/workspace_layout_plan.md`
+Rules:
 
-Current canonical ownership:
+- backlog owns identity
+- roadmap owns sequencing and release posture
+- neither backlog nor roadmap should retain the full execution story once a canonical workstream record exists
 
-- `boot_access_design.md` is the canonical boot-planning source
-- `ncp_hardening_assessment.md` is the canonical typed-first NCP hardening reference for the now-closed FB-027 hardening follow-through
-- `orin_interaction_architecture.md` is the canonical interaction-planning source
-- `ownership_ip_plan.md` is the canonical ownership / licensing / IP-planning source
-- `workspace_layout_plan.md` is the canonical workspace-planning source
+### Canonical Workstream Records
 
-Use these only when the task is directly about those workstreams.
+Use these for promoted work that needs a stable planning, execution, validation, and closure record:
 
-### Historical / Optional Docs
+- `Docs/workstreams/index.md`
+- `Docs/workstreams/FB-035_release_context_fallback_hardening.md`
+- `Docs/workstreams/FB-034_recoverable_diagnostics.md`
+- `Docs/workstreams/FB-025_boot_desktop_milestone_taxonomy_clarification.md`
+- `Docs/workstreams/FB-033_startup_snapshot_harness_follow_through.md`
+- `Docs/workstreams/FB-028_history_state_relocation.md`
 
-These docs are still valid, but they are not part of the default prompt baseline for every task:
+### Rebaselines And Closeouts
 
-- `docs/closeouts/v1.6.0_closeout.md`
-- `docs/closeouts/v1.7.0_closeout.md`
-- `docs/closeouts/v1.8.0_closeout.md`
-- `docs/closeouts/v1.9.0_closeout.md`
-- `docs/closeouts/v2.0_closeout.md`
-- `docs/closeouts/v2.2.0_closeout.md`
-- `docs/closeouts/v2.2.1_closeout.md`
-- `docs/closeout_index.md`
+Use these for closeout policy, historical closeout lookup, and the modern Nexus-era baseline summary:
 
-Use them when the task depends on:
+- `Docs/closeout_guidance.md`
+- `Docs/closeout_index.md`
+- `Docs/closeouts/nexus_prebeta_rebaseline_through_v1.2.7-prebeta.md`
 
-- version guarantees
-- version closeout facts
-- post-closeout sequencing
-- auditing whether later work reopens closed version behavior
+Historical closeout leaf docs are intentionally routed through `Docs/closeout_index.md`.
 
-### Retired / Archive Docs
+### Incident Patterns
 
-Retired or archival planning docs are not part of the active docs tree or the default prompt baseline.
+Use this layer for generalized debugging and validation lessons:
 
-If older slice docs or archival planning artifacts are reintroduced for historical tracing, treat them as optional evidence only, not equal-weight current truth.
+- `Docs/incident_patterns.md`
 
-## Default Prompt Baselines By Task Type
+### Validation Guidance
 
-### General Minimal Baseline
+Use this when a task depends on manual validation handoff, User Test Summary structure, or returned test-evidence digestion:
 
-For most tasks, start with:
+- `Docs/user_test_summary_guidance.md`
 
-- `docs/development_rules.md`
-- `docs/Main.md`
-- the directly relevant canonical doc or docs
-- relevant evidence inputs
+### Auxiliary Planning References
 
-Do not bulk-list unrelated docs by default.
+Use these only when the task directly depends on their planning content:
 
-This same minimal baseline should also apply when the user gives only a short cue or shorthand prompt rather than a fully expanded task request.
+- `Docs/boot_access_design.md`
+- `Docs/orin_interaction_architecture.md`
+- `Docs/workspace_layout_plan.md`
+- `Docs/orin_display_naming_guidance.md`
+- `Docs/ncp_hardening_assessment.md`
+- `Docs/ownership_ip_plan.md`
 
-### Code Progression / Patch Work
+These are reference layers, not active workstream or roadmap owners.
 
-For active code work, prompts should usually include:
+## Routing Rules
 
-- `docs/development_rules.md`
-- `docs/Main.md`
-- the directly relevant canonical doc or docs
-- the relevant logs, screenshots, traces, or test evidence
-
-Add closeout docs only if the patch could affect a closed version guarantee.
-
-### Boot Work
-
-For boot-planning or future boot-access work, prompts should usually include:
-
-- `docs/development_rules.md`
-- `docs/Main.md`
-- `docs/boot_access_design.md`
-
-Add `architecture.md`, `orin_vision.md`, `feature_backlog.md`, or `orchestration.md` when the task touches authority, vision, backlog scope, or launcher-owned desktop boundaries.
-
-### Workspace / Folder Organization Work
-
-For workspace-organization work, prompts should usually include:
-
-- `docs/development_rules.md`
-- `docs/Main.md`
-- `docs/workspace_layout_plan.md`
-
-Add `architecture.md` or startup-path docs only if path-sensitive surfaces are directly involved.
-
-### Analysis / Sequencing Work
-
-For "what should we do next," "is this complete," or "is this the right target" tasks, prompts should usually include:
-
-- `docs/development_rules.md`
-- `docs/Main.md`
-- the canonical doc for the active workstream
-- relevant closeout docs only if version guarantees or sequencing are part of the question
-
-For merge-ready, PR-ready, release-ready, or version-bump review, also include:
-
-- `docs/codex_modes.md`
-- the relevant closeout or rebaseline docs when readiness depends on closed guarantees or milestone facts
-
-### First Post-Closeout Version Planning
-
-For the first planning prompt after a version closes, prompts should usually include:
-
-- `docs/development_rules.md`
-- `docs/Main.md`
-- `docs/codex_modes.md`
-- the latest relevant closeout doc
-- the latest relevant interim rebaseline doc if one exists for the active post-closeout branch
-- the directly relevant canonical planning doc or docs for the next version lane
-
-That first prompt should explicitly answer:
-
-- what facts must be carried forward into the new version baseline
-- what repeated prompt content can now be removed because the source-of-truth docs already capture it
-
-### Branch-Start Canon Alignment
-
-For the first prompt on a new non-doc implementation branch after a prior lane has merged or released, prompts should usually include:
-
-- `docs/development_rules.md`
-- `docs/Main.md`
-- `docs/codex_modes.md`
-- the directly relevant planning docs
-- the directly relevant architecture docs
-- the directly relevant implementation truth
-
-That branch-start analysis should explicitly answer:
-
-- what canon from the just-finished lane must now be closed
-- what canon must be activated for the new lane
-- whether the minimum supporting docs sync should land immediately on this new branch before code starts
-- what the smallest worthwhile milestone is for this branch rather than just the first safe slice
-- what tightly coupled follow-through should stay on this branch before readiness
-- what would make the branch too small to justify its declared release floor if stopped early
-
-Do not recommend a separate docs-only roadmap or drift-refresh branch by default for this routine post-release catch-up.
-Instead, carry that closure or activation sync on the new implementation branch unless the user explicitly approves an exception.
-
-### Governance / Prompt / Workflow Docs Work
-
-For prompt-governance or workflow-governance tasks, prompts should usually include:
-
-- `docs/development_rules.md`
-- `docs/Main.md`
-- `docs/codex_modes.md`
-- `docs/orin_task_template.md`
-- `docs/codex_user_guide.md`
-- `docs/closeout_guidance.md` when closeout policy, cadence, cleanup, or post-release baseline questions are in scope
-- `docs/prebeta_roadmap.md` when current near-term sequencing, lane choice, or provisional version-impact questions are in scope
-- `docs/user_test_summary_guidance.md`
-
-Add other canonical docs only if the governance wording depends on them.
-
-This governance lane includes:
-
-- user-test-summary handling rules
-- backlog-control rules
-- batched-workstream execution rules
-- grouped-workstream branch strategy for `pre-Beta`
-- multi-developer workflow and GitHub/tooling governance boundaries
-- shorthand prompt and default-baseline behavior
-- human-operator shorthand guidance for reliable short prompts
-
-For reusable human-facing prompt patterns and operator shorthand examples, use `docs/codex_user_guide.md`.
-
-For current near-term roadmap, branch-sequencing, or provisional release-floor / target-version questions, use `docs/prebeta_roadmap.md`.
-For grouped `pre-Beta` branch-sizing, minimum merge-ready threshold, release floor, target version, release-debt, or "should this lane stop now?" questions, use `docs/prebeta_roadmap.md` together with `docs/codex_modes.md`.
-That roadmap remains subordinate to:
-
-- `docs/orin_vision.md` for release-stage meaning
-- `docs/closeout_guidance.md` for closeout and rebaseline cadence
-- `docs/feature_backlog.md` for detailed backlog-item ownership
-
-## When To Add Closeout Docs
-
-Add closeout docs when the task:
-
-- checks whether a closed version guarantee still holds
-- sequences work immediately after a closeout
-- audits whether a later change reopens a closed version’s behavior
-- needs version-specific implementation facts that are not already captured elsewhere
-
-Do not include all closeout docs by default if only one is relevant.
-
-For closeout policy, cadence, cleanup, or drift questions, use `docs/closeout_guidance.md` alongside the relevant closeout doc or docs.
-
-For historical closeout lookup and browsing, use `docs/closeout_index.md`.
-
-## When To Add Historical Or Archival Docs
-
-Add historical or archival docs only when the task is explicitly about:
-
-- tracing why a decision was made
-- auditing a consolidation
-- comparing current canon to earlier slice decisions
-- resolving a real source-of-truth conflict
-
-Historical or archival docs should normally be treated as supporting evidence, not current prompt baseline.
-
-## Code Progression And Doc Sync Rule
-
-Core code progression is prioritized.
-
-That means:
-
-- active code work should not be repeatedly interrupted by separate doc-only micro-passes unless a docs-first clarification is the safest boundary-setting move
-- truth-doc updates may be bundled into the same approved code workstream when they directly support, record, or stabilize the active code task
-- doc batching should stay minimal and relevant to the active workstream
-- broader canonical sync should happen at meaningful milestones rather than after every tiny slice when that would create unnecessary prompt churn
-- branch planning should target the smallest worthwhile milestone, while revision planning should use the smallest safe slices inside that milestone
-- active implementation branches should not stop at the first clean slice when the resulting branch would still be too small to justify its declared release floor
-
-This does not authorize unrelated doc rewrites.
-It only allows directly supporting truth-doc maintenance to travel with the active workstream when safe and approved.
+- route through the layer that owns the truth you need
+- prefer index docs for historical or high-cardinality layers
+- do not treat a local-only document as canonical just because it exists in the workspace
+- do not create duplicate authority by making backlog, roadmap, and workstream docs all carry the same execution story
+- keep historical Jarvis material preserved, but mark it as historical rather than current reality
 
 ## Practical Prompt Rule
 
-If you are writing a future Jarvis prompt and are unsure what to include:
+If you are unsure what to include in a future Nexus Desktop AI prompt:
 
-1. include `development_rules.md`
-2. include `Main.md`
-3. include the directly relevant canonical doc or docs
-4. include only the evidence inputs that matter
-5. add closeout or historical docs only if the task truly depends on them
+1. start with `Docs/Main.md`
+2. add `Docs/development_rules.md`
+3. add `Docs/codex_modes.md` when collaboration posture matters
+4. add the directly relevant authority docs for the active question
+5. add live repo evidence only where the truth could have changed or drifted
 
-Shorter prompts are preferred when they still preserve the real source of truth.
-
-For batched-workstream execution specifics, rely on `docs/codex_modes.md` rather than retyping the full rule set in every prompt unless the task needs a deliberate override.
+Only after that full scan should scope be narrowed for execution.

--- a/Docs/architecture.md
+++ b/Docs/architecture.md
@@ -1,686 +1,162 @@
-# Jarvis Architecture
+# Nexus Architecture
 
-## Architectural Context
+## Purpose
 
-The current startup path is the stabilized desktop orchestration path, not the final product vision.
+This document defines current architectural boundaries and long-term architectural direction for Nexus Desktop AI.
 
-Current path:
+It does not own:
 
-`launch_jarvis_desktop.vbs`
--> `jarvis_desktop_launcher.pyw`
--> `jarvis_desktop_main.py`
+- backlog identity
+- roadmap sequencing
+- workstream execution history
 
-Long-term vision:
-Windows boot and login should transition into Jarvis as the primary user-facing layer, with Windows remaining the underlying platform.
+Use this doc for boundary truth and system design.
 
-## Startup Path
+## Current Runtime Reality
 
-`launch_jarvis_desktop.vbs`
--> `jarvis_desktop_launcher.pyw`
--> `jarvis_desktop_main.py` (renderer)
+The current controlled desktop runtime path is:
 
-## Future Boot Orchestrator Boundary
+`launch_orin_desktop.vbs`
+-> `desktop/orin_desktop_launcher.pyw`
+-> `desktop/orin_desktop_main.py`
+
+This is the active stabilized runtime path on merged truth.
+It is not yet the final boot-first product experience.
+
+Historical note:
+
+- older Jarvis-named releases and docs remain preserved as historical context
+- they do not override the current runtime path above
+
+## Architectural Layer Model
+
+Current architecture should be read as:
+
+Windows host platform
+-> Windows-facing launch shim
+-> desktop launcher
+-> desktop renderer
+-> support, diagnostics, history, and interaction-support subsystems
+
+Design rule:
+
+- higher layers may consume lower-layer truth
+- lower layers must not be reinterpreted by higher layers after the fact
+
+## Current Ownership Boundaries
+
+### Launch Shim
+
+`launch_orin_desktop.vbs` is the Windows-facing entry shim for the current desktop runtime path.
+
+It is a launcher entry surface, not a planning or control owner.
+
+### Desktop Launcher
+
+`desktop/orin_desktop_launcher.pyw` owns:
+
+- startup observation
+- readiness, stall, abort, and failure classification
+- cooperative control
+- recovery routing
+- finalized runtime and crash truth generation
+
+The launcher remains the authority for desktop-phase orchestration.
+
+### Desktop Renderer
+
+`desktop/orin_desktop_main.py` owns:
+
+- desktop rendering
+- visible desktop lifecycle milestones
+- cooperative response to launcher control
+- clean shutdown behavior inside the renderer layer
+
+The renderer does not own retry, escalation, or final run classification.
+
+### Reporting And Diagnostics Surfaces
+
+Current merged truth keeps:
+
+- support-report generation under launcher and support-reporting ownership
+- recoverable diagnostics bounded to the currently shipped surface
+- fatal launcher and runtime diagnostics separate from bounded recoverable handling
+- manual reporting and manual issue submission as the current reporting boundary
+
+### Historical State
+
+Normal runtime history resolves under:
+
+- `%LOCALAPPDATA%/Nexus Desktop AI/state/jarvis_history_v1.jsonl`
+
+That historical filename is still part of current runtime truth even though the product framing is Nexus Desktop AI and ORIN.
+
+## Root Logs And Evidence Boundaries
+
+Current approved live launcher surfaces remain under:
+
+- `C:/Jarvis/logs`
+- `C:/Jarvis/logs/crash`
+
+Those roots remain the current runtime truth for:
+
+- launcher-generated runtime logs
+- matching crash logs
+- launcher control or status files when relevant
+
+Launcher-owned historical state is no longer a root-logs surface during normal runtime.
+
+Developer, worker, toolkit, and harness evidence belongs under:
+
+- `C:/Jarvis/dev/logs/<lane>/...`
+
+That separation is part of the current architecture, not just a docs convention.
+
+## Future Boot-Orchestrator Boundary
 
 A future top-level boot orchestrator may sit above the current desktop launcher stack to coordinate:
 
 - Windows boot and login handoff
-- Jarvis startup presentation
-- transition into the desktop phase
-- future phase-to-phase health decisions
+- pre-desktop presentation
+- access or trust framing before desktop delegation
+- post-delegation observation
 
-At the architecture level, that future boot orchestrator is a coordinating layer for pre-desktop experience and cross-phase handoff.
-It is not the source of truth for desktop-stage startup state and does not replace the desktop launcher inside the desktop phase.
+That future layer must remain above the launcher boundary.
 
-Until that higher-level system is explicitly designed, the desktop launcher remains the owner of:
+It may:
 
-- desktop-phase readiness observation
-- desktop-phase stall handling
-- desktop-phase cooperative control
-- desktop-phase recovery routing
-- desktop-phase classification and finalized end-state determination
-- desktop-phase runtime and crash truth generation
+- observe launcher-emitted downstream truth
+- narrate or frame the handoff
+- coordinate the transition around the launcher
 
-A future boot orchestrator may consume the desktop launcher layer only as read-only downstream inputs, such as:
+It must not:
 
-- launcher-owned desktop-phase readiness, failure, recovery, and finalized end-state signals after they are emitted
-- launcher-owned desktop-phase truth surfaces after they are emitted
-- bounded historical or advisory outputs only as descriptive downstream context, never as authority over desktop-stage truth or control
+- override launcher-owned desktop truth
+- reinterpret launcher-owned final state
+- inject cross-layer control back into the launcher
 
-Conceptually, desktop-stage authority begins when boot-stage coordination delegates desktop startup execution to the desktop launcher.
-From that point forward, the boot layer may coordinate around the transition and consume launcher-emitted downstream outputs, but the launcher owns desktop-phase observation, classification, control, recovery routing, and finalized truth generation.
+Desktop-stage authority begins when execution is delegated to the desktop launcher.
 
-A future boot orchestrator must not rewrite, override, or reinterpret launcher-owned desktop truth or desktop control decisions.
+## Current Design Principles
 
-### FB-004 Minimal Future Boot-Orchestrator Stage Model
+The architecture should continue to preserve this order when evolving subsystem behavior:
 
-At planning level, the minimal future boot orchestrator is shaped as four conceptual stages:
+1. observability
+2. classification
+3. control
+4. outcome clarity
+5. behavior
 
-1. boot presence stage
-2. access/trust framing stage
-3. delegation checkpoint
-4. post-delegation observation stage
+And it should continue to preserve this boundary rule:
 
-Those stages mean:
+- launcher is the desktop-phase control authority
+- renderer is the desktop-phase presentation authority
 
-- the boot presence stage owns only pre-desktop startup presence and presentation before launcher delegation
-- the access/trust framing stage owns only pre-desktop framing around access or trust before launcher delegation
-- the delegation checkpoint is the exact point where desktop startup execution is handed to the launcher and boot-stage authority ends
-- the post-delegation observation stage may observe launcher-emitted downstream inputs only under the existing read-only and non-authoritative `FB-015` contract
+## Relationship To Other Canon Layers
 
-This stage model is conceptual lifecycle shape only.
-It does not authorize boot runtime behavior, integration sequencing, higher-layer control, or `FB-004` implementation work.
-
-### FB-015 Rev1a Phase-Boundary Contract
-
-`FB-015 rev1a` clarifies the future boundary between boot-stage coordination and launcher-owned desktop-stage execution.
-
-Boot-stage ownership is limited to:
-
-- pre-desktop startup presence and presentation
-- Windows boot and login handoff coordination
-- the decision to delegate desktop startup execution into the launcher
-- cross-phase observation before desktop-stage authority begins
-
-Desktop-stage ownership begins when boot-stage coordination delegates execution to the desktop launcher.
-From that handoff forward, the launcher remains the sole owner of:
-
-- renderer startup execution and observation
-- readiness, stall, abort, and failure classification
-- desktop-phase cooperative control and recovery routing
-- retry and escalation behavior inside the desktop phase
-- finalized runtime, crash, and diagnostics truth generation for the desktop phase
-
-A future higher boot layer may consume launcher-owned downstream outputs only after they are emitted, including:
-
-- readiness, failure, recovery, and finalized end-state signals
-- runtime logs, crash artifacts, and diagnostics status surfaces
-- bounded historical-memory and advisory outputs only as descriptive downstream context
-
-The canonical allowed downstream input classes are therefore:
-
-- emitted lifecycle and end-state signals
-- emitted desktop-phase truth artifacts
-- bounded historical-memory or advisory summaries after launcher emission
-
-Those downstream inputs remain read-only.
-They may support only:
-
-- boot-stage narration or presentation framing
-- transition-state observation around the handoff into or around the desktop phase
-- later explanatory observation after launcher emission
-
-They must not become authority over launcher-owned desktop truth, classification, control, retry policy, escalation policy, or finalized outcome determination.
-They must not be used as a backchannel for cross-layer control into the launcher.
-
-Historical or advisory surfaces remain especially constrained across the phase boundary:
-
-- they may be consumed only after launcher emission
-- they remain non-authoritative and non-binding
-- they must not be used by a future boot layer to rewrite desktop-stage truth
-- they must not be used to inject cross-layer control back into the launcher
-
-`FB-015 rev1a` is contract clarification only.
-It does not authorize boot runtime behavior, higher-layer recovery control, or `FB-004` implementation work.
-
-## System Roles
-
-### Launcher (`jarvis_desktop_launcher.pyw`)
-
-Responsible for:
-
-- process orchestration
-- startup observation
-- classification (ready / slow / stall / abort / failure)
-- control (cooperative abort)
-- recovery and retry flow
-- runtime and crash logging
-
-### Launcher-Owned Root Log Boundary
-
-Current root-owned live launcher surfaces remain under `C:/Jarvis/logs` only for approved launcher/runtime truth such as:
-
-- launcher-generated `Runtime_*.txt`
-- matching live crash logs under `C:/Jarvis/logs/crash`
-- launcher control/status files when relevant
-
-Launcher-owned historical state no longer lives under the root logs tree during normal runtime.
-It now resolves under `%LOCALAPPDATA%/Nexus Desktop AI/state/jarvis_history_v1.jsonl`, while contained harness runs may still keep historical state under the contained harness log root to preserve isolation.
-This relocation does not change runtime log, crash log, or support-bundle locations.
-
-Dev/test/worker/toolkit evidence does not belong in the live root logs tree.
-That evidence must write under `C:/Jarvis/dev/logs/<lane>/...` and must not introduce new artifact families or new subfolders under `C:/Jarvis/logs` or `C:/Jarvis/logs/crash` without explicit approval.
-
-### Renderer (`jarvis_desktop_main.py`)
-
-Responsible for:
-
-- UI and desktop rendering
-- emitting lifecycle milestones
-- responding to cooperative abort signal
-- clean shutdown behavior
-
-## Lifecycle Model
-
-1. Startup begins
-2. Launcher observes readiness
-3. Renderer signals readiness
-4. Launcher confirms state
-5. System runs
-6. Shutdown or failure occurs
-7. Launcher handles outcome
-
-## Startup Classification
-
-- `STARTUP_READY_OBSERVED` -> healthy
-- `STARTUP_READY_NOT_OBSERVED_WITHIN_WINDOW` -> slow
-- `STARTUP_READY_STALL_CONFIRMED` -> stalled
-- `RENDERER_MAIN|STARTUP_ABORTED` -> renderer acknowledged the cooperative startup-abort request
-- `STARTUP_ABORT_COMPLETE` -> launcher completed abort-specific cleanup and control-flow handoff
-- failure path -> crash or exception
-
-## Control System
-
-- Launcher owns control signals
-- Renderer responds cooperatively
-- No hard kill unless explicitly designed later
-
-## Recovery Model
-
-- Failed startup attempts enter recovery flow
-- Recovery is handled by launcher
-- Renderer remains simple and reactive
-
-## Design Rule
-
-The launcher is the brain.
-The renderer is the body.
-
-## System Layer Model
-
-Jarvis is built as layered control over Windows:
-
-Windows (host platform)
--> Launcher (orchestration and control)
--> Renderer (visual and interaction layer)
--> Future systems (voice, AI, user interaction)
-
-Design rule:
-Higher layers depend on lower layers, but lower layers must remain simple and stable.
-
-The launcher controls behavior.
-The renderer executes behavior.
-
-## Version Context
-
-`v1.6.0` completed the desktop orchestration stabilization track with:
-
-- startup observation and classification (ready / slow / stall)
-- cooperative startup-abort control
-- retry and recovery with threshold-based early escalation for repeated `STARTUP_ABORT` and repeated identical crash outcomes
-- mixed failure-pattern classification
-- attempt-pattern, failure-stability, end-reason, and diagnostics-priority summaries
-- diagnostics parity across live status, runtime logs, and crash reports
-- triage guidance aligned with stability
-- cross-layer consistency across runtime markers, diagnostics output, runtime summaries, and crash summaries
-
-`v1.6.0` is closed and should be treated as a stable orchestration foundation, not an active tuning track.
-
-This staged build order should be preserved in future subsystems when possible:
-
-- observability
-- classification
-- control
-- outcome clarity
-- behavior
-
-## v1.7.0 Direction
-
-`v1.7.0` begins a new layer above the finalized `v1.6.0` orchestration truth:
-
-- controlled intelligence
-- passive cross-run historical awareness first
-- deterministic execution preserved
-- advisory-only outputs at the start
-- no runtime behavior changes yet
-
-The purpose of `v1.7.0` is not to revisit launcher control policy.
-It is to introduce a derived memory layer that can describe history safely without altering the closed `v1.6.0` runtime behavior.
-
-## Historical Memory Layer
-
-The `v1.7.0` historical-memory layer is a passive, derived layer above finalized `v1.6.0` truth.
-
-Its foundation is intended to support:
-
-- cross-run outcome recording
-- recurrence tracking
-- stability trend tracking
-- a multi-run regression concept
-
-Confidence may exist inside this layer, but only as explanatory metadata.
-It must never be treated as authoritative runtime policy.
-
-## Historical Memory Contract (v1.7.0 Phase 1)
-
-The historical memory layer was contract-defined before implementation began and remains governed by that contract.
-
-That contract must define:
-
-- versioned history schema
-- run identity rules
-- failure fingerprint rules
-- provenance labeling
-- retention and reset behavior
-- corruption and fallback behavior
-
-## v1.7.0 Implemented Foundation (rev1-rev6)
-
-Current implemented foundation:
-
-- rev1: recorder-only historical memory groundwork with versioned schema scaffolding and one finalized record per completed run
-- rev2: recorder validation and storage-path hardening with fail-safe fallback
-- rev3: read-only internal summarizer groundwork using recorded failure fingerprints and simple stability characterization
-- rev4: diagnostics-only historical context on failed runs using prior finalized failure history
-- rev5: diagnostics-only historical advisory hints on failed runs, clearly labeled historical and non-authoritative
-- rev6: source-of-truth stabilization and doc/backlog sync for the implemented memory and advisory layer
-
-Current guarantees:
-
-- historical memory remains derived from finalized `v1.6.0` truth surfaces
-- the launcher remains the source of truth for current-run state
-- history remains non-authoritative and does not read back into runtime behavior
-- diagnostics-facing historical context and advisory output remain failed-run-only
-- advisory output remains non-binding
-- historical context and advisory output remain diagnostics-facing surfaces and do not replace current-run incident-summary or crash-report truth
-- if history is missing, unreadable, corrupt, or hostile, behavior degrades cleanly to finalized `v1.6.0` orchestration behavior
-
-## Recorder / Summarizer / Advisor Separation
-
-`v1.7.0` separates historical intelligence into three roles:
-
-### Recorder
-
-Responsible for:
-
-- writing versioned per-run history
-- storing only derived facts from finalized `v1.6.0` truth surfaces
-- preserving deterministic, auditable history inputs
-
-### Summarizer
-
-Responsible for:
-
-- recurrence interpretation
-- stability trend summaries
-- historical comparisons across runs
-- provenance labeling for derived statements
-
-### Advisor
-
-Responsible for:
-
-- presenting non-binding advisory output
-- surfacing historical context to diagnostics or operators
-- remaining advisory-only until a later explicitly approved control phase
-
-Current implemented scope through rev5:
-
-- diagnostics-only historical advisory hints
-- failed runs only
-- no runtime-control influence
-
-## v1.7.0 Closeout State
-
-`v1.7.0` is the completed historical-memory and diagnostics-advisory foundation above the closed `v1.6.0` orchestration layer.
-
-It should be treated as:
-
-- a completed passive recorder, summarizer, diagnostics-context, and diagnostics-advisory track
-- a non-authoritative and non-binding intelligence layer
-- a stopping point before any future confidence scoring, broader advisory expansion, or behavior-coupled intelligence work
-
-## v1.8.0 Direction
-
-`v1.8.0` should be treated as a trust-and-validation phase for cross-run historical intelligence.
-
-Its job is not to make Jarvis more behaviorally aggressive or more authoritative.
-Its job is to make the existing historical layer more trustworthy, repeatable, and future-safe before any broader intelligence work is considered.
-
-Official objective:
-
-- validation-first multi-run historical-intelligence infrastructure
-- stronger replay and verification across launches
-- clearer recurrence and provenance semantics built on existing `v1.7.0` boundaries
-- no runtime-control coupling
-- no authority expansion
-
-## v1.8.0 Safest First Revision
-
-The safest first revision for `v1.8.0` is:
-
-- `FB-014` multi-run orchestration regression harness
-
-That first revision should remain:
-
-- tooling and verification focused
-- cross-run and replay oriented
-- isolated from launcher runtime-control behavior
-- sufficient to validate recorder, summarizer, diagnostics-context, and diagnostics-advisory behavior across repeated launches
-
-Explicit non-goals for `v1.8.0` rev1:
-
-- confidence scoring
-- advisory authority expansion
-- historical readback into runtime behavior
-- retry, escalation, threshold, or classification changes
-- boot-level orchestration work
-
-## v1.8.0 Implemented Rev1 Foundation
-
-`FB-014` rev1 is now implemented as the validation-first harness foundation for `v1.8.0`.
-
-Current implemented rev1 foundation:
-
-- rev1a: dormant contained-execution seams in the launcher for isolated log-root control, target-script override, and optional diagnostics or voice no-op seams
-- rev1b: first reusable contained harness runner covering healthy runs, failed runs with no prior history, and failed runs with matching prior failure history
-- rev1c: harness scenario expansion covering varied prior failure history, success-only prior history, malformed history input, and hostile or unreadable history storage fallback
-
-Current guarantees remain unchanged:
-
-- harness execution remains external validation tooling rather than runtime-control behavior
-- launcher and runtime behavior remain unchanged in production mode when seams are unset
-- historical context remains non-authoritative
-- advisory output remains non-binding
-
-## v1.8.0 Implemented Rev2a Strict Fingerprint Contract
-
-`FB-012` rev2a is now implemented as the first strict failure-fingerprint contract slice for `v1.8.0`.
-
-Implemented rev2a state:
-
-- fingerprints apply only to finalized failure records
-- success records keep empty `failure_fingerprint` values
-- failure records require non-empty normalized `failure_fingerprint` values
-- initial recurrence grouping uses strict equality on the normalized full fingerprint
-- success records and empty fingerprints are excluded from recurrence grouping
-
-Current guarantees remain unchanged:
-
-- no fuzzy matching
-- no confidence or provenance semantics
-- no reinterpretation of recurrence as runtime policy significance
-- no coupling of historical recurrence to runtime-control behavior
-
-## v1.8.0 Implemented Rev2b Deterministic Stability Model
-
-`FB-012` rev2b is now implemented as the deterministic recent-history stability-model slice for `v1.8.0`.
-
-Implemented rev2b state:
-
-- stability is computed only from recurrence-eligible finalized failure records
-- the recent-history window is explicitly the most recent `5` eligible finalized failure records
-- `stable` means a recent window containing `0` or `1` unique normalized full fingerprints
-- `varied` means a recent window containing more than `1` unique normalized full fingerprints
-- success records, empty fingerprints, malformed lines, contract-invalid records, and hostile or unreadable history cases are excluded from stability calculations
-
-Current guarantees remain unchanged:
-
-- no fuzzy matching
-- no confidence or provenance semantics
-- no advisory redesign
-- no reinterpretation of stability as runtime policy significance
-- no coupling of historical stability to runtime-control behavior
-
-Taken together, `FB-012` rev2a and rev2b complete the failure fingerprint and recurrence model track for `v1.8.0` without changing runtime policy.
-
-## v1.8.0 Implemented Rev3a Provenance-First Advisory Semantics
-
-`FB-013` rev3a is now implemented as the provenance-first advisory semantics slice for `v1.8.0`.
-
-Implemented rev3a state:
-
-- diagnostics-facing output now explicitly distinguishes current-run truth, prior finalized historical context, and advisory inference
-- advisory inference remains non-binding and non-authoritative
-- confidence remains absent from surfaced operator-facing output in this first slice
-- crash-report and incident-summary truth surfaces remain free of historical or advisory provenance language
-
-Current guarantees remain unchanged:
-
-- no surfaced confidence scoring
-- no interpretation of confidence as severity, urgency, escalation level, recommendation strength, or runtime-policy permission
-- no coupling of advisory semantics to runtime-control behavior
-- no authority expansion beyond the existing diagnostics-only advisory boundary
-
-## v1.8.0 Implemented Rev3b Internal Confidence Semantics
-
-`FB-013` rev3b is now implemented as the definition-only and internal confidence-semantics slice for `v1.8.0`.
-
-Implemented rev3b state:
-
-- confidence is defined only as evidence-directness or evidence-quality for advisory inference
-- confidence remains absent from surfaced operator-facing output
-- internal confidence handling stays aligned only with the existing exact-recurrence and varied-history advisory evidence lanes
-
-Current guarantees remain unchanged:
-
-- no surfaced confidence scoring
-- no interpretation of confidence as severity, urgency, escalation level, recommendation strength, predictive correctness, runtime-policy permission, or authority over current-run truth
-- no coupling of confidence semantics to runtime-control behavior
-- no authority expansion beyond the existing diagnostics-only advisory boundary
-- no confidence, historical, or advisory language added to crash-report or incident-summary truth surfaces
-
-Taken together, `FB-013` rev3a and rev3b complete the advisory provenance and confidence semantics track for `v1.8.0` without introducing surfaced confidence output or runtime-policy meaning.
-
-## Read-Only Memory Rule
-
-Historical memory in `v1.7.0` must remain a derived, read-only layer over `v1.6.0` truth.
-
-That means:
-
-- current-run runtime markers remain the primary truth
-- current-run classification remains owned by the launcher
-- historical memory may summarize, compare, and advise
-- historical memory may not rewrite, override, or reinterpret current-run control state
-- if historical data is missing, unreadable, or corrupt, the system must fall back cleanly to `v1.6.0` behavior
-
-## Boot-Orchestration Preparation Boundary
-
-`v1.7.0` may prepare for later boot-level orchestration only at the modeling layer.
-
-This preparation boundary is modeling and contract work only.
-It may clarify ownership, dependency, and read-only consumption rules, but it must not introduce boot-stage behavior, cross-layer control, or launcher-policy changes.
-
-Allowed:
-
-- define desktop-stage history shapes that a future boot orchestrator could consume
-- define boot and desktop phase-boundary concepts
-- document how future higher layers may depend on launcher truth
-- define which launcher-owned desktop-stage outputs may be consumed on a read-only downstream basis
-- define which desktop-stage responsibilities remain exclusively launcher-owned
-- define the future boot orchestrator's coordination envelope before desktop-stage authority begins
-- define the conceptual handoff from boot-stage coordination into launcher-owned desktop-stage execution
-
-Not allowed yet:
-
-- boot-level runtime control
-- adaptive retry or escalation
-- instability-driven behavior
-- hard-kill behavior
-- cross-layer authority over launcher-owned desktop truth or control
-- replacement of launcher-owned desktop-stage execution with boot-layer control
-
-## Support-Bundle Reporting Boundary
-
-The first coherent `FB-017` deliverable is now implemented as a privacy-safe manual reporting flow in the existing diagnostics window.
-
-The implemented `Report Issue` flow packages a minimal local support bundle and opens a prefilled GitHub issue page or draft for manual user submission.
-
-This boundary is reporting and packaging work only.
-It may package already-produced runtime and crash artifacts plus a small manifest, but it must not introduce upload behavior, silent collection expansion, or diagnostics-policy changes.
-
-Implemented first-deliverable state:
-
-- the relevant runtime log for the reported run
-- the matching crash log if present and trustworthily determinable by exact runtime-to-crash reference match
-- a small manifest containing Jarvis version, run or timestamp identity, and a basic environment summary
-- bundled file list recorded in the manifest
-- local bundle generation only
-- manual user review before sharing
-- a prefilled GitHub issue page or draft opened for manual completion
-- manual user attachment and manual user submission
-
-Current guarantees remain unchanged:
-
-- historical-memory files
-- harness artifacts
-- internal-only debug extras
-- silent or background upload behavior
-- fully automatic GitHub submission
-- launcher or runtime behavior changes
-- retry, escalation, threshold, classification, diagnostics-trigger, summary, or triage-guidance changes
-- diagnostics redesign
-- reinterpretation of diagnostics-facing historical or advisory surfaces as report-bundle authority
-
-The support bundle should remain simple by default.
-Advanced or internal artifacts may be considered only in a later explicitly approved slice.
-
-## Failure-Class / Diagnostics-Surface Contract
-
-This contract defines how current and future Nexus failures should be classified for user-visible handling without silently widening current launcher policy.
-
-The classification rule is:
-
-- classify by survivability and ownership first
-- do not classify only by which subsystem raised the problem
-- do not treat every recoverable issue as a diagnostics popup
-
-Current repo truth supports four meaningful classes:
-
-### Class 1: Expected Non-Success Or Guidance State
-
-Examples may include:
-
-- `not_found`
-- ambiguous choice
-- explicit confirm step
-
-These are not incident surfaces.
-They should remain inline, local, and lightweight.
-
-### Class 2: Contained Recoverable Action Failure
-
-This means a user-visible action failed, but Nexus remains operational and the failure stays contained to the active interaction surface.
-
-Current example:
-
-- NCP `launch_failed` inside the command overlay
-
-Current default behavior for this class should be:
-
-- contained user-visible result inside the active surface
-- clean retry and reset posture
-- relevant runtime trace for the failed action
-- no automatic diagnostics-window escalation
-- no corrupted/error voice behavior
-
-This class may later gain a bounded report affordance if explicitly approved, but that is not implied by this contract.
-
-### Class 3: Recoverable Operational Incident While Nexus Remains Alive
-
-This means something meaningful went against normal expected Nexus behavior, but the persona and runtime remain operational enough to continue guiding the user.
-
-This class is not yet a broadly implemented current behavior.
-
-Current repo truth now includes one bounded desktop example: repeated identical `launch_failed` for the same action in a still-running session may prepare a local support bundle and issue draft once while keeping the local/manual reporting boundary intact.
-
-When later approved for a specific subsystem, this class may use:
-
-- a recoverable diagnostics or reporting surface
-- normal ORIN voice and trace semantics
-- relevant local evidence for user review
-- the existing manual reporting boundary when reporting is exposed
-
-This class must not be treated as permission to send every recoverable issue directly into diagnostics.
-It should be used only for bounded high-signal incidents that merit operator review while the system remains alive.
-
-### Class 4: Fatal Launcher / Runtime / Persona Failure
-
-This means Nexus can no longer be treated as normally operational for the current run.
-
-Current examples include:
-
-- launcher-owned instability exhaustion
-- repeated startup-abort exhaustion
-- repeated identical crash exhaustion
-- equivalent renderer or launcher failure states that reuse the current diagnostics completion path
-
-Current default behavior for this class should remain:
-
-- launcher-owned diagnostics completion path
-- diagnostics UI
-- launcher/runtime truth surfaces
-- corrupted/error voice behavior where currently defined
-
-### Surface Mapping
-
-The current recommended surface mapping is:
-
-- Class 1 -> inline or contained guidance only
-- Class 2 -> inline or contained recoverable failure only
-- Class 3 -> recoverable diagnostics or reporting surface for an explicitly approved bounded incident class
-- Class 4 -> existing launcher-owned diagnostics completion path
-
-This contract does not by itself authorize new diagnostics triggers or UI surfaces.
-It defines the intended shape for future bounded work.
-
-### Voice / Persona Mapping
-
-The current recommended voice split is:
-
-- Class 1 -> usually no voice
-- Class 2 -> no corrupted/error voice; future normal ORIN guidance remains optional and approval-gated
-- Class 3 -> normal ORIN voice and trace semantics when voice is present
-- Class 4 -> corrupted/error voice semantics for launcher-owned fatal or instability completion paths
-
-This preserves the difference between:
-
-- recoverable incidents where Nexus is still functioning
-- failures where the persona/runtime is no longer functioning normally
-
-### Evidence / Reporting Boundary By Failure Class
-
-All classes may write relevant runtime evidence within their owned surfaces.
-
-The current reporting boundary remains:
-
-- local support-bundle generation only
-- local bundle folder open
-- prefilled GitHub issue draft open when available
-- manual user review before sharing
-- manual user attachment and submission
-- no silent or background upload behavior
-
-Current reporting expectations by class are:
-
-- Class 1 -> no diagnostics reporting surface required
-- Class 2 -> trace evidence only by default
-- Class 3 -> may expose a recoverable diagnostics or reporting surface in a later bounded slice
-- Class 4 -> existing diagnostics-window reporting flow
-
-This contract must not be used to smuggle automatic upload, silent collection expansion, or launcher-policy changes into future work.
-
-### Extensibility Rule
-
-Future subsystem additions should map into the existing classes above before proposing a new failure class.
-
-That means future work should:
-
-- prefer survivability and ownership as the classification rule
-- reuse the existing manual-reporting boundary unless a later explicit reporting-policy revision changes it
-- leave room for future recoverable incident classes that do not exist yet
-- allow later re-analysis as new subsystems, voice behaviors, and packaged product layers are added
-
-Only add a new class later if a future subsystem truly cannot fit the four-class model cleanly.
-
-This contract is intentionally conservative.
-It preserves room for later refinement without overfitting current implementation details.
+- use `Docs/orin_vision.md` for product intent and release-stage meaning
+- use `Docs/orchestration.md` for orchestration-specific philosophy and current behavior boundaries
+- use `Docs/boot_access_design.md` for future boot and access planning
+- use `Docs/workstreams/...` for workstream execution and closure history
+- use `Docs/prebeta_roadmap.md` for sequencing
+- use `Docs/feature_backlog.md` for registry identity

--- a/Docs/boot_access_design.md
+++ b/Docs/boot_access_design.md
@@ -1,1129 +1,165 @@
-# Jarvis Boot Access Design
+# Nexus Boot Access Design
 
 ## Purpose
 
-This document is the canonical planning baseline for Jarvis boot-entry, login, trust, recovery, and resident post-login trust-state behavior on a consumer Windows machine.
+This document is the canonical planning reference for future boot-entry, trust, recovery, and post-login presence design in Nexus Desktop AI.
 
-It consolidates the stable planning decisions previously split across smaller boot-planning slice documents.
+It does not authorize implementation work by itself.
+It also does not own:
 
-This is still a planning artifact.
-It does not define implementation details for backend logic, auth storage, biometrics, tray mechanics, shell integration, renderer wiring, diagnostics presentation, or boot runtime control.
+- backlog identity
+- roadmap sequencing
+- workstream execution history
 
-## Consolidation Status
+Use it for future boot-access planning boundaries only.
 
-This document supersedes and replaces the earlier slice-by-slice boot planning stack as the primary boot-planning source.
+## Current Reality
 
-The earlier boot slice docs have been retired from the active docs tree.
-This document is now the current canonical source for boot access design.
+The current merged runtime path is:
 
-## Relationship To Core Source-Of-Truth Docs
+`launch_orin_desktop.vbs`
+-> `desktop/orin_desktop_launcher.pyw`
+-> `desktop/orin_desktop_main.py`
 
-This document is downstream of:
+This is the current controlled desktop-launch path.
+It is not yet a boot-first Nexus experience.
 
-- `architecture.md` for boot/desktop authority boundaries
-- `orin_vision.md` for long-term product identity
-- `feature_backlog.md` for workstream status and scope control
-- `orchestration.md` for launcher-owned desktop-phase control limits
+## Planning Boundary
 
-This document does not replace those files.
-It narrows only the product and planning shape of the future Jarvis boot-access experience.
+The future boot layer, if implemented later, sits above the current desktop launcher stack.
 
-## Current Startup Reality
-
-The current stabilized startup path is:
-
-`launch_jarvis_desktop.vbs`
--> `jarvis_desktop_launcher.pyw`
--> `jarvis_desktop_main.py`
-
-This is the current controlled desktop-launch path, not the final Jarvis-first experience.
-
-The path-sensitive surfaces that matter most at planning level are:
-
-- `main.py`
-- `launch_jarvis_desktop.vbs`
-- `desktop/jarvis_desktop_launcher.pyw`
-- `jarvis_desktop_main.py`
-
-## Future Boot-Layer Shape
-
-The smallest future boot layer sits above the current launcher stack.
-
-Its conceptual job is to coordinate:
-
-- boot-entry presentation
-- pre-desktop trust flow
-- delegation into launcher-owned desktop execution
-- later observation of downstream launcher outputs after emission
-
-It is not allowed to replace launcher-owned desktop authority.
-
-Desktop-stage ownership begins when boot-stage coordination delegates execution to the launcher.
-From that point forward, launcher-owned desktop truth, classification, control, retry, recovery routing, and finalized end-state determination remain launcher-owned and read-only to higher layers.
-
-The canonical allowed downstream input classes available to a future boot/access layer after launcher emission are:
-
-- emitted lifecycle and end-state signals
-- emitted desktop-phase truth artifacts
-- bounded historical-memory or advisory summaries after launcher emission
-
-Those classes remain read-only and non-authoritative.
-They may support only:
-
-- Jarvis presentation or narration framing around the handoff
-- transition-state observation around desktop entry
-- later explanatory observation after launcher emission
-
-They must not rewrite, reinterpret, suppress, or override launcher-owned desktop truth or control decisions.
-They must not become a cross-layer command path back into the launcher.
-
-At planning level, the minimal future boot orchestrator is shaped as four conceptual stages:
-
-1. boot presence stage
-2. access/trust framing stage
-3. delegation checkpoint
-4. post-delegation observation stage
-
-Within this boot-access planning surface, those stages mean:
-
-- the boot presence stage owns only pre-desktop Jarvis startup presence and presentation
-- the access/trust framing stage owns only pre-desktop access or trust framing before launcher delegation
-- the delegation checkpoint is the point where desktop startup execution is handed into the launcher and boot-stage authority ends
-- the post-delegation observation stage may observe only launcher-emitted downstream inputs under the existing read-only and non-authoritative boundary contract
-
-This stage model remains conceptual only.
-It does not define boot runtime behavior, implementation sequencing, higher-layer control, or concrete shell/login integration.
-
-## Product Intent
-
-Jarvis should feel like the primary visible system presence on a consumer Windows machine.
-
-The intended user impression is:
-
-- the machine feels like it is entering Jarvis, not launching a normal app
-- Windows remains the host platform, but not the dominant visible identity during entry
-- Jarvis remains coherent before login, during trust confirmation, and after desktop entry
-- access feels cinematic, intelligent, and low-friction rather than theatrical or bureaucratic
-
-## Governing Framing
-
-The core framing for this boot-access design is:
-
-- Jarvis owns presentation
-- real authentication owns trust
-- the user should experience both as one continuous Jarvis-controlled flow
-
-This means:
-
-- the trust action must be explicit and meaningful
-- the trust action must remain inside Jarvis presentation
-- conversation and presence may frame access, but must not replace real trust
-- typed and voice interaction belong to one shared access flow, not two separate products
-
-## Core Design Principles
-
-- cinematic but fast
-- immersive but dependable
-- voice is presence, typing is certainty
-- one shared auth flow, not two systems
-- real authentication without breaking the Jarvis atmosphere
-- Windows-safe fallback must always exist
-- recovery should feel guided and supportive, not punitive
-- Jarvis must never trap the user outside Windows
-- consumer Windows first, not enterprise
-
-## Consumer Windows Assumptions
-
-This design is for ordinary personal Windows use, not domain-managed or business deployment.
-
-It must remain workable for:
-
-- users who prefer typing
-- users who prefer voice
-- noisy or private environments
-- inconsistent consumer hardware
-- users who may forget Jarvis credentials
-- users who may need fallback access to Windows
-- users who expect speed and clarity during daily use
-
-## Entry And Handoff Model
-
-At planning level, the future boot-access sequence is:
-
-1. Jarvis boot presence appears above the current launcher stack
-2. Jarvis frames identity and access inside its own presentation
-3. the user completes a real trust step
-4. Jarvis delegates into launcher-owned desktop execution
-5. Jarvis later continues as a resident post-login presence
-
-The minimal pre-delegation boot layer is for:
+That future layer may eventually own:
 
 - pre-desktop presence
-- trust and recovery framing
-- Windows handoff coordination
-- delegation into desktop-stage launcher execution
+- access or trust framing before desktop delegation
+- user-facing boot experience
+- post-login resident continuity as part of a coherent product surface
 
-It is not for:
+It does not currently authorize:
 
-- desktop-stage retry or escalation control
-- desktop-stage diagnostics authority
-- launcher-policy replacement
-
-## Experience Layer Versus Trust Layer
-
-Jarvis boot access must clearly separate:
-
-- experience-layer interaction
-- trust-layer authentication
-
-### Experience Layer
-
-The experience layer includes:
-
-- visual presence
-- greeting
-- conversational framing
-- optional voice timing
-- transitions
-- identity continuity
-
-### Trust Layer
-
-The trust layer includes:
-
-- the explicit access decision
-- the deliberate trust action that grants access
-- the distinction between normal access and degraded or recovery-oriented trust states
-
-The experience layer may frame the trust layer.
-It must not replace it.
-
-## Dual-Modality Contract
-
-Jarvis access must support typed and voice interaction inside one shared flow.
-
-### Typed Input
-
-Typed input is the certainty path.
-It must always remain sufficient for:
-
-- the routine trust step
-- the stronger trust step
-- fallback selection
-- recovery entry
-- recovery completion
-- resident post-login trust and recovery access
-
-### Voice Input
-
-Voice may support:
-
-- presence
-- greeting
-- explanatory framing
-- optional guidance
-- emotional tone
-
-Voice must never be required for:
-
-- trust completion
-- fallback use
-- recovery completion
-- resident trust-state access
-
-### Shared Flow Rule
-
-Typed and voice interaction must feed the same conceptual flow:
-
-- same identity state
-- same trust state
-- same recovery posture
-- same session transition
-
-The user should never feel like there is a separate typed-login product and voice-login product.
-
-## Real Authentication Contract
-
-Jarvis access must include a real, explicit trust action.
-
-That trust action must be:
-
-- deliberate
-- understandable
-- meaningful
-- low-friction for daily use
-- visually integrated into Jarvis presentation
-
-The trust step should feel like:
-
-- Jarvis is granting access after a real check
-
-It should not feel like:
-
-- a vague conversational performance
-- fake recognition theater
-- a generic detached Windows interruption
-
-## Primary Trust Family
-
-At planning level, the safest first trust family is:
-
-- explicit local knowledge-based secret entry
-
-This planning baseline does not choose exact storage or backend mechanics.
-It only defines the acceptable trust family shape.
-
-## Auth-Factor Shape
-
-At planning level, the trust family narrows into two conceptual factor shapes:
-
-- a short-form deliberate secret entry for routine daily access
-- a longer-form deliberate secret entry for stronger or recovery-oriented trust states
-
-This keeps the normal daily path fast while preserving a distinct elevated path when trust continuity is different from routine access.
-
-## Windows Hello Additive Path Contract
-
-At planning level, Windows Hello may be considered only as a future optional additive shortcut for the routine daily path.
-It does not replace the current local knowledge-based secret family as the canonical Jarvis trust baseline.
-
-Conceptually, this means:
-
-- the short-form deliberate secret entry remains the baseline routine-path trust factor
-- Windows Hello may later act as a faster routine-path unlock on a compatible Windows device for a user who has already established the Jarvis local-secret baseline
-- the longer-form deliberate secret entry remains the stronger or recovery-oriented path unless a later explicitly approved planning pass changes that
-
-Windows Hello should be understood here as:
-
-- a device-local convenience and hardening layer for routine access
-- subordinate to the current Jarvis trust-family baseline
-- additive rather than replacement-oriented
-
-Windows Hello should not be treated here as:
-
-- the new primary Jarvis identity model
-- the new stronger or recovery-oriented factor by default
-- a reason to remove typed sufficiency
-- a reason to redefine Jarvis trust continuity around Windows-owned device state
-
-## Windows Hello Role Inside The Routine Path
-
-At planning level, if Windows Hello is later introduced, it should fit the routine path as a shortcut that preserves the existing routine-path character:
-
-- quick
-- calm
-- intentional
-- low-friction
-
-That means:
-
-- typed secret entry must remain sufficient even when Windows Hello is available
-- Windows Hello may make ordinary daily access faster on a compatible device, but it must not become mandatory
-- if Windows Hello is unavailable, unset, declined, or fails, the routine typed path remains the ordinary fallback rather than a special recovery event
-- the stronger or recovery-oriented path should not silently collapse into Windows Hello just because the device supports it
-
-This keeps the routine path aligned with the current Jarvis contract:
-
-- Jarvis still presents the trust moment
-- the trust step remains real and understandable
-- routine access does not become a separate Windows-owned login product
-
-## Windows Hello Boundary And Deferral Contract
-
-This planning clarification does not authorize:
-
+- boot runtime behavior
 - auth backend design
-- credential storage design
-- biometric implementation details
-- device-trust implementation details
-- passkey-account or relying-party design
-- shell, tray, renderer, diagnostics, or boot-runtime mechanics
+- tray or shell implementation
+- credential storage mechanics
+- OS integration mechanics
 
-This planning clarification only defines the role Windows Hello could later play:
+## Experience Goal
 
-- optional
-- routine-path only by default
-- subordinate to the local-secret baseline
-- non-replacing unless a later planning pass explicitly reopens that decision
+The long-term access experience should feel like:
 
-## Routine Daily Path
+- the machine is entering Nexus Desktop AI rather than launching a normal app
+- ORIN is the assistant presence the user is meeting
+- trust and recovery are framed inside that experience rather than tacked on around it
+- Windows remains reachable as the host platform rather than being replaced as a rescue path
 
-The routine path is the default consumer-Windows access path.
+## Delegation Boundary
 
-It should conceptually fit into three short beats:
+The future boot layer must stop owning execution once it delegates into the desktop launcher.
 
-1. concise Jarvis presence
-2. explicit routine trust action
-3. immediate confirmation and transition
+After delegation:
 
-The routine path should feel:
+- launcher owns desktop startup execution
+- launcher owns desktop failure and recovery truth
+- higher layers may observe launcher-emitted truth only after emission
+
+This preserves the current architecture instead of creating a second control authority.
+
+## Access Model
+
+The planning model should preserve two distinct conceptual paths:
+
+- routine access
+- stronger or recovery-oriented access
+
+Routine access should feel:
 
 - quick
 - calm
 - intentional
 - low-friction
 
-It should avoid:
+Stronger access should feel:
 
-- extended conversation before trust
-- repeated trust checkpoints
-- recovery-style seriousness during normal login
-- decorative ceremony that slows routine access
-
-Acceptable routine friction is limited to:
-
-- recognizing the prompt
-- entering one routine factor
-- receiving immediate confirmation and transition
-
-If normal daily use starts to feel like a ritual, the routine path has become too heavy.
-
-## Routine-To-Stronger Trust Boundary
-
-At planning level, Jarvis should stop treating access as routine when doing so would incorrectly frame the current trust posture as ordinary daily continuity.
-
-Routine access remains sufficient when:
-
-- the user is completing ordinary daily entry and Jarvis trust continuity is still normal enough to be treated as routine
-- the trust moment is still just one ordinary daily confirmation rather than trust restoration or recovery-oriented confirmation
-- a future optional routine-path shortcut such as Windows Hello is unavailable, unset, declined, or fails, but the ordinary typed routine path still applies
-
-The stronger path becomes justified when:
-
-- Jarvis should no longer pretend the current trust posture is ordinary daily continuity
-- the trust moment now carries restoration, recovery-oriented confirmation, or clearly non-routine confirmation meaning
-- trust continuity is meaningfully different from normal daily entry even before any future additive stronger-path hardening factor is considered
-
-This boundary clarification does not mean:
-
-- the stronger path becomes the new default daily path
-- routine access should be escalated just because optional routine-path convenience is unavailable
-- the stronger path is defined by future TOTP mechanics rather than by the underlying non-routine trust posture
-
-## Stronger Path
-
-The stronger path is not for routine daily use.
-
-Its conceptual purpose is:
-
-- trust restoration
-- recovery-oriented confirmation
-- elevated confidence when normal trust continuity is meaningfully different from ordinary daily entry
-
-The stronger path is justified when trust continuity is degraded, such as:
-
-- post-bypass return into Jarvis trust restoration
-- recovery-oriented access states
-- other non-routine trust states where the system should not pretend everything is ordinary
-
-The stronger path should feel:
-
-- more deliberate than routine access
+- more deliberate
 - clearly non-routine
-- recovery-aware
-- still finite
-- still Jarvis-framed
-
-It should not feel:
-
-- punitive
-- hostile
-- corporate
-- like the new default login path
-
-## TOTP Additive Stronger-Path Contract
-
-At planning level, TOTP or authenticator-app factors may be considered only as a future optional additive hardening layer for stronger or recovery-oriented trust states.
-They do not replace the current longer-form deliberate secret entry as the canonical Jarvis stronger-path baseline.
-
-Conceptually, this means:
-
-- the longer-form deliberate secret entry remains the baseline stronger or recovery-oriented trust factor
-- TOTP may later act as an additional stronger-path confirmation factor when a later explicitly approved planning pass chooses to harden that lane
-- the routine path does not become a TOTP-driven path by default
-
-TOTP should be understood here as:
-
-- a possible additive hardening factor for non-routine trust states
-- separate from the Windows Hello routine-path shortcut
-- supportive of stronger-path confidence, not a replacement for the current local-secret family
-
-TOTP should not be treated here as:
-
-- the new default daily login path
-- a replacement for typed sufficiency
-- a reason to collapse the stronger path into phone-dependent access by default
-- a reason to redefine Jarvis trust continuity around external app possession alone
-
-## TOTP Role Inside Stronger And Recovery Paths
-
-At planning level, if TOTP is later introduced, it should fit only where the existing design already justifies a more deliberate trust posture:
-
-- trust restoration
-- recovery-oriented confirmation
-- other non-routine states where the system should not pretend everything is ordinary
-
-That means:
-
-- typed secret entry must remain sufficient as part of the stronger-path baseline unless a later planning pass explicitly changes that contract
-- TOTP may later add hardening to stronger or recovery-oriented entry, but it must not silently become the routine path
-- failure or absence of TOTP must not cause the routine path and the stronger path to collapse into one confused flow
-- stronger-path hardening must remain conceptually separate from Windows Hello routine convenience
-
-This keeps the stronger path aligned with the current Jarvis contract:
-
-- more deliberate than routine access
 - recovery-aware when needed
-- still finite
-- still Jarvis-framed
+- still finite and understandable
 
-## TOTP Absence As Degraded Stronger-Path Condition
+The stronger path must not silently become the default daily path.
 
-At planning level, if TOTP is later introduced and the user cannot use the current authenticator device or code path, Jarvis should treat that by default as a narrower degraded stronger-path condition rather than as ordinary routine access or a full separate recovery state.
+## Typed Sufficiency Rule
 
-Conceptually, this means:
-
-- the longer-form deliberate secret entry remains usable as the baseline stronger-path factor
-- the stronger path remains clearly non-routine and deliberate even when the additive hardening factor is unavailable
-- TOTP absence narrows the hardening posture of the stronger path, but does not automatically mean Jarvis trust continuity was bypassed
-- the routine path does not become an acceptable substitute just because the additive stronger-path factor is currently unavailable
-
-This degraded stronger-path condition should be understood here as:
-
-- less hardened than a future stronger path where the additive TOTP factor is available
-- still stronger than routine access
-- narrower than the broader post-bypass trust-restoration state
-- still inside the stronger-path family rather than a separate recovery lane by default
-
-This degraded stronger-path condition should not be treated here as:
-
-- proof that the user bypassed Jarvis trust completion
-- a reason to immediately route the user into the broader post-bypass recovery contract by default
-- a reason to make the longer-secret stronger-path baseline unusable
-- a reason to require recovery-code planning in this clarification
-
-## TOTP Absence Versus Full Recovery State
-
-At planning level, TOTP absence differs from the broader recovery contract because the user is still attempting to complete Jarvis trust through an approved stronger-path factor rather than reaching Windows through fallback and later repairing bypassed trust continuity.
+Typed secret entry remains the baseline trust-family rule in planning.
 
 That means:
 
-- degraded stronger-path use remains inside the stronger-path lane
-- full trust-recovery remains reserved for broader trust-continuity breakage such as post-bypass restoration
-- typed sufficiency remains preserved because the longer-form deliberate secret entry is still valid
-- any later companion mechanics for device loss, recovery codes, or alternate fallback remain explicitly deferred until a later planning pass reopens them
+- typed entry must remain sufficient for the routine path
+- future convenience or hardening factors must not silently replace typed sufficiency by default
 
-## TOTP Boundary And Deferral Contract
+## Windows Hello Role
 
-This planning clarification does not authorize:
+If Windows Hello is introduced later, it should fit only as an optional routine-path convenience on compatible devices.
 
-- auth backend design
-- credential or secret storage implementation
-- exact TOTP enrollment or provisioning flow
-- exact fallback, device-loss, or recovery-code mechanics
-- device-trust implementation details
-- shell, tray, renderer, diagnostics, or boot-runtime mechanics
+It should not:
 
-This planning clarification only defines the role TOTP could later play:
+- become mandatory
+- replace typed sufficiency
+- redefine trust continuity around device state alone
 
-- optional
-- stronger-path or recovery-path only by default
-- additive to the current longer-secret baseline
-- non-replacing unless a later planning pass explicitly reopens that decision
+If Windows Hello is unavailable or fails, the ordinary routine typed path should remain valid.
 
-## Fallback And Safety Contract
+## TOTP Role
 
-Jarvis must never become the only rescue path to Windows access.
+If TOTP or authenticator-app factors are introduced later, they should fit only as optional additive hardening for stronger or recovery-oriented trust states.
 
-A Windows-safe fallback path must always exist if:
+They should not:
 
-- Jarvis credentials are forgotten
-- Jarvis trust completion is unavailable
-- Jarvis access continuity is degraded
-- the Jarvis layer is temporarily unable to complete normal access
+- become the default daily path
+- replace the deliberate stronger-path baseline
+- collapse routine and stronger access into one confused flow
 
-Jarvis is the preferred front door.
-It must not be the only emergency exit.
+## Fallback And Recovery Rule
 
-## Post-Bypass Recovery Contract
-
-If the user reaches Windows through fallback instead of normal Jarvis trust completion, Jarvis should later detect that trust continuity was bypassed at a conceptual level.
-
-After desktop entry, Jarvis should surface a guided recovery path that:
-
-- explains that normal Jarvis trust continuity needs restoration
-- provides a clear recovery entry path
-- allows bounded postponement without silently leaving the trust state broken forever
-
-The recovery posture must feel:
-
-- supportive
-- restorative
-- non-accusatory
-
-## Resident Presence After Login
-
-After desktop entry, Jarvis should continue to exist as a visible resident presence inside Windows.
-
-At planning level, that resident layer is:
-
-- the post-login trust and recovery anchor
-- the place where trust continuity remains understandable
-- the home for recovery entry after login
-- the stable presence that carries Jarvis beyond the boot moment
-
-This resident layer is conceptually where future tray and control-center responsibilities belong, but implementation details remain deferred.
-
-## Resident Trust States
-
-At planning level, the resident Jarvis layer should recognize three post-login trust states:
-
-- normal trust state
-- degraded trust state
-- recovery-needed state
-
-### Normal Trust State
-
-Normal trust state means:
-
-- access continuity is healthy
-- no immediate recovery action is needed
-- Jarvis can remain calm and available in the background
-
-Normal state should reassure without demanding attention.
-
-### Degraded Trust State
-
-Degraded trust state means:
-
-- trust continuity is no longer fully normal
-- desktop use may continue
-- recovery entry should be visible and easy to reach
-
-Degraded state should inform without becoming alarmist.
-
-### Recovery-Needed State
-
-Recovery-needed state means:
-
-- trust restoration now needs to be surfaced clearly
-- recovery entry must be obvious
-- the user should not have to hunt through deep settings
-
-Recovery-needed state should guide without punishing.
-
-## Recovery Entry After Login
-
-Recovery entry must remain reachable after desktop entry through the resident Jarvis presence.
-
-At planning level, this means:
-
-- recovery entry must not be boot-only
-- recovery entry must not be voice-only
-- recovery entry must remain discoverable later
-- the user should be able to revisit recovery without re-entering a boot flow
-
-The resident layer should support both:
-
-- proactive surfacing when trust continuity is degraded
-- user-initiated recovery entry later
-
-## Resident Recovery-Entry Trigger And Surfacing Contract
-
-At planning level, resident recovery entry should follow the post-login resident trust states:
-
-- in normal trust state, no proactive recovery surfacing is needed
-- in degraded trust state, recovery entry should be visible, easy to reach, and calmly re-discoverable
-- in recovery-needed state, recovery entry should surface proactively and clearly enough that the user understands restoration is pending
-
-Resident recovery entry is for restoring Jarvis trust continuity after desktop entry.
-It is not a license for:
-
-- launcher-owned runtime classification
-- diagnostics escalation or diagnostics authority
-- boot-time control after desktop handoff
-- backend trust implementation details
-
-## Bounded Deferral And Re-Surface Contract
-
-At planning level, bounded deferral means:
-
-- the user may choose to postpone recovery for now
-- postponement must not silently normalize a degraded or recovery-needed state forever
-- the system should later re-surface recovery entry until trust continuity is restored
-- re-surfacing should remain calmer in degraded state than in recovery-needed state
-
-The user-posture contract is:
-
-- normal desktop use may continue after a bounded deferral
-- the user must not feel trapped or locked out of Windows because recovery was postponed
-- the user must not be forced through repeated recovery prompts during the same immediate interaction once a clear postpone choice has been made
-- later re-surfacing should remind rather than punish
-
-This document intentionally does not define:
-
-- exact timers, cadences, counters, or re-surface schedules
-- exact tray, control-center, resident UI, shell, or notification mechanics
-- exact post-bypass detection logic
-- exact persistence storage or backend state handling
-
-## Resident Trust-State Transition Contract
-
-At planning level, the resident trust-state transitions are:
-
-- normal -> degraded when trust continuity is no longer fully normal but immediate strong recovery surfacing is not yet required
-- degraded -> recovery-needed when recovery should be made proactively obvious rather than merely easy to reach
-- degraded or recovery-needed -> normal only after trust restoration is completed through the future resident recovery path
-
-These are conceptual planning states for the future resident boot-access layer.
-They do not authorize runtime control over launcher-owned desktop behavior or reinterpretation of launcher-owned desktop truth.
-
-## Resident Control-Anchor Responsibility Contract
-
-At planning level, the future resident control-center or settings anchor is the stable post-login place where the user can:
-
-- understand current Jarvis trust posture without re-entering a boot flow
-- see whether the current resident trust state is normal, degraded, or recovery-needed
-- reach recovery entry later through a user-initiated path
-- understand why recovery is being surfaced when trust continuity is no longer fully normal
-- revisit Jarvis trust-continuity posture after login through one stable anchor rather than scattered one-off prompts
-
-This resident control anchor is conceptually responsible for:
-
-- calm post-login trust-state visibility
-- user-initiated recovery entry after login
-- concise explanation of current trust continuity posture
-- being the stable post-login home for recovery posture once the boot flow has already handed off to the desktop phase
-
-This resident control anchor should relate to the resident trust states as follows:
-
-- in normal trust state, it may remain quiet and low-demand while still existing as the stable post-login anchor
-- in degraded trust state, it should make recovery discoverable, legible, and easy to revisit
-- in recovery-needed state, it should make restoration obvious enough that the user does not have to hunt for the next safe step
-- after a bounded deferral, it remains the stable place where recovery can later be resumed without forcing the user back through a boot-only flow
-
-This planning contract does not make the resident control anchor responsible for:
-
-- pre-desktop presence or boot-time trust completion
-- launcher-owned desktop truth, classification, control, retry, recovery routing, or finalized end-state determination
-- diagnostics authority, diagnostics policy, or incident handling
-- auth backend, credential storage, biometrics, device-trust, or shell mechanics
-- exact tray, control-center, resident UI, or notification implementation mechanics
-- broad consumer setup or environment-preference ownership
-
-Consumer setup and environment-preference planning remains a separate future lane.
-This resident control-anchor contract is only about post-login trust continuity, trust-state visibility, and user-initiated recovery access.
-
-## Consumer Setup Purpose And Entry Contract
-
-At planning level, consumer setup is the short post-install or first-run onboarding lane that helps Jarvis establish an initial fit for this person and this machine without turning setup into trust, recovery, or system configuration.
-
-Consumer setup is conceptually responsible for:
-
-- introducing Jarvis as the intended system-facing experience rather than a generic Windows app wizard
-- establishing a usable first everyday posture after install
-- collecting only the smallest set of early user-facing choices needed to avoid an obviously wrong first-run experience
-- reassuring the user that typed interaction remains sufficient and that early setup choices are not irreversible commitments
-- handing the user into ordinary Jarvis use without keeping them inside a prolonged onboarding ritual
-
-Consumer setup should begin only after install and first run have reached the point where Jarvis can present itself coherently as an experience layer.
-It should not be treated as:
-
-- the trust step itself
-- a stronger trust or recovery path
-- a replacement for resident trust-state visibility
-- an excuse to introduce shell, tray, backend, renderer, or diagnostics mechanics
-
-Consumer setup should stay short, legible, and consumer-friendly.
-Its purpose is to establish initial fit and comfort, not to front-load every future choice.
-
-## Minimum Consumer-Setup First Slice
-
-At planning level, the smallest coherent first consumer-setup slice should include only the minimum broad posture choices needed to avoid an obviously wrong first-run experience:
-
-- an initial presence-posture baseline
-- an initial guidance-posture baseline
-- an initial interaction-posture baseline that keeps typing sufficient and voice optional
-
-This first slice may be satisfied by explicit user choice or by accepting a coherent default posture for those same categories.
-
-This first slice should not require:
-
-- deeper pacing or atmosphere refinement
-- detailed per-surface preference tuning
-- non-essential resident presence refinement for later ordinary use
-- any choice that would force the user to understand trust restoration, recovery posture, or later post-login ownership lanes
-
-## Consumer Setup Completion And Handoff Contract
-
-At planning level, consumer setup should count as complete once:
-
-- Jarvis has established a coherent initial posture for ordinary use
-- the user has made only the minimum early choices needed for that posture
-- the minimum first-slice posture bundle has been either explicitly chosen or coherently accepted by default
-- the user understands that later preference adjustment remains possible
-- the system can hand off into normal Jarvis use without continuing to behave like an installer or onboarding wizard
-
-Consumer setup completion should not require:
-
-- exhaustive settings selection
-- environment-preference finalization across every later context
-- auth enrollment, trust restoration, or recovery completion
-- decisions about backend, shell, tray, renderer, diagnostics, or runtime behavior
-
-The handoff after setup should feel like:
-
-- Jarvis is now ready for everyday use
-- the user is no longer inside a special onboarding state
-- future adjustment can happen later without replaying the entire setup lane
-
-At planning level, that first handoff into ordinary use includes:
-
-- the chosen initial posture becoming the active everyday starting posture
-- ordinary Jarvis use beginning without reopening setup as an access gate
-- later refinement remaining available only as a future adjacent lane rather than as part of first-slice completion
-
-## Consumer Setup Relationship To Trust And Recovery Lanes
-
-Consumer setup is separate from the already-defined resident trust and recovery lanes.
+Nexus Desktop AI must never become the only rescue path to Windows access.
 
 That means:
 
-- consumer setup may shape presentation posture, comfort, and early user guidance
-- consumer setup must not determine whether trust continuity is normal, degraded, or recovery-needed
-- consumer setup must not own recovery-entry surfacing, bounded deferral, or resident trust-state transitions
-- consumer setup must not become a hidden access gate or a disguised stronger trust path
+- fallback to Windows must remain conceptually possible
+- if trust continuity is bypassed, the system may later surface a guided recovery path after desktop entry
+- fallback must not erase the distinction between routine access and trust restoration
 
-The resident control anchor remains the post-login home for:
+## Resident Post-Login Presence
 
-- trust-state visibility
-- recovery-entry access
-- explanation of current trust continuity posture
+Later planning may treat Nexus Desktop AI as a resident post-login presence that can:
 
-Consumer setup remains responsible only for:
+- reflect trust continuity state
+- surface recovery entry when needed
+- remain visible as a stable assistant anchor after desktop entry
 
-- initial onboarding fit after install or first run
-- early consumer-facing calibration
-- handing the user into normal use with reversible early choices
+That future resident surface remains planning-only.
 
-Later-adjustment and safe-undo remains a distinct adjacent lane.
-This document intentionally does not define the exact setup sequence, exact preference labels, or exact later settings ownership mechanics.
+It should stay distinct from:
 
-## Environment-Preference Taxonomy Contract
+- setup
+- routine settings
+- one-off recovery prompts
 
-At planning level, environment preferences are the user-facing posture choices that shape how Jarvis feels during setup and ordinary use without changing trust meaning, recovery meaning, or runtime authority.
+## Setup And Preference Posture
 
-The environment-preference categories that belong in this lane are:
+Consumer setup, later adjustment, and environment preferences remain separate future planning lanes.
 
-- presence posture:
-  how calm, expressive, quiet, or pronounced Jarvis should feel as an experience layer
-- guidance posture:
-  how concise or guided Jarvis should be while helping the user understand the early experience
-- interaction posture:
-  how voice participates as optional framing or guidance while typed interaction remains fully sufficient
-- pacing and atmosphere posture:
-  how brief versus atmospheric the early Jarvis experience should feel without turning setup into ceremony
-- everyday resident presence posture:
-  how visible or quiet Jarvis should feel after setup when trust continuity is normal and no recovery-oriented surfacing is active
+This planning layer should preserve:
 
-These categories are about comfort, presentation, and usability posture.
-They are not:
+- future boot enablement as a user-controlled preference
+- guided setup if OS changes are needed
+- later adjustment as different from recovery
+- environment preferences as different from trust or access semantics
 
-- trust categories
-- recovery-state categories
-- backend categories
-- shell or tray categories
-- diagnostics categories
-- runtime-policy categories
+## Relationship To Other Canon Layers
 
-## Environment-Preference Timing Model
-
-At planning level, the most plausible up-front setup choices are the broad posture decisions that help Jarvis avoid an obviously wrong first-run experience:
-
-- an initial presence-posture baseline
-- an initial guidance-posture baseline
-- an initial interaction-posture baseline that keeps typing sufficient and voice optional
-
-At planning level, the most plausible optional setup choices are refinements that may improve comfort but are not required to establish a coherent first everyday posture:
-
-- deeper pacing or atmosphere refinements
-- non-essential resident presence refinements for normal trust state
-- secondary comfort refinements that are helpful but not required for setup completion
-
-At planning level, the choices that should remain deferred until later are those the user can evaluate better only after living with Jarvis for some time:
-
-- detailed per-surface preference tuning
-- exact later everyday adjustments
-- anything that would require the user to understand future shell, tray, renderer, or diagnostics behavior
-- anything that meaningfully overlaps with trust, recovery, or resident control-anchor ownership
-
-This timing model is meant to keep setup short and consumer-friendly.
-It prevents setup from becoming either:
-
-- a full settings migration exercise
-- a disguised access-control sequence
-
-## Environment-Preference Boundary Contract
-
-Environment preferences may shape:
-
-- comfort
-- presentation tone
-- guidance density
-- presence intensity
-- normal-state everyday visibility posture
-
-Environment preferences must not shape:
-
-- whether trust continuity is normal, degraded, or recovery-needed
-- whether recovery-entry surfacing is required
-- how bounded deferral works
-- how the resident control anchor owns trust-state visibility or recovery access
-- launcher-owned desktop truth, diagnostics authority, or any runtime behavior
-
-Later-adjustment and safe-undo remains a separate adjacent lane.
-This document does not define how preference changes are revisited later; it defines only which categories belong here and when they are plausibly chosen.
-
-## Later-Adjustment And Safe-Undo Purpose Contract
-
-At planning level, later adjustment and safe-undo is the ordinary post-setup lane where the user can revisit, soften, or reverse prior consumer-facing setup and environment-preference choices without implying that trust is broken or recovery is required.
-
-This lane is conceptually responsible for:
-
-- allowing the user to make Jarvis calmer, simpler, quieter, or less demanding after living with the initial setup choices
-- reinforcing that setup and environment-preference choices are revisable rather than one-time commitments
-- helping the user recover from overly strong, overly guided, or otherwise poor comfort choices without replaying the meaning of trust failure
-- preserving confidence that the Jarvis experience can be adjusted without destabilizing ordinary use
-
-This lane should feel:
-
-- normal
-- user-directed
-- non-urgent
-- non-punitive
-- like ordinary preference revision rather than a system repair event
-
-## Ordinary Adjustment Versus Trust Recovery Contract
-
-At planning level, ordinary preference adjustment is different in meaning from trust recovery.
-
-Ordinary preference adjustment is about:
-
-- comfort
-- presentation posture
-- guidance density
-- presence intensity
-- how strong or quiet the everyday Jarvis experience should feel
-
-Trust recovery is about:
-
-- degraded or recovery-needed trust continuity
-- restoring the intended trust path after bypass or disruption
-- the resident trust-state and recovery-entry contracts already defined elsewhere in this document
-
-That means:
-
-- wanting Jarvis to feel calmer or simpler must not be treated as recovery-needed state
-- revising a setup choice must not change trust-state meaning by itself
-- undoing a consumer-facing preference must not require trust restoration
-- trust recovery must remain separate from normal post-setup preference revision
-
-## Later-Adjustment Relationship To The Resident Control Anchor
-
-The resident control anchor remains the post-login home for:
-
-- trust-state visibility
-- recovery-entry access
-- explanation of current trust continuity posture
-
-Later adjustment and safe-undo may still be reachable after login, but it is not conceptually the same lane as the resident control anchor.
-
-At planning level, that means:
-
-- later adjustment may coexist with post-login Jarvis presence without being reclassified as trust-state ownership
-- later adjustment must not take over recovery-entry surfacing or bounded-deferral meaning
-- the resident control anchor must not become the owner of broad consumer setup or environment-preference revision just because both are post-login reachable
-
-This document intentionally does not define:
-
-- exact screen or settings-surface layout
-- exact tray, shell, resident UI, or notification mechanics for how later adjustment is reached
-- exact later-adjustment screen flow or safe-undo sequence
-
-## Post-Login Settings Ownership Boundary Contract
-
-At planning level, the post-login settings and control surface remains conceptually split across three adjacent but distinct lanes:
-
-- the resident control anchor
-- later adjustment and safe-undo
-- environment-preference revision
-
-The resident control anchor is allowed to own only:
-
-- current trust-state visibility after login
-- recovery-entry reachability after login
-- concise explanation of current trust-continuity posture
-- calm wayfinding toward ordinary adjustment only when the user issue is comfort or presentation rather than trust restoration
-
-The resident control anchor must not own:
-
-- broad comfort or presentation revision
-- ordinary setup-choice undo
-- environment-preference editing as a primary responsibility
-- reinterpretation of launcher-owned desktop truth or any runtime authority
-
-Later adjustment and safe-undo is allowed to own only:
-
-- revision of prior consumer-facing setup choices after the user has lived with them
-- softening or undoing comfort, guidance, presence, or pacing choices that proved too strong or poorly matched
-- reinforcing that user-facing posture choices remain revisable without implying trust breakage
-- ordinary post-login adjustment paths that feel normal rather than recovery-oriented
-
-Later adjustment and safe-undo must not own:
-
-- trust-state visibility meaning
-- recovery-entry surfacing or bounded-deferral meaning
-- determination of whether the user is in a normal, degraded, or recovery-needed trust state
-- launcher-owned desktop truth, diagnostics authority, or runtime control
-
-Environment-preference revision is allowed to own only:
-
-- the content categories already defined in the environment-preference taxonomy
-- revision of those categories when the user is adjusting how Jarvis feels rather than restoring trust continuity
-- normal-state everyday presence posture as a comfort and presentation concern
-
-Environment-preference revision must not own:
-
-- recovery entry
-- trust-state explanation or trust-state classification
-- post-bypass restoration meaning
-- launcher-owned desktop truth or runtime authority
-
-At planning level, these lanes may conceptually link only as follows:
-
-- the resident control anchor may point the user toward later adjustment when the issue is ordinary comfort or presentation rather than trust restoration
-- later adjustment may expose environment-preference revision as the place where posture choices are actually revised
-- later adjustment may point back to the resident control anchor when the user needs trust-state visibility or recovery entry rather than ordinary adjustment
-- environment-preference revision may remain reachable after login without becoming the owner of trust-state visibility or recovery posture
-
-These conceptual links are allowed to improve clarity and discoverability.
-They must not collapse the three lanes into one mixed settings surface, and they do not authorize any tray, shell, renderer, notification, or implementation mechanics.
-
-## How Jarvis Stays Present Without Becoming Heavy
-
-Jarvis should remain present through:
-
-- the visual frame around the trust step
-- the immediate before and after of access confirmation
-- the continuity of post-login resident presence
-- supportive recovery framing when needed
-
-Jarvis should not stay present by:
-
-- adding extra trust gestures
-- delaying routine access
-- turning voice into a hidden requirement
-- extending the emotional posture of boot-time login through the entire desktop session
-
-## In-Bounds Patterns
-
-The following are in-bounds for the canonical boot-access design:
-
-- a Jarvis-framed pre-desktop layer above the current launcher stack
-- one shared typed-and-voice access flow
-- typed completion for all critical trust and recovery actions
-- voice as optional presence and guidance only
-- a short routine trust path for normal daily use
-- a distinct stronger path for degraded or recovery-oriented trust states
-- Windows-safe fallback
-- guided post-bypass recovery
-- resident post-login trust-state surfacing
-- a future resident control anchor distinct from the boot flow
-
-## Out-Of-Bounds Patterns
-
-The following are out-of-bounds for the current canonical design:
-
-- conversation or voice alone as primary trust
-- mandatory voice for access or recovery
-- hidden or passive primary trust decisions
-- enterprise-style challenge choreography for routine consumer access
-- punitive recovery posture
-- turning the stronger path into the default path
-- turning resident trust-state surfacing into constant warning posture
-- using the boot layer to override launcher-owned desktop truth or control
-- implementation drift into backend, shell, tray, or diagnostics mechanics inside this design baseline
-
-## Explicit Deferrals
-
-This canonical document intentionally defers:
-
-- auth backend design
-- credential storage design
-- biometric design
-- device-trust design
-- tray implementation details
-- resident UI mechanics
-- shell integration
-- renderer wiring
-- diagnostics presentation behavior
-- notification-system implementation
-- exact post-bypass detection logic
-- exact resident recovery-entry persistence mechanics
-- exact resident control-anchor information architecture or settings taxonomy
-- exact consumer setup sequence, prompt set, or screen flow
-- exact environment-preference labels, defaults, or per-surface mappings
-- exact later-adjustment or safe-undo mechanics for setup choices
-- exact Windows Hello enrollment, availability, fallback, or failure-handling mechanics
-- exact TOTP enrollment, provisioning, fallback, device-loss, or recovery-code mechanics
-- boot runtime control
-- launcher-policy changes
-
-## Main Risks
-
-### Experience Risks
-
-- making routine access slower than users tolerate
-- confusing atmosphere with delay
-- letting the boot flow feel theatrical instead of usable
-
-### Trust Risks
-
-- making the trust step visually explicit but conceptually weak
-- allowing conversation to substitute for real trust
-- blurring routine and stronger trust states together
-
-### Recovery Risks
-
-- making fallback available but socially discouraged
-- making recovery too easy to ignore forever
-- making recovery feel like punishment
-
-### Planning Risks
-
-- mixing canonical design work with implementation details
-- re-opening launcher-owned desktop behavior inside boot planning
-- keeping too many slice docs active after consolidation
-
-## What Success Looks Like
-
-A successful consolidated boot-access design would make the user feel:
-
-- the machine entered Jarvis, not a generic app
-- the trust step was real
-- typing was always enough
-- voice made Jarvis feel alive without becoming required
-- normal daily access stayed fast
-- stronger trust only appeared when it felt justified
-- fallback existed if something went wrong
-- recovery after login felt guided and supportive
-- Jarvis remained present after entry as a trustworthy anchor
-
-## Recommended Next Planning Splits
-
-If boot planning continues after this clarification, any later revisions should stay narrower than the already-defined planning contracts and focus only on:
-
-- exact settings ownership or information-architecture clarification if a later planning boundary still needs it
-- exact preference labels, defaults, or per-surface mappings if a later planning boundary intentionally allows that depth
-
-Those should remain separate from backend, shell, diagnostics, or implementation design until the planning boundary is intentionally changed.
+- use `Docs/architecture.md` for current system boundaries
+- use `Docs/orin_vision.md` for product intent
+- use `Docs/orchestration.md` for current launcher-stack behavior
+- use `Docs/orin_interaction_architecture.md` for future interaction-system planning
+- use `Docs/feature_backlog.md` for tracked item identity
+- use `Docs/prebeta_roadmap.md` for sequencing and release posture

--- a/Docs/closeout_guidance.md
+++ b/Docs/closeout_guidance.md
@@ -2,199 +2,81 @@
 
 ## Purpose
 
-This document defines what closeouts are for, when they are required, when they are optional, and how Nexus Desktop AI should handle closeout drift.
+This document defines how Nexus Desktop AI should use:
 
-It exists because the repo has a historical closeout line, but the current Nexus pre-Beta release cadence moved forward without a clear replacement rule for every newer release milestone.
+- closeouts
+- rebaselines
+- preserved historical closeout records
 
-This document is downstream of:
+Use this file for policy.
+Use `Docs/closeout_index.md` for lookup.
+Use individual closeout or rebaseline docs for the historical or epoch summary itself.
 
-- `development_rules.md`
-- `Main.md`
-- `codex_modes.md`
-- `orin_vision.md`
+## What Closeouts And Rebaselines Are For
 
-If this document conflicts with those files, those files win.
+A closeout or rebaseline should:
 
-Use:
+- summarize what is locked
+- state what remains deferred
+- reduce prompt bloat by replacing repeated historical recaps
+- give later planning a stable shared baseline
 
-- `docs/closeout_guidance.md` for closeout policy
-- `docs/closeout_index.md` for closeout lookup
-- `docs/closeouts/...` for the actual historical closeout records
+They do not replace:
 
-## What A Closeout Is
-
-A closeout is a source-of-truth audit for a completed version lane or milestone.
-
-Its job is to:
-
-- record what is complete
-- record what remains intentionally deferred
-- lock in the accepted guarantees at that layer
-- give future planning a clean baseline
-- reduce prompt bloat by letting later prompts cite the closeout instead of replaying all prior work
-
-A closeout is not the same thing as:
-
-- a release tag
+- the backlog registry
+- canonical workstream records
+- release tags
 - GitHub release notes
-- a merged branch
-- a PR summary
 
-Those are related artifacts, but they do different jobs.
+## Current Nexus Posture
 
-## What Drift Happened
+The historical Jarvis line already has preserved closeouts through `v2.2.1`.
 
-The historical Jarvis line used closeouts regularly through:
+The modern Nexus pre-Beta line now resumes epoch-summary coverage through:
 
-- `v1.6.0`
-- `v1.7.0`
-- `v1.8.0`
-- `v1.9.0`
-- `v2.0`
-- `v2.2.0`
-- `v2.2.1`
+- `Docs/closeouts/nexus_prebeta_rebaseline_through_v1.2.7-prebeta.md`
 
-After that, the Nexus pre-Beta public release line moved to:
+That rebaseline is the current modern carry-forward baseline.
 
-- `v1.0.0-prebeta`
-- `v1.0.1-prebeta`
-- `v1.1.0-prebeta`
-- `v1.1.1-prebeta`
-- `v1.2.0-prebeta`
-- `v1.2.1-prebeta`
-- `v1.2.2-prebeta`
-- `v1.2.3-prebeta`
+## When To Use A Closeout
 
-but no matching closeout series was created for those newer pre-Beta releases.
+Use a closeout when:
 
-That drift happened because:
+- a milestone or lane materially resets future planning
+- future work depends on knowing what is now locked
+- a meaningful release or workstream justifies its own durable summary
 
-- the project shifted from the earlier Jarvis version-lane cadence to a newer Nexus pre-Beta release cadence
-- releases and branch milestones continued
-- but closeout policy was not explicitly redefined for the new cadence
+## When To Use A Rebaseline
 
-So the repo ended up in a mixed state where:
+Use a rebaseline when:
 
-- historical closeouts still matter
-- current canon still references closeouts as real planning surfaces
-- but newer Nexus pre-Beta releases have been carried mostly by tags, release notes, branch truth, and source-of-truth doc updates rather than by dedicated closeout docs
+- several smaller releases or lanes need one shared epoch summary
+- the repo needs a fresh planning baseline without backfilling every small patch release
+- current planning truth is fragmented across multiple closed lanes
 
-## Are Closeouts Still Needed
+## What Not To Do
 
-Yes.
+- do not create retroactive closeouts for every missed small prerelease
+- do not rewrite historical closeouts just to modernize wording
+- do not use closeouts or rebaselines as substitutes for workstream records
+- do not force release-dependent canon repair onto a future implementation branch when the truthful next move is a docs-only canon pass
 
-Closeouts are still useful because they:
+## Post-Release Rule
 
-- create a stable planning baseline
-- reduce repeat prompt bulk
-- clarify what is intentionally complete versus merely paused
-- make post-release sequencing cleaner
-- reduce drift between merged work, backlog truth, and future planning
+Release-dependent facts can change only after a public release exists.
 
-But they are not needed for every tiny release or every docs-only pass.
+Examples:
 
-## Required, Recommended, And Optional Closeouts
+- latest public prerelease
+- release state
+- closure state tied to a public release
 
-### Required
+When those facts change, the repo may legitimately need a docs-only canon repair or rebaseline if no safe next implementation lane should be selected yet.
 
-A closeout should be required when:
+## Current Policy
 
-- a coherent version lane has actually closed
-- a milestone materially resets future planning baseline
-- the next planning step depends on clearly knowing what is now locked versus deferred
-- a release line has accumulated enough change that relying only on branch history and chat memory would create drift risk
-
-### Recommended
-
-A closeout is recommended when:
-
-- a merged workstream created a meaningful user-visible milestone
-- several related slices now form one coherent completed milestone
-- prompt reduction would materially benefit from having a new stable baseline doc
-- a release or milestone changed the practical "what is true now" answer for future planning
-
-### Optional
-
-A closeout is optional, and often unnecessary, when:
-
-- the work is a tiny follow-through patch
-- the pass is docs-only governance with no major planning reset
-- the milestone does not materially change future sequencing
-- the latest truth already lives clearly in canonical docs and a new closeout would mostly duplicate that truth
-
-## Nexus Pre-Beta Rule
-
-For the current Nexus pre-Beta line, closeouts should usually be milestone-based, not release-by-release by default.
-
-That means:
-
-- a non-doc implementation branch may still justify the next prerelease even when it does not need its own dedicated closeout doc
-- docs-only governance or rebaseline branches remain the common no-release exception
-- do not force a new closeout doc for every small pre-Beta patch release
-- do create a closeout when a meaningful milestone or lane has actually stabilized and future planning will benefit from a fresh baseline
-
-For small Nexus `pre-Beta` patch releases that do not justify their own closeout, the default closure path should be:
-
-- carry any branch-truth canon sync on the active implementation branch before PR
-- carry any release-dependent lifecycle closure on the next implementation branch as its first docs-only step
-- do not create a standalone docs-only roadmap or drift-refresh branch by default just to close a small released lane
-
-Use a standalone docs-only exception only when no safe next implementation branch can yet be chosen and the user explicitly approves that exception.
-
-Examples that usually do not need their own closeout:
-
-- tiny usability follow-through
-- narrow docs-only governance sync
-- one small regression fix release
-
-Examples that likely do need a closeout:
-
-- a completed multi-slice interaction milestone
-- a major pre-Beta baseline shift
-- a milestone that materially changes what future prompts should carry forward
-
-## Release, Closeout, And Rebaseline
-
-These should be treated as separate tools:
-
-- `release`
-  - a published version/tag/release event
-- `closeout`
-  - a source-of-truth audit for a completed milestone or version lane
-- `rebaseline`
-  - a catch-up canonical baseline when many small steps happened without individual closeouts
-
-If Nexus pre-Beta continues through several small releases without closeouts, the clean corrective move is usually:
-
-- one rebaseline or milestone closeout
-
-not:
-
-- one retroactive closeout doc for every missed small patch release
-
-## Cleanup Recommendation For Current Drift
-
-The current recommended cleanup is:
-
-1. keep existing historical closeouts
-2. keep them organized under `docs/closeouts/`
-3. use an index doc for lookup rather than merging all closeouts into one large historical file
-4. do not rewrite them just to modernize wording
-5. do not create retroactive closeout docs for every missed Nexus pre-Beta patch release
-6. create a new closeout or rebaseline only when the next milestone genuinely justifies it
-
-This keeps the history useful without manufacturing unnecessary documentation churn.
-
-## Current Recommendation
-
-For the current repo state:
-
-- historical closeouts should remain in place
-- closeouts should not be treated as abandoned
-- closeouts should resume when the next meaningful Nexus milestone closes, not automatically after every small patch
-
-If a future planning pass needs a fresh post-`v1.2.3-prebeta` canonical baseline before broader next-lane work, the best move would be:
-
-- one Nexus-era milestone rebaseline or closeout
-
-rather than trying to backfill every missing pre-Beta patch release individually.
+- preserve historical closeouts
+- route historical lookup through `Docs/closeout_index.md`
+- use canonical workstream records for workstream-level detail
+- use the modern Nexus rebaseline for epoch truth through `v1.2.7-prebeta`
+- create new closeouts or rebaselines only when they materially improve future planning clarity

--- a/Docs/closeout_index.md
+++ b/Docs/closeout_index.md
@@ -2,74 +2,69 @@
 
 ## Purpose
 
-This document is the routing index for historical closeout records in Nexus Desktop AI.
+This document is the lookup index for:
 
-Use this file when you need:
+- preserved historical closeouts
+- current Nexus-era rebaseline summaries
 
-- the right closeout doc quickly
-- a short reminder of what each closeout covered
-- a clear separation between closeout policy and closeout history
+Use `Docs/closeout_guidance.md` for policy and cadence questions.
 
-Use:
+## Current Nexus-Era Baseline
 
-- `closeout_guidance.md` for closeout policy, cadence, cleanup, and drift questions
-- the individual closeout docs in `docs/closeouts/` for factual historical closeout content
+### Nexus Pre-Beta Rebaseline Through v1.2.7-prebeta
+
+- scope:
+  - current shared Nexus pre-Beta baseline through the released FB-035 milestone
+- file:
+  - `Docs/closeouts/nexus_prebeta_rebaseline_through_v1.2.7-prebeta.md`
 
 ## Historical Jarvis Closeouts
 
 ### v1.6.0
 
 - scope:
-  - desktop orchestration system stabilization and alignment
+  - desktop orchestration stabilization and alignment
 - file:
-  - `docs/closeouts/v1.6.0_closeout.md`
+  - `Docs/closeouts/v1.6.0_closeout.md`
 
 ### v1.7.0
 
 - scope:
   - passive historical-memory and diagnostics-only advisory foundation
 - file:
-  - `docs/closeouts/v1.7.0_closeout.md`
+  - `Docs/closeouts/v1.7.0_closeout.md`
 
 ### v1.8.0
 
 - scope:
   - validation-first trust-and-verification phase for cross-run historical intelligence
 - file:
-  - `docs/closeouts/v1.8.0_closeout.md`
+  - `Docs/closeouts/v1.8.0_closeout.md`
 
 ### v1.9.0
 
 - scope:
   - backend-tools, developer-tools, testing-and-validation closeout
 - file:
-  - `docs/closeouts/v1.9.0_closeout.md`
+  - `Docs/closeouts/v1.9.0_closeout.md`
 
 ### v2.0
 
 - scope:
   - developer-surface, shutdown-voice, workspace-slice, and planning-groundwork closeout
 - file:
-  - `docs/closeouts/v2.0_closeout.md`
+  - `Docs/closeouts/v2.0_closeout.md`
 
 ### v2.2.0
 
 - scope:
   - contained developer-surface and shutdown-voice closeout
 - file:
-  - `docs/closeouts/v2.2.0_closeout.md`
+  - `Docs/closeouts/v2.2.0_closeout.md`
 
 ### v2.2.1
 
 - scope:
   - contained interaction-foundation and desktop-stability closeout
 - file:
-  - `docs/closeouts/v2.2.1_closeout.md`
-
-## Nexus Pre-Beta Note
-
-The newer Nexus pre-Beta release line does not yet have a matching resumed closeout series after `v2.2.1`.
-
-For policy on whether a new closeout should be created, use:
-
-- `docs/closeout_guidance.md`
+  - `Docs/closeouts/v2.2.1_closeout.md`

--- a/Docs/closeouts/nexus_prebeta_rebaseline_through_v1.2.7-prebeta.md
+++ b/Docs/closeouts/nexus_prebeta_rebaseline_through_v1.2.7-prebeta.md
@@ -1,0 +1,74 @@
+# Nexus Pre-Beta Rebaseline Through v1.2.7-prebeta
+
+## Purpose
+
+This document is the modern Nexus-era rebaseline through `v1.2.7-prebeta`.
+
+Its job is to:
+
+- summarize the current shared pre-Beta baseline
+- capture what is locked versus deferred
+- reduce prompt bloat by replacing repeated lane recaps
+- point back to preserved historical closeouts without rewriting them
+
+## Baseline Scope
+
+This rebaseline covers merged shared truth through the released public prerelease:
+
+- `v1.2.7-prebeta`
+
+It stands on top of the preserved historical closeout line indexed in:
+
+- `Docs/closeout_index.md`
+
+## Material Closed Workstreams In This Baseline
+
+The closed workstreams that materially define the current baseline are:
+
+- `Docs/workstreams/FB-028_history_state_relocation.md`
+- `Docs/workstreams/FB-033_startup_snapshot_harness_follow_through.md`
+- `Docs/workstreams/FB-025_boot_desktop_milestone_taxonomy_clarification.md`
+- `Docs/workstreams/FB-034_recoverable_diagnostics.md`
+- `Docs/workstreams/FB-035_release_context_fallback_hardening.md`
+
+## What Is Locked Now
+
+Through `v1.2.7-prebeta`, current shared truth includes:
+
+- launcher-owned historical state is not a live root-logs surface
+- the startup snapshot harness is a bounded dev-only and opt-in debugging surface
+- boot and desktop milestone taxonomy remains clarified without collapsing ownership boundaries
+- one recoverable-operational-incident class is closed and shipped:
+  - repeated identical `launch_failed` for the same action in a still-running session
+- support-report fallback now derives release context from released-canon truth instead of the highest planned prerelease target
+- the manual-reporting boundary remains local and manual only
+
+## What Remains Deferred
+
+This rebaseline does not authorize automatic continuation into:
+
+- broader recoverable diagnostics surface work
+- broader reporting-policy or upload-behavior work
+- broader boot-layer implementation work
+- broader interaction, rebrand, or UI follow-through by inertia
+
+## Forward-Planning Posture After This Baseline
+
+Current merged truth does not automatically activate a new non-doc implementation lane.
+
+The next implementation workstream must be chosen from refreshed backlog, workstream, and product-boundary truth rather than by continuing the released FB-035 lane.
+
+## Historical Relationship
+
+The preserved historical Jarvis closeout line remains valid historical context.
+
+Use:
+
+- `Docs/closeout_guidance.md` for closeout and rebaseline policy
+- `Docs/closeout_index.md` for historical closeout lookup
+
+This document does not rewrite those historical closeouts.
+
+## Carry-Forward Rule
+
+Future prompts should usually treat this rebaseline plus the retained workstream records as the modern carry-forward baseline through `v1.2.7-prebeta` instead of replaying each closed lane narrative in full.

--- a/Docs/codex_modes.md
+++ b/Docs/codex_modes.md
@@ -1,721 +1,234 @@
-# Jarvis Codex Modes
+# Nexus Codex Modes
 
 ## Purpose
 
-This document formalizes the two Codex collaboration modes used in the Jarvis project:
+This document defines the collaboration posture Codex should use while handling Nexus Desktop AI tasks.
 
-- Analysis mode
-- Workflow mode
+It works with:
 
-The purpose of these modes is to keep planning, execution, and verification disciplined without weakening user authority, backlog control, or locked architecture boundaries.
+- `Docs/development_rules.md`
+- `Docs/Main.md`
+- `Docs/orin_task_template.md`
 
-This document is operational guidance for how Codex should collaborate inside Jarvis work.
-It does not override `development_rules.md`, `orin_task_template.md`, version closeout facts, or explicit user approval requirements.
-
----
+If those sources conflict, live repo truth and the higher-order governance docs win.
 
 ## Why Two Modes Exist
 
-Jarvis work needs two different collaboration postures:
+Nexus work benefits from two different postures:
 
-- one for evidence-first analysis, planning, audit, and direction validation
-- one for carrying an approved narrow task through analysis, patching, verification, and closeout
+- one for deep truth-mapping, drift analysis, and next-move determination
+- one for carrying an approved task through execution and verification
 
-Keeping those postures explicit helps prevent:
-
-- premature patching
-- scope drift
-- silent backlog changes
-- reopening closed version guarantees
-- mixing planning with implementation before the architecture boundary is clear
-
----
+The modes should not be confused.
+Analysis mode exists to understand the whole system first.
+Workflow mode exists to execute approved work without silent scope drift.
 
 ## Analysis Mode
 
 ### Goal
 
-Use Analysis mode when the immediate job is to understand, validate, challenge, audit, or sequence work before any patching begins.
+Map the real current state of the system before deciding what should happen next.
 
 ### When To Use It
 
-Use Analysis mode when:
+Use Analysis mode when the user asks for:
 
-- deciding whether a version, revision, or backlog item is the correct next target
-- auditing whether a completed revision is clean enough to close
-- identifying risks, missing evidence, or drift traps
-- defining the safest scope for a future docs-only or patch task
-- validating whether a proposed next move conflicts with source-of-truth docs
-- investigating runtime bugs, behavior regressions, or other systems-level failures before patching
-- tracing architecture-sensitive behavior where a shallow file-reference answer would be risky
-- performing readiness or risk analysis that could directly lead to a patch recommendation
-- performing post-version planning such as deciding whether `FB-015` is the correct next architecture-first target
+- drift review
+- post-release or post-merge review
+- workstream planning
+- readiness analysis
+- sequencing analysis
+- source-of-truth audit
+- next-lane determination
 
 ### What Codex Should Do
 
-Codex should:
+In Analysis mode, Codex should:
 
-- read the source-of-truth docs first
-- inspect the relevant repo state before making recommendations
-- validate assumptions against implemented behavior and documented boundaries
-- identify the narrowest safe next step
-- separate confirmed facts from inference
-- call out risks, blockers, and conflicts directly
-- recommend doc-first clarification when implementation boundaries are not yet tight enough
+- validate current repo truth first
+- scan broadly enough to understand the whole affected system
+- compare code, docs, branches, tags, and release facts where relevant
+- identify factual drift, structural drift, and authority drift
+- classify prior suggestions as carry-forward, defer, or discard
+- determine the correct next workstream-level move
 
 ### Required Analysis Depth
 
-Analysis mode is not one fixed depth for every task.
+Analysis mode should reason at:
 
-For a tiny docs review, narrow sanity check, or lightweight source-of-truth drift check, Codex should use only the analysis depth needed to answer the question cleanly.
+- system level
+- lane level
+- workstream level
+- document-ownership level
 
-For runtime bugs, behavior regressions, systems investigations, architecture-sensitive work, or readiness/risk analysis that could lead to patching, Analysis mode must become deep investigative analysis rather than shallow reference review.
-
-Deep investigative analysis is also required for branch-level merge-readiness, PR-readiness, release-readiness, version-bump, or release-package review, even when no patch is being proposed.
-
-When that deeper investigation applies, Codex should:
-
-- trace the full execution or behavior chain from entry point to affected output
-- identify direct files, indirect files, and regression-risk files
-- explain current behavior versus intended behavior
-- identify the relevant validators, state transitions, logging surfaces, config usage, and user-visible side effects
-- list assumptions, unknowns, and evidence still needed
-- define the smallest safe patch scope when a patch may be needed
-- define the verification plan, including commands, log review, and user-test needs, before recommending patching or readiness
-
-Analysis mode should follow those same requirements even when the user invokes it with only a short cue such as:
-
-- `Analyze and Report`
-- `Analyze for drift`
-- `Analysis mode`
-- `reference docs for the following`
-
-Those shorthand prompts are mode selectors, not reduced-quality requests.
-Codex should still load the default baseline from `docs/Main.md` and the directly relevant canonical docs before reporting.
-
-### First Prompt Rule For New Post-Closeout Version Chats
-
-In the first Codex prompt of each new post-closeout version chat, Analysis mode should explicitly address:
-
-- what must be carried forward into the new version context
-- what can be removed from the prompt because the source-of-truth docs already cover it
-
-This keeps new-version chats grounded in the closed baseline without repeating version-closeout facts unnecessarily.
+Do not narrow to the first apparent slice before full drift and dependency mapping is complete.
 
 ### What Codex Must Not Do
 
-Codex must not:
+In Analysis mode, Codex must not:
 
-- patch files
-- change backlog state
-- imply that unimplemented work already exists
-- widen scope to "helpfully" include implementation
-- smuggle in authority, policy meaning, or runtime coupling through analysis language
-- reopen closed `v1.6.0`, `v1.7.0`, or `v1.8.0` guarantees without explicit user approval
+- default into implementation
+- assume PR, merge, release, or closure is the next move
+- compress the task into the smallest possible pass before understanding the system
+- treat local unmerged overlays as merged truth
 
 ### Expected Outputs
 
-Analysis mode outputs should usually include:
+Analysis mode should usually return:
 
-- source-of-truth validation result
-- readiness assessment
-- recommended scope or next revision
-- explicit non-goals
-- drift risks
-- whether a docs-only clarification should happen before patching
-- recommended next move
-
-When deep investigative analysis applies, outputs should also include:
-
-- affected-chain summary
-- current behavior versus intended behavior
-- explicit assumptions, unknowns, and missing evidence
-- smallest safe patch scope when patching is still a live outcome
-- verification and user-test plan
-
-Analysis mode should leave the repo unchanged.
-
----
+- validated current truth
+- key drift findings
+- structural assessment
+- sequencing options
+- one recommended next workstream move
 
 ## Workflow Mode
 
 ### Goal
 
-Use Workflow mode only when the user has explicitly approved a narrow task and wants Codex to carry that exact task through end to end inside the approved boundaries.
+Execute an approved task faithfully, verify it, and keep the resulting truth coherent.
 
 ### When To Use It
 
-Use Workflow mode when:
+Use Workflow mode when the user has already approved:
 
-- a docs-only pass has been clearly approved
-- a narrow patch revision has been clearly approved
-- a closeout sync is needed and its boundaries are already established
-- the user has explicitly approved a bounded task rather than a broad implied workflow handoff
+- a docs-only pass
+- a bounded patch
+- a canon sync
+- a workstream closure pass
+- another clearly bounded execution task
 
 ### What Codex Should Do
 
-Codex should:
+In Workflow mode, Codex should:
 
-- still analyze first
-- complete the required deep Analysis-mode investigation before editing when the task involves runtime bugs, behavior regressions, systems investigations, architecture-sensitive work, or readiness/risk analysis that could lead to patching
-- define the exact narrow scope before editing
-- make only the approved isolated change
-- verify the result directly
-- run the same user-facing test path or the closest faithful equivalent before handing that path back to the user when feasible
-- report what changed and what was verified
-- keep the source-of-truth docs aligned with actual implemented state
-- stop and report if the task would require reopening locked architecture or widening beyond one controlled revision
-
-Workflow mode should follow those same requirements even when the user invokes it with only a short cue such as:
-
-- `Workflow mode`
-- `docs-only pass`
-- `patch this`
-- `continue on this branch`
-
-Those shorthand prompts are execution selectors, not permission to skip truth-doc reading, validation, or scope control.
-Codex should still load the default baseline from `docs/Main.md`, infer the directly relevant canonical docs, and keep the same validation standard as a longer structured prompt.
-
-Workflow mode means Codex carries the task responsibly, not mechanically.
-Codex should behave like a careful senior collaborator who keeps progress moving without bypassing control boundaries.
-
-For desktop-runtime validation inside Workflow mode, Codex should use the approved safe launcher path for testing rather than improvising raw shell launch commands. In practice, that means:
-
-- prefer an approved helper in `dev/launchers/`
-- or launch `desktop/orin_desktop_launcher.pyw` directly through `pythonw.exe`
-
-Codex should only use the user-facing VBS or desktop shortcut path when the task specifically requires validating that wrapper layer itself.
+- validate live repo truth before editing
+- stay inside the approved execution boundary
+- make the required changes
+- verify the changed behavior or changed docs
+- report any drift or remaining gaps honestly
 
 ### What Codex Must Not Do
 
-Codex must not:
+In Workflow mode, Codex must not:
 
-- treat workflow ownership as permission to widen scope
-- patch runtime, behavior, or systems-impacting work before the required pre-patch investigation is complete
-- silently change backlog status or priorities without explicit approval
-- reopen version-closed behavior as a "small improvement"
-- merge multiple conceptual fixes into one revision
-- convert advisory or historical semantics into runtime policy
-- treat Workflow mode as authority over user decisions
+- silently widen scope
+- silently start a new workstream
+- silently create PR, merge, release, or closure output without current-truth justification
+- treat a clean first slice as automatic branch readiness
 
 ### Expected Outputs
 
-Workflow mode outputs should usually include:
+Workflow mode should usually return:
 
-- source-of-truth validation result
-- exact files changed
-- exact minimal changes made
-- why the change is sufficient
-- verification summary
-- whether validation is:
-  - self-validated
-  - helper-validated
-  - or still user-only for the final gap
-- any docs intentionally left unchanged
-- commit summary
-- commit description
+- changes applied
+- validation performed
+- remaining drift or known gaps
+- whether the approved phase is complete
 
-Workflow mode should report the result, not paste the full contents of edited files.
+## Workstream And Branch Governance
 
-Workflow mode may perform edits, but only after the task scope is explicitly approved and bounded.
+### Grouped Workstreams
 
----
+During `pre-Beta`, grouped workstreams are allowed when they remain coherent by subsystem and end-state.
 
-## Batched Workstream Rule
+That means:
 
-Jarvis may use one tightly related batched workstream per prompt when that is the smallest coherent way to complete one approved subproblem.
+- one branch may host multiple validated slices for one milestone
+- grouped workstreams should not become grab-bags of unrelated ideas
+- lane evaluation should stay milestone-driven rather than slice-driven
 
-A batched workstream is safe only when all of the following are true:
+### Milestone Gate
 
-- one subsystem
-- one end-state
-- one coherent approved subproblem
-- later slices are dependent completion steps of the same chain
-- validation can still stay narrow and exact
-
-Common checkpoint range:
-
-- 3-5 dependent sub-slices before a deliberate branch-health review
-
-This is a review checkpoint, not a stop rule.
-
-More than 5 dependent sub-slices are allowed when:
-
-- they still belong to one subsystem, one end-state, and one coherent approved subproblem
-- each additional slice is still required to complete the same worthwhile milestone
-- validation can still stay narrow and exact
-- stopping earlier would leave the branch too small to justify its declared release floor
-
-Jarvis batched workstreams must not:
-
-- mix unrelated subsystems
-- mix production behavior changes with unrelated dev-tool or docs cleanup
-- use filler batching just to make a prompt feel larger
-- smuggle in backlog cleanup unrelated to the active workstream
-
-### Validation Inside A Batched Workstream
-
-When a batched workstream is approved, Workflow mode should use:
-
-- baseline validation before edits
-- slice-local validation after each code-bearing slice
-- one final integrated validation at the end
-
-### Batched-Workstream Stop Conditions
-
-Stop the workstream early and report immediately if:
-
-- a source-of-truth conflict appears
-- the next slice would cross into another subsystem
-- the next slice would reopen locked production behavior outside the approved scope
-- safe verification for the current slice is not possible
-- the current slice fails validation
-- the remaining slices are no longer obviously required to complete the same end-state
-
-### Docs And Backlog Sync Inside A Batched Workstream
-
-Directly supportive doc sync may travel with the active workstream when it records that exact implemented work and does not widen scope.
-
-Backlog sync remains controlled:
-
-- exact markdown approval is still required before editing `docs/feature_backlog.md`
-- only the exact active workstream truth may be synced
-- unrelated backlog cleanup must stay separate
-
-### Docs-Only Governance Pass Batching
-
-When the user explicitly approves a docs-only governance or source-of-truth pass, that pass may batch several directly related clarifications when they all serve one coherent workflow or canon end-state.
-
-This is allowed only when:
-
-- the edits stay inside one governance lane
-- the file scope stays minimal
-- the pass does not widen into unrelated repo cleanup
-- the pass does not mix in runtime implementation work
-- backlog status or priority changes are not made without separate approval
-
-## Grouped Workstream Branch Rule
-
-For `pre-Beta` planning, Codex may recommend or use a grouped workstream branch when:
-
-- the work belongs to one clear category or subsystem
-- several related ideas are better handled as one lane than as disconnected micro-branches
-- the lane is suitable for multi-developer coordination
-- each actual revision inside the branch can still stay narrow and validated
-
-Examples of valid grouped workstream branches:
-
-- interaction
-- UI / UX
-- workflow / GitHub infrastructure
-- diagnostics / tooling
-
-A grouped workstream branch does not authorize one broad patch.
-
-Instead, it means:
-
-- one branch may host a sequence of approved narrow slices
-- one focused branch may also carry multiple small related patches when they all serve the same project-focus lane
-- one focus-group lane may also carry one larger coherent implementation when that is still the smallest worthwhile milestone inside the same subsystem
-- each slice inside that branch still needs clear scope and verification
-- each small patch inside that branch must still stay narrow, validated, and within the same subsystem boundary
-- unrelated ideas should still be split out even if they are all deferred work
-
-For `pre-Beta`, the default branch strategy should usually prefer focus-group lanes over one branch per micro-fix when:
-
-- the lane stays inside one subsystem or category
-- the lane still follows one coherent milestone path
-- the resulting branch does not become a grab-bag of unrelated follow-through
-
-For those `pre-Beta` focus-group lanes:
-
-- merge cadence should follow meaningful lane milestones rather than every tiny follow-through
-- non-doc implementation branches should usually be version-bearing lane milestones rather than merge-only deltas
-- release cadence should follow those implementation-lane milestones and should usually advance by at least the next patch prerelease step unless the user explicitly approves a different posture
-- grouped branches must still be split if the work starts crossing subsystem boundaries or accumulating unrelated fixes
-
-## Grouped Lane Milestone Gate
-
-For an active `pre-Beta` grouped workstream branch, Codex should define before implementation:
+Before treating a non-doc implementation branch as ready, Codex should be able to explain:
 
 - the lane milestone target
 - the minimum merge-ready threshold
-- the milestone value statement that explains why the branch is worthwhile if squashed and merged
-- the tightly coupled groundwork that still belongs inside the same branch
-- the expected same-branch follow-through that is still required before readiness
+- the milestone value statement
+- the same-branch follow-through that still belongs inside the lane
 
-Codex should not treat the first validated revision inside that branch as PR-ready by default.
+### Worthwhile Milestone Gate
 
-Instead, Codex should continue through additional narrow slices inside the same branch until:
+For a non-doc implementation branch, Codex should not recommend readiness until:
 
-- the declared minimum merge-ready threshold is reached
-- the branch would still read as a worthwhile milestone if squashed and merged now
-- the branch is strong enough to justify its declared release floor
-- a real blocker appears
-- or the user explicitly chooses to stop early
+- the threshold is reached
+- the branch is still worthwhile if squashed today
+- the remaining obviously coupled slices are no longer required
 
-If enabling groundwork and the first usable outcome are tightly coupled inside one subsystem and remain low-risk, they should usually stay in the same grouped branch rather than being split into separate micro-branches or premature PRs.
+### Release-Debt Gate
 
-## Worthwhile Milestone Gate
+If `main` already contains merged unreleased non-doc implementation work beyond the latest public prerelease, treat that as release debt.
 
-Before Codex recommends PR-readiness for a non-doc implementation branch, it must be able to answer `yes` to all of the following:
+While release debt exists, the default next move is usually:
 
-- the declared minimum merge-ready threshold is reached
-- the branch would still represent a worthwhile milestone if squashed today
-- the branch is strong enough to justify its declared release floor
-- the remaining obviously coupled slices are no longer required to make the milestone feel complete
+- release review
+- release prep
+- directly needed docs support
 
-If any of those answers is `no`, Codex should continue on the same branch unless:
+not another unrelated implementation lane.
 
-- a real blocker appears
-- the next step would cross subsystem boundaries
-- or the user explicitly chooses to stop early
+### Fresh Branch Start After A Closed Workstream
 
-## Grouped Lane Release Floor
+After a workstream is merged and closed, the next workstream should start from updated `main` on a fresh branch.
 
-For an active `pre-Beta` grouped lane, Codex should also define before implementation:
+If a branch is stale, merged, or identical to `main`, call it out explicitly and stop using it as the base for next-lane planning.
 
-- the lane type
-- the release floor
-- the target version for non-doc implementation lanes
+### Post-Release Canon Repair
 
-Use these lane types:
+Release-dependent truth sometimes changes after the code lane is already closed.
 
-- `docs-only`
-- `implementation`
-- `rebaseline`
+When that happens:
 
-Use these release floors:
-
-- `no release`
-- `patch prerelease`
-- `minor prerelease`
-
-Rules:
-
-- `docs-only` branches are the default and preferred `no release` exception
-- `rebaseline` branches may remain `no release` when they are docs-only and are only syncing baseline truth after a release or milestone
-- non-doc `implementation` branches should usually declare at least `patch prerelease`
-- larger subsystem or capability shifts may justify `minor prerelease`
-
-Codex should judge PR-readiness for a non-doc implementation branch against:
-
-- the lane milestone target
-- the minimum merge-ready threshold
-- the declared release floor
-- the declared target version
-
-## Release-Debt Stop Rule
-
-If `main` already contains merged unreleased non-doc implementation work beyond the latest public prerelease, Codex should treat that as release debt.
-
-While release debt exists, Codex should not recommend merging another non-doc implementation branch by default unless:
-
-- the new branch is the intentionally selected version-bearing milestone that resolves that debt
-- or the user explicitly approves stacking more implementation before the next release
-
-When release debt exists, the default next move should usually be:
-
-- release or version-readiness review
-- or a docs-only rebaseline or governance pass that is directly needed to resolve the release decision cleanly
-
-At `Beta` and later, the default recommendation should usually shift toward:
-
-- issue-specific branches
-- bug-fix branches
-- single-idea branches
-
-unless a grouped branch remains clearly justified.
-
-## Fresh Branch Start After A Closed Workstream
-
-After a prior workstream branch has been merged, released if applicable, and deleted, the next workstream should start from updated `main` on a fresh branch.
-
-For routine Nexus `pre-Beta` work, standalone docs-only roadmap, rebaseline, or drift-refresh branches should not be the default cleanup path anymore.
-
-Instead, canon freshness must be handled in only two required windows:
-
-### 1. Branch-Start Canon Alignment Review
-
-Before the first code slice on every new non-doc implementation branch, Codex must run a deep branch-start canon alignment review against:
-
-- `docs/Main.md`
-- `docs/development_rules.md`
-- `docs/codex_modes.md`
-- the directly relevant planning docs
-- the directly relevant architecture docs
-- the directly relevant implementation truth
-
-That review must:
-
-- close the just-finished released or merged lane in canon when that closure is now known
-- activate or clarify the new lane in canon when that activation is already known
-- sync only the directly supporting docs needed for the new branch to start from current shared truth
-- land any required docs-only sync as the first commit, or first tightly grouped docs-only commits, on that same new implementation branch before further implementation work
-
-### 2. Pre-PR Canon Freeze Review
-
-Before PR packaging for a non-doc implementation branch, Codex must run a deep canon-freeze review on that same branch.
-
-That review must confirm:
-
-- the roadmap entry matches actual branch truth
-- the backlog item state, suggested version, and suggested revision fields match actual lane truth
-- governing docs reflect any implemented boundary changes now carried by that lane
-- architecture docs reflect any implemented boundary changes now carried by that lane
-- no directly supporting canon needed for merge or release remains stale
-
-If supporting canon is still stale, the required sync must land on the same branch before PR packaging.
-
-### Post-Release Lifecycle Closure Rule
-
-Some facts cannot become true until a public release actually exists. Those facts include:
-
-- latest public prerelease
-- lane `release state: released`
-- lane `status: closed` when that closure depends on the release actually existing
-
-When those release-dependent facts change, Codex should not open a routine standalone docs-only refresh branch by default.
-
-Instead:
-
-- if a new implementation lane is about to begin, Codex should carry the release-closure sync as the first docs-only step on that new implementation branch during the branch-start canon alignment review
-- if no safe next implementation branch can yet be chosen, Codex must say so explicitly and ask for user approval before using any standalone docs-only exception path
-
-This means routine roadmap or drift refresh should happen either:
-
-- before PR on the active implementation branch
-- or at the start of the next implementation branch
-
-It should not be deferred into a separate docs-only branch by default.
-
----
+- carry the canon sync on the active lane when that lane is still open
+- use a docs-only canon pass when current truth requires it and no safe next implementation lane should be selected yet
+- do not force post-release canon repair onto a hypothetical next implementation branch when that would leave the repo planning baseline misleading
 
 ## Shared Rules Across Both Modes
 
-These rules apply in both modes:
-
-- analyze first
-- verify exact behavior or exact doc alignment before changing anything
-- no blind iteration
-- minimal isolated changes only
+- analyze before changing anything
+- verify exact behavior or doc alignment before editing
 - preserve architecture boundaries
-- one fix per revision
-- production behavior must remain unchanged unless explicitly in scope
-- logs, code, and current repo docs are the source of truth for implemented behavior
-- when a source-of-truth conflict exists, call it out explicitly before proceeding
+- call out source-of-truth conflicts explicitly
+- backlog owns identity
+- roadmap owns sequencing
+- workstream docs own promoted-work execution and closure truth
+- User Test Summary belongs to workstream-owned validation
+- incident patterns are generalized knowledge, not case history
 
 ## Live-State Readiness Sanity Check
 
-Before Codex generates any readiness or release package such as:
+Before generating any readiness, PR, merge, or release recommendation, validate:
 
-- merge-ready or release-ready judgments
-- version bump recommendations
-- PR title or PR body output
-- release title or release notes output
+- current branch truth
+- branch merge state
+- tag or release state
+- dirty worktree risk
+- whether the prompt framing is stale
 
-Codex must verify live repo state first.
+If the framing is stale, report the real state instead of producing a hypothetical package.
 
-Those readiness reviews are Analysis-mode work and must use deep investigative analysis rather than shallow branch-summary reasoning.
+## Prompt Hygiene
 
-That live-state check must include:
+When a canonical workstream or rebaseline doc exists, prompts should prefer that canonical doc over a stack of superseded slice docs.
 
-- whether the referenced branch is still active
-- whether that branch has already been merged
-- whether related tag or release state already exists
-- whether the prompt framing is stale relative to current repo or GitHub state
-
-For branch-level merge-ready or release-ready review, that deeper analysis should also cover:
-
-- the actual branch scope and what changed on that branch
-- whether any active bug, unresolved drift, or dirty worktree state remains
-- whether verification evidence is strong enough for the claimed readiness level
-- whether closed guarantees, milestone expectations, or release facts could be reopened by the current branch state
-
-If the prompt framing is stale, Codex must not generate a fresh hypothetical readiness package.
-
-Instead, Codex should:
-
-- report the actual current state
-- explain which assumptions in the prompt were stale
-- recommend the true next move from the live state
-
-## Readiness Output Content Rule
-
-When Codex is asked to provide PR-ready or release-ready output, the default should be to describe what is included in the work under review.
-
-Codex should not add a `Not included` section unless:
-
-- the user explicitly asks for one
-- omitting it would create a real scope misunderstanding for the active task
-
-For non-doc implementation branches, PR-readiness output must explicitly state one of:
-
-- `supporting canon already aligned on branch`
-- `supporting canon sync required before PR`
-
-PR-readiness output for non-doc implementation branches must also explicitly state one of:
-
-- `branch milestone is worthwhile and complete for PR`
-- `branch milestone still too small; continue same branch`
-
-That canon-freshness result is mandatory and must be based on live branch truth, not on prompt framing alone.
-
-In slice-sizing terms:
-
-- one fix per revision means one coherent approved subproblem per revision
-- minimal isolated changes means the minimal coherent approved change set needed to close that subproblem
-- smallest safe slice and smallest coherent slice are execution rules for revisions inside a branch, not automatic branch stop rules
-- for `pre-Beta` non-doc branches, choose the smallest worthwhile milestone for the branch first, then use as many safe dependent slices as needed to complete it
-- use the smallest safe slice for architecture clarification, boundary-setting, and high-risk behavior or policy work
-- use the smallest coherent slice for lower-risk post-boundary feature delivery when a smaller fragment would leave an incomplete first deliverable
-
-Neither mode permits:
-
-- silent scope expansion
-- silent backlog control changes
-- policy drift disguised as wording cleanup
-- authority expansion disguised as confidence or intelligence work
-
-In Jarvis work, Codex must not return the full contents of created or edited files.
-
-Codex should instead return:
-
-- a summary of what changed
-- the changed file path or paths
-- the approved scope
-- the verification performed
-
-If actual file review is needed, the file should be reviewed outside Codex by uploading it for inspection.
-
-## Pull Request Opening Boundary
-
-Codex may open or submit a pull request directly only for an approved docs-only branch.
-
-For code branches or mixed code/docs branches, Codex may:
-
-- perform PR-readiness analysis
-- provide the exact PR title and PR body
-- provide merge and release posture guidance
-
-For those non-docs-only branches, Codex should stop short of opening the PR.
-
----
-
-## Backlog-Control Reminder
-
-`docs/feature_backlog.md` remains a controlled planning layer.
-
-Codex may:
-
-- propose backlog changes
-- draft exact backlog markdown for approval
-
-Codex may not:
-
-- silently edit backlog status or priority fields
-- mark items complete without approval
-- reorder backlog items without approval
-
-If backlog state needs to change, user approval is still required even in Workflow mode.
-
----
-
-## Relationship To `orin_task_template.md`
-
-`docs/orin_task_template.md` remains the per-task execution scaffold.
-
-This document does not replace the template.
-Instead:
-
-- `orin_task_template.md` defines the structure of an individual task request
-- `codex_modes.md` defines the collaboration posture Codex should take while handling that task
-
-In practice:
-
-- Analysis mode pairs naturally with `analysis-only`, `planning-only`, and audit tasks in the template
-- Workflow mode pairs naturally with approved `docs-only` and `patch` tasks in the template
-
-If the template and a casual user request conflict, Codex should follow the explicit structured task and the source-of-truth docs.
-
----
-
-## Prompt Hygiene After Consolidation
-
-When a workstream has been consolidated into a canonical planning or design doc, prompts should prefer that canonical doc over the earlier slice-by-slice planning stack.
-
-This keeps prompts shorter, reduces duplicate source lists, and prevents archival reasoning docs from being treated like equal-weight current truth.
-
-### Analysis Mode Guidance
-
-In Analysis mode, Codex should:
-
-- use `docs/Main.md` as the routing index for the active source-of-truth set
-- identify whether a canonical consolidated doc already exists for the active workstream
-- carry forward that canonical doc instead of the full stack of superseded slice docs
-- explicitly say what older slice docs can be removed from the prompt because the canonical doc already covers them
-- pull older slice docs back in only if the task is about historical tracing, consolidation audit, or source conflict checking
-
-### Workflow Mode Guidance
-
-In Workflow mode, Codex should:
-
-- use `docs/Main.md` plus the relevant canonical doc or docs as the default prompt baseline for the active workstream
-- use the canonical consolidated doc as the primary planning baseline for the active workstream
-- avoid re-listing archival slice docs unless the approved task explicitly depends on them
-- keep the prompt evidence set narrow and current rather than mechanically repeating every earlier planning file
-- prioritize the active code workstream when the task is code-focused
-- bundle directly supporting truth-doc updates into the same approved workstream when that keeps docs aligned without widening scope
-- prefer milestone-level or canonical doc sync over repeated separate doc-only micro-passes when docs are not the primary deliverable
-
-### Prompt Reduction After Closeout
-
-Once a version has a closeout doc and the directly supportive truth-sync items are complete, future prompts should usually:
-
-- cite the latest relevant closeout doc instead of re-listing the full completed-workstream recap
-- carry forward only the baseline facts still needed for the next version lane
-- omit validator, harness, and reachability details that are already captured in the closeout and backlog truth unless the new task depends on them directly
-- avoid repeating the full batched-workstream rule block when `codex_modes.md` is already part of the prompt baseline
-
-Closeout cadence and whether a new closeout is actually needed should follow `docs/closeout_guidance.md` rather than being assumed mechanically from the existence of a release, branch merge, or docs-only pass.
-
-### Current Boot-Planning Example
-
-For current Jarvis work, `docs/Main.md` should be the default docs index and prompt-baseline map.
-
-For current Jarvis boot-access work, `docs/boot_access_design.md` is the canonical boot planning source.
-
-That means future boot-access prompts should usually prefer:
-
-- `development_rules.md`
-- `Main.md`
-- `architecture.md`
-- `orin_vision.md`
-- `feature_backlog.md`
-- `orchestration.md`
-- `boot_access_design.md`
-- relevant closeout docs only when still needed
-
-The earlier `boot_*_plan.md` slice docs have been retired from the active docs tree and should not be listed as prompt inputs unless they are reintroduced separately for historical review outside the normal planning baseline.
-
----
+This does not mean shrinking analysis depth.
+It means reducing duplicated prompt inputs once authority is clear.
 
 ## Practical Rule Of Thumb
 
 If the user is asking:
 
-- "What should we do next?"
-- "Is this the right next version or revision?"
-- "Is this complete enough to close?"
+- what is true now
+- what drift exists
+- what should happen next
+- whether the current branch is still the right base
 
-Use Analysis mode.
+start in Analysis mode.
 
 If the user is asking:
 
-- "Carry this approved docs-only pass"
-- "Implement this exact narrow revision"
-- "Own this closeout sync"
+- execute this approved docs-only phase
+- implement this approved patch
+- carry this approved workstream closure or canon sync
 
-Use Workflow mode.
-
-When in doubt, start in Analysis mode first.
+use Workflow mode.

--- a/Docs/codex_user_guide.md
+++ b/Docs/codex_user_guide.md
@@ -2,26 +2,45 @@
 
 ## Purpose
 
-This document is the canonical operator guide for using short, reliable prompts with Codex inside Nexus Desktop AI work.
+This document explains how to prompt Codex effectively inside Nexus Desktop AI work without sacrificing analysis depth, source-of-truth discipline, or validation quality.
 
-It exists to reduce prompt overhead without reducing source-of-truth discipline, validation quality, or scope control.
+It is an operator guide for prompt construction and collaboration posture.
 
-This guide is downstream of:
+It is downstream of:
 
-- `development_rules.md`
-- `Main.md`
-- `codex_modes.md`
-- `user_test_summary_guidance.md`
+- `Docs/development_rules.md`
+- `Docs/Main.md`
+- `Docs/codex_modes.md`
+- `Docs/user_test_summary_guidance.md`
 
 If this guide conflicts with those files, those files win.
 
-## Quick Start
+## Core Rule
 
-The best default prompt pattern is:
+Concise prompts are allowed.
+
+Concise prompts do **not** mean:
+
+- shallow analysis
+- reduced source-of-truth reading
+- premature scope compression
+- automatic readiness, closure, merge, or release framing
+
+Codex should still:
+
+1. validate live repo truth
+2. scan broadly enough to understand the affected system
+3. map drift, risk, dependencies, and options
+4. report clearly
+5. narrow execution only after the user and ChatGPT choose scope
+
+## Default Prompt Posture
+
+The default prompt posture is:
 
 - one cue
 - one anchor
-- optional control add-ons only when needed
+- optional control add-ons only when they materially reduce ambiguity
 
 Use:
 
@@ -29,157 +48,149 @@ Use:
 
 Examples:
 
-- `Analyze and Report: merge readiness for current branch`
-- `Analyze for drift: current branch before merge`
-- `Workflow mode: fix zero-match safety on current branch`
-- `docs-only pass: improve prompt cookbook guidance`
-- `continue on current branch: finish the remaining regression`
+- `Analyze and Report: best next workstream after current release`
+- `Analyze for drift: post-release canon on updated main`
+- `Workflow mode: execute the approved canon phase on current branch`
+- `docs-only pass: align README to the merged source-of-truth model`
 - `use latest User Test Summary as authoritative and continue`
 
-## Fastest Reliable Rule
-
-Short prompts are fine.
-
-What still matters is:
-
-- the cue tells Codex how to work
-- the anchor tells Codex what the work is about
-
-Good anchors include:
-
-- the active branch
-- the bug
-- the file
-- the workstream
-- the outcome you want
-- the returned evidence artifact
-
-Weak anchors include:
-
-- `continue`
-- `fix it`
-- `look at this`
-
-Those can still work if the current thread already makes the target obvious, but they are less reliable than one explicit anchor.
+The prompt may be concise.
+Codex's investigation should still be complete enough for the task.
 
 ## What Codex Should Do Automatically
 
-Short prompts do not waive source-of-truth reading.
+Brief prompts do not waive source-of-truth reading.
 
-When the user gives a brief cue such as:
+When the user gives a short cue such as:
 
 - `Analyze and Report`
 - `Analyze for drift`
 - `Analysis mode`
 - `Workflow mode`
 - `docs-only pass`
-- `reference docs for the following`
 - `continue on current branch`
 
 Codex should still:
 
-1. load `docs/development_rules.md`
-2. load `docs/Main.md`
-3. infer the directly relevant canonical doc or docs
-4. pull only the evidence inputs needed for the task
-5. keep the same validation standard as a longer structured prompt
+1. load `Docs/development_rules.md`
+2. load `Docs/Main.md`
+3. load `Docs/codex_modes.md` when collaboration posture matters
+4. infer the directly relevant authority docs
+5. pull the repo evidence needed to validate live truth
+6. keep the same reasoning standard as a longer structured prompt
 
-If the task is still materially ambiguous after that baseline, Codex should ask one tight clarifying question rather than lowering quality.
+If the task remains materially ambiguous after that baseline, Codex should ask one focused clarifying question rather than lowering the quality of analysis.
 
-## Cue Cheat Sheet
+## Analysis-Phase Prompting
 
-Use `Analyze and Report` or `Analysis mode` when you want:
+Use analysis-phase prompts when the user wants:
 
-- audit
-- sequencing
-- readiness judgment
-- recommendation without patching
+- current-truth validation
+- drift review
+- sequencing review
+- next-move determination
+- post-release or post-merge review
+- source-of-truth audit
+- lane or branch evaluation
 
-Use `Analyze for drift` when you specifically want:
+Helpful cues:
 
-- a check for scope drift
-- source-of-truth drift
-- prompt drift
-- architecture drift
-- branch-readiness risk caused by mixed work
+- `Analyze and Report`
+- `Analyze for drift`
+- `Analysis mode`
+- `analysis-to-plan pass`
 
-Use `Workflow mode` when you want:
+Helpful add-ons:
 
-- a bounded patch
-- a docs-only pass
-- a same-branch fix pass
-- a same-branch milestone-completion pass
-- a controlled validation pass after approval
-
-Use `docs-only pass` when you want:
-
-- truth-doc updates only
-- no runtime implementation work
-
-## Best Prompt Building Blocks
-
-The easiest reliable prompt usually contains:
-
-- one cue
-- one anchor
-- zero to three control add-ons
-
-Useful control add-ons include:
-
-- `on current branch`
-- `do not widen scope`
-- `until the milestone is worthwhile`
 - `analysis only`
-- `docs-only pass`
-- `no PR/release output`
 - `use latest User Test Summary as authoritative`
+- `use origin/main as authoritative truth`
+- `do not patch`
+
+Analysis-phase prompts should encourage:
+
+- full-system reasoning first
+- branch and release truth validation
+- structural and authority drift mapping
+- carry-forward / defer / discard classification of prior suggestions
+
+They should **not** push Codex to behave like a narrowly bounded executor before the analysis is complete.
+
+## Execution-Phase Prompting
+
+Execution-phase prompts are for work the user has already approved.
+
+Helpful cues:
+
+- `Workflow mode`
+- `docs-only pass`
+- `execute the approved phase`
+- `continue on current branch`
+
+Useful execution add-ons:
+
+- `do not widen scope`
 - `self-validate before handoff`
 - `use helper if needed`
-- `commit and push if clean`
+- `no PR/release output`
 
-These add-ons are optional.
-Use them only when they materially reduce ambiguity or protect scope.
+Execution-phase discipline such as:
+
+- bounded patching
+- minimal isolated change
+- smallest coherent execution slice
+- narrow fix pass
+
+belongs here, after analysis and scope selection are already complete.
 
 ## Prompt Recipes
 
-### Analyze The Next Move
+### Deep Analysis Of The Next Move
 
 Use:
 
-- `Analyze and Report: best next lane after current branch`
+- `Analyze and Report: best next workstream after current branch`
 
 Useful add-ons:
 
 - `analysis only`
-- `use latest User Test Summary as authoritative`
+- `use origin/main as authoritative truth`
 
-### Check For Drift
+### Drift Review
 
 Use:
 
 - `Analyze for drift: current branch before merge`
+- `Analyze for drift: post-release canon on updated main`
 
 Best for:
 
 - mixed-scope branches
 - stale prompt assumptions
 - source-of-truth mismatch
+- release-dependent docs drift
 - architecture or workflow drift
 
-### Continue The Same Branch
+### Docs-Only Canon Repair
 
 Use:
 
-- `continue on current branch: [exact remaining bug or task]`
-- `continue on current branch until the milestone is worthwhile: [active lane]`
+- `docs-only pass: repair post-release canon drift on updated main`
+
+This is a valid standalone workstream when live truth justifies it.
+It does not need to be forced onto a hypothetical next implementation branch.
+
+### Continue An Approved Branch
+
+Use:
+
+- `continue on current branch: [approved remaining task]`
+- `Workflow mode on current branch: [approved phase]`
 
 Examples:
 
-- `continue on current branch: finish zero-match safety`
-- `continue on current branch: do one final smoke-focused hardening pass`
-- `continue on current branch until the milestone is worthwhile: finish the remaining recoverable-diagnostics follow-through`
-
-Use the second form when you want Codex to keep multiple safe same-lane slices together until the branch feels like a real milestone rather than stopping after the first clean revision.
+- `continue on current branch: finish the approved validator follow-through`
+- `Workflow mode on current branch: execute Phase 2 of canon reconstruction`
 
 ### Run A Narrow Fix Pass
 
@@ -187,20 +198,14 @@ Use:
 
 - `Workflow mode: fix [bug] on current branch`
 
+This recipe is for approved execution work.
+It is not the default posture for system analysis.
+
 Useful add-ons:
 
 - `do not widen scope`
 - `use helper if needed`
 - `self-validate before handoff`
-
-### Run Desktop Runtime Tests Reliably
-
-When the task needs Codex to launch the Nexus desktop runtime for testing, the safe default is:
-
-- use the approved launcher helper in `dev/launchers/`
-- or launch `desktop/orin_desktop_launcher.pyw` directly through `pythonw.exe`
-
-Codex should not rely on ad hoc raw `wscript.exe` shell launches for test automation, because path-with-spaces failures can create misleading Windows Script Host errors unrelated to the actual product behavior.
 
 ### Review A Returned User Test Summary
 
@@ -212,18 +217,7 @@ or:
 
 - `use latest User Test Summary as authoritative and continue`
 
-### Run A Docs-Only Pass
-
-Use:
-
-- `docs-only pass: [exact truth change]`
-
-Examples:
-
-- `docs-only pass: add prompt recipes for same-branch workflow`
-- `docs-only pass: clarify helper decision rules`
-
-### Ask For A Ready-To-Use Prompt
+### Ask For A Prompt
 
 Use:
 
@@ -231,110 +225,43 @@ Use:
 
 Examples:
 
-- `give me a prompt for ChatGPT to fix zero-match safety on the current branch`
-- `give me a prompt for ChatGPT to analyze merge readiness`
+- `give me a prompt for ChatGPT to analyze post-release canon drift`
+- `give me a prompt for ChatGPT to execute the approved docs-only phase`
 
-### Publish Completed Work
+## Fresh-Branch Rule
 
-Use:
+After a workstream is closed, released, merged, or otherwise no longer the right execution base, the next workstream should start from updated `main` on a fresh branch.
 
-- `commit and push`
+Prompting should reflect that reality.
 
-If you want more safety, use:
-
-- `review current branch, then commit and push if clean`
-
-### Ask For A Merge-Readiness Review
-
-Use:
-
-- `Analyze and Report: merge readiness for current branch`
-
-Useful add-ons:
-
-- `analysis only`
-- `no PR/release output`
-
-### Ask For A Branch Plan
-
-Use:
-
-- `analysis-to-plan pass: [goal]`
-
-Examples:
-
-- `analysis-to-plan pass: improve Codex operator workflow`
-- `analysis-to-plan pass: choose the next FB-027 interaction lane`
-
-## High-Value Special Cases
-
-### Latest User Test Summary
-
-When handing back a filled `User Test Summary.txt`, the strongest short prompt is usually:
-
-- `use latest User Test Summary as authoritative and continue`
-
-If needed, add one anchor:
-
-- `use latest User Test Summary as authoritative and continue on click-away mirroring`
-
-Codex should then:
-
-- digest what passed
-- digest what failed
-- identify what remains unclear
-- separate current-slice work from later ideas
-- recommend the next move using repo truth
-
-### Same-Branch Continuation
-
-When you want Codex to stay on the same branch, the strongest short prompts are:
-
-- `continue on current branch: [exact task]`
-- `Workflow mode on current branch: [exact task]`
-
-This keeps branch churn low while still preserving scope.
-
-### Review And Readiness
-
-Good short prompts for review:
-
-- `Analyze and Report: is this merge-ready`
-- `Analyze for drift: current branch before merge`
-- `review latest User Test Summary to files-of-truth standards`
-
-Good short prompts for implementation:
-
-- `Workflow mode: finish Issue 1 on current branch`
-- `Workflow mode: do a tiny docs-only pass for shorthand prompt guidance`
+Do not ask Codex to keep planning from an old lane branch when live repo truth shows that branch is stale, merged, or identical to `main`.
 
 ## When To Use A Longer Prompt
 
 Use a longer structured prompt when:
 
-- the branch state may be stale or ambiguous
-- you need very tight in-scope and out-of-scope boundaries
-- the task spans more than one approval-sensitive step
-- the work could affect release/readiness, backlog, or source-of-truth canon significantly
-- the work involves many exact files, helper paths, or validation expectations
+- the branch or release state may be stale
+- the task spans multiple authority layers
+- the work could affect canon, governance, routing, backlog, or roadmap behavior
+- the exact approved execution boundary matters
+- validation expectations are unusually specific
 
-If the task is simple, a short prompt is usually enough.
-If the task has hidden risk, a longer prompt is worth it.
+Use a shorter prompt when the task is already well anchored and the current thread or canon makes the target obvious.
+
+The key distinction is prompt length, not analysis depth.
 
 ## Best Operator Habits
 
-These habits will make the system easier to use:
-
-- prefer one cue plus one anchor over very long prompts by default
-- add one control add-on only when scope or validation is easy to misunderstand
-- use `Analyze for drift` before merge, release, or major docs carry-forward decisions
-- use `use latest User Test Summary as authoritative` whenever returned testing should control the next move
-- use `give me a prompt for ChatGPT to ...` whenever you want a reusable handoff prompt instead of rebuilding one manually
-- keep using the desktop shortcut to the live guide so updates in repo truth stay visible without duplicating guidance
+- use one cue plus one anchor by default
+- add control language only when it materially protects truth or scope
+- use `Analyze for drift` before merge, release, or major canon carry-forward decisions
+- use `use latest User Test Summary as authoritative` when returned validation evidence should control the next move
+- route through `Docs/Main.md` whenever authority is unclear
+- treat local unmerged overlays as reference material until revalidated against updated `origin/main`
 
 ## What This Guide Does Not Do
 
-This guide does not make two-word prompts universally safe with no anchor at all.
+This guide does not make vague prompts universally safe.
 
 It also does not remove:
 
@@ -342,5 +269,6 @@ It also does not remove:
 - backlog control
 - scope control
 - validation requirements
+- branch and release truth checks
 
-The goal is lower prompt burden with the same discipline, not lower discipline with shorter prompts.
+The goal is lower prompt overhead with the same analytical rigor, not lower rigor with shorter prompts.

--- a/Docs/development_rules.md
+++ b/Docs/development_rules.md
@@ -1,105 +1,127 @@
-# Jarvis Development Rules
+# Nexus Development Rules
 
 ## Core Principles
 
-- One fix per revision
-- No regressions
-- Latest files are the only source of truth
-- Identical source filenames only (do not create versioned code files)
-- Generated runtime and crash artifacts may use Run ID-based filenames
+- Analyze first
+- Validate live repo truth before making lane, branch, merge, or release recommendations
+- One coherent approved change per revision
+- Preserve architecture boundaries
+- Logs, code, and merged docs are the source of truth for implemented behavior
+- No silent scope expansion
+- No silent backlog or policy drift
 
-## Workflow
+## Analysis-First Operating Posture
 
-1. Analyze first
-2. Patch second
-3. Verify the exact failure path before changing logic
-4. No blind iteration
-5. Run a post-revision Analyze pass before recommending the next revision
+Codex is a full-scan analyst before it becomes an executor.
+
+That means Codex must:
+
+- scan broadly enough to understand the whole affected system
+- validate current repo truth
+- surface drift, risk, dependencies, and options
+- only narrow scope after the analysis is complete and the user approves execution boundaries
+
+Execution language such as:
+
+- `minimal`
+- `smallest safe slice`
+- `narrow`
+- `single patch`
+
+belongs to execution planning after analysis, not to the initial investigative posture.
 
 Short prompts, shorthand cues, or mode-only requests do not waive source-of-truth reading.
 
-If the user gives a brief cue such as:
+## Live-State Validation Gate
 
-- `Analyze and Report`
-- `Analyze for drift`
-- `Workflow Mode`
-- `docs-only pass`
-- `reference docs for the following`
+Before recommending the next move after a merge, release, or major lane transition, validate:
 
-Codex must still load the default truth baseline from `docs/Main.md`, then add the directly relevant canonical docs and evidence inputs needed for the task.
+- current branch
+- local `main` versus `origin/main`
+- whether referenced PRs are actually merged
+- whether referenced branches still exist
+- latest public tag or release versus current `main`
+- whether docs and canon reflect live repo truth
 
-## Canon Freshness Gate
+If prompt framing is stale, report the real state first and plan from that state.
 
-For routine Nexus `pre-Beta` implementation work:
+## Source-Of-Truth Ownership Model
 
-- do not let supporting canon drift until after release and then clean it up with a separate docs-only refresh branch by default
-- supporting canon for an active lane must be synced on the implementation branch itself before PR packaging
-- if a just-finished released lane needs lifecycle closure in canon, that closure should normally be the first docs-only step on the next implementation branch rather than a standalone docs-only cleanup branch
-- use a standalone docs-only roadmap or drift-refresh branch only as an explicit exception after telling the user why no safe next implementation branch can yet be chosen
+Use this layered ownership model:
 
-Supporting canon means only the directly relevant truth docs for the active lane, such as:
+- backlog = identity and registry
+- workstream docs = planning, execution, validation, and closure truth for promoted work
+- roadmap = sequencing and release posture
+- rebaselines and closeouts = epoch or milestone summaries
+- incident patterns = generalized reusable lessons
+- bugs = backlog-first, with promoted bug docs only when warranted
+- User Test Summary = validation-contract layer owned by workstreams
+- `Docs/Main.md` = routing authority aligned to merged truth
 
-- `docs/prebeta_roadmap.md` for lane lifecycle, release floor, target version, and release state
-- `docs/feature_backlog.md` for per-item state and version truth
-- `docs/development_rules.md` and `docs/architecture.md` for implemented boundary changes
+Use these lifecycle fields:
 
-This rule does not authorize broad docs cleanup.
-It only requires the minimum directly supporting canon sync needed so PR-readiness, release-readiness, and next-branch planning all start from current truth.
+- `Status` = delivery or work state
+- `Record State` = canonical-record lifecycle
 
-## Pre-Patch Investigation Gate
+Allowed `Record State` values are:
 
-For runtime bugs, behavior regressions, systems investigations, architecture-sensitive work, or readiness/risk analysis that could lead directly to patching, Codex must complete pre-patch investigation before editing.
+- `Registry-only`
+- `Promoted`
+- `Closed`
 
-The detailed workflow contract for that deeper investigation belongs in `docs/codex_modes.md`.
+Rules:
 
-## Workstream Organization
+- if `Record State` is not `Registry-only`, `Canonical Workstream Doc` must exist
+- closed workstream docs stay at stable paths
+- backlog and roadmap must not continue carrying the full execution story once a canonical workstream doc exists
 
-During `pre-Beta`, the project may organize work through grouped workstreams by category or subsystem when that is the clearest way to support multi-developer progress.
+## Branch And Lane Governance
 
-Examples may include:
+PR-readiness is not the default checkpoint after a clean slice.
 
-- interaction work
-- UI / UX work
-- diagnostics / tooling work
-- release-prep or repo-admin work
-- workflow or GitHub-infrastructure work
+Default checkpoint:
 
-This grouping rule does not replace one-fix-per-revision discipline.
+- branch-level lane evaluation
 
-It means:
+Stay inside the active grouped lane until one of these is true:
 
-- the branch or workstream may group related ideas under one coherent lane
-- each approved revision or patch inside that lane must still stay narrow, validated, and architecture-safe
-- unrelated categories must not be silently mixed just because they are all "nice to do"
+- the milestone threshold is satisfied
+- a real blocker appears
+- the next work crosses subsystem boundaries
+- the user explicitly stops
 
-The purpose of grouped workstreams is:
+After a lane is closed:
 
-- clearer backlog-to-branch mapping
-- cleaner multi-developer coordination
-- less churn from fragmenting every release into isolated micro-branches when the work is obviously part of one coherent lane
+- the next workstream must start from updated `main` on a fresh branch
 
-Until `Beta`, grouped workstreams are allowed when they remain coherent by subsystem and end-state.
+If a branch becomes:
 
-At `Beta` and later, the default planning posture should shift back toward narrower:
+- stale
+- merged
+- identical to `main`
 
-- issue branches
-- bug-fix branches
-- single-idea follow-through branches
+Codex must call that out explicitly and recommend a fresh branch from updated `main`.
 
-unless a grouped workstream is explicitly justified.
+## Canon Freshness Rules
+
+Supporting canon must stay aligned with live truth.
+
+That means:
+
+- directly supporting canon may be updated on the active implementation branch when that branch changes the truth
+- docs-only canon reconstruction is also valid when no safe implementation lane should be selected until canon is trustworthy
+- do not force post-release canon repair onto a hypothetical next implementation branch when the truthful next move is a docs-only canon pass
+- do not use canon sync as an excuse for broad unrelated documentation churn
+
+Local docs overlays are reference material only until revalidated against updated `origin/main`.
 
 ## Change Discipline
 
-- Changes must be minimal and isolated
-- Preserve architecture boundaries
-- Do not mix multiple behaviors into one revision
-
-In Jarvis workflow terms:
-
-- one fix per revision means one coherent approved subproblem per revision, not one tiny mechanical fragment
-- minimal isolated changes means the minimal coherent approved change set needed to close that subproblem
-- multiple revisions may still live inside one grouped implementation branch when they are tightly coupled to one milestone
-- except for docs-only governance or rebaseline branches, a `pre-Beta` branch should usually target one version-bearing milestone rather than a merge-only code delta
+- one fix per revision means one coherent approved subproblem per revision
+- minimal isolated changes means the minimal coherent change set needed to close that approved subproblem
+- grouped workstreams are allowed during `pre-Beta` when they remain coherent by subsystem and end-state
+- a grouped branch may carry multiple validated slices when they all belong to the same milestone
+- unrelated ideas must still be split out even if they look convenient to batch
 
 Use the smallest safe slice for:
 
@@ -109,329 +131,97 @@ Use the smallest safe slice for:
 
 Use the smallest coherent slice for:
 
-- lower-risk post-boundary feature delivery where a smaller fragment would leave an incomplete first deliverable
+- lower-risk follow-through inside an already-approved milestone when a smaller fragment would leave the milestone incomplete
 
-## Branch Sizing Rule
+These are execution rules, not analysis-stop rules.
 
-For `pre-Beta` non-doc implementation work, revision sizing and branch sizing are separate decisions.
-
-- revision sizing chooses the smallest safe slice needed to make architecture-safe progress inside the approved milestone
-- branch sizing chooses the smallest worthwhile milestone strong enough to justify the branch's declared release floor
-
-A worthwhile milestone means:
-
-- if the branch were squashed and merged as one commit, it would still read as a meaningful implementation increment rather than as a setup fragment, validator-only stub, or bookkeeping-only follow-through
-- the branch would materially improve current repo truth, future planning baseline, or shipped operator value
-- the branch would still feel strong enough to justify its declared prerelease floor rather than reading like a merge-only delta
-
-Therefore:
-
-- do not stop a non-doc implementation branch just because the first safe slice validates
-- keep tightly coupled follow-through on the same branch when it is still required to make that milestone feel complete
-- stop only when the milestone is complete, a real blocker appears, the next work would cross subsystem boundaries, or the user explicitly chooses to stop early
-
-## Testing Requirements
+## Testing And Validation
 
 Every revision must include:
 
-- Healthy path verification
-- Failure or edge-case verification (if applicable)
-- Runtime log review
-- Crash log review (if present)
-- Artifact cleanup verification
+- healthy-path verification
+- failure or edge-case verification when relevant
+- runtime log review
+- crash log review when present
+- artifact cleanup verification when relevant
 
 Before handing a user-visible runtime, UI, or manual validation path back to the user, Codex must run that same path or the closest faithful equivalent when feasible.
 
-If Codex cannot self-run the same path reliably, Codex must say so explicitly and identify the exact validation gap rather than implying the path was personally verified.
+If Codex cannot self-run the same path reliably, it must say so explicitly and identify the remaining validation gap.
 
-For Nexus desktop-runtime testing, Codex must not use fragile ad hoc shell invocations such as raw `wscript.exe` path calls against launchers with spaces in their path.
+## Runtime Evidence And Logging
 
-Codex should prefer:
+- logs are the source of truth for runtime behavior
+- do not assume behavior without log or code evidence
+- prefer structured markers over raw output
 
-- an approved launcher helper under `dev/launchers/`
-- or direct `pythonw.exe` launch of `desktop/orin_desktop_launcher.pyw`
+### Root Logs Governance
 
-If Codex uses a launcher helper for testing, that helper becomes the default testing launch path unless the active task explicitly requires validating the user-facing desktop shortcut or VBS wrapper itself.
+- `C:/Jarvis/logs` and `C:/Jarvis/logs/crash` remain reserved for approved live launcher and runtime truth surfaces only
+- launcher-owned historical state is not a root-owned live logs surface
+- normal runtime historical state resolves under `%LOCALAPPDATA%/Nexus Desktop AI/state/jarvis_history_v1.jsonl`
+- dev, test, worker, and toolkit evidence must write under `C:/Jarvis/dev/logs/<lane>/...`
+- no new dev or worker evidence roots may be introduced under `C:/Jarvis/logs` without explicit approval
 
-## Standard Analyze Pass
+### Dev-Only Startup Snapshot Harness
 
-After every revision, review:
-
-- the newest runtime log
-- the newest crash log, if one exists
-- `diagnostics_status.txt`
-- `diagnostics_stop.signal` and `renderer_startup_abort.signal` when relevant
-- the exact startup, shutdown, failure, or recovery milestones reached
-- whether observed behavior matches the intended revision scope
-- whether any regression markers appeared
-
-## Logging Philosophy
-
-- Logs are the source of truth
-- Do not assume behavior without log evidence
-- Prefer structured markers over raw output
-
-## Root Logs Governance
-
-- `C:/Jarvis/logs` and `C:/Jarvis/logs/crash` are reserved for already-approved live launcher/runtime truth surfaces only
-- current approved root-owned surfaces are:
-  - launcher-generated `Runtime_*.txt`
-  - matching live crash logs
-  - launcher control/status files when relevant
-- launcher-owned historical state is no longer a root-owned live surface
-- normal runtime historical state now resolves under `%LOCALAPPDATA%/Nexus Desktop AI/state/jarvis_history_v1.jsonl`
-- contained harness runs may still keep historical state under the contained harness log root to preserve harness isolation
-- dev/test/worker/toolkit evidence must write under `C:/Jarvis/dev/logs/<lane>/...`
-- no new dev/test/worker evidence roots, new subfolders, or new artifact families may be introduced under `C:/Jarvis/logs` or `C:/Jarvis/logs/crash` without explicit user approval
-
-## Dev-Only Startup Snapshot Harness
-
-For desktop attach, first-visible frame, or startup-freeze debugging, Codex may use the env-gated startup snapshot harness in the desktop renderer when that is the smallest reliable evidence path.
+For startup-state debugging, Codex may use the env-gated startup snapshot harness when it is the smallest reliable evidence path.
 
 Rules:
 
 - the harness must remain opt-in through `JARVIS_HARNESS_STARTUP_SNAPSHOT_DIR`
-- snapshot output must write to an explicitly chosen dev/test evidence path, not to root `logs`
-- the harness is for internal debugging only and must not become normal user-facing behavior
-- snapshot timing should stay bounded to the startup window under investigation
+- snapshot output must write to an explicitly chosen dev evidence path, not root logs
+- the harness is internal debugging infrastructure only
 - if the harness is not needed for the active task, leave it disabled
-
-## Orchestration Philosophy
-
-Build in this order:
-
-1. Observability (know what is happening)
-2. Classification (know what state it is in)
-3. Control (safe ability to intervene)
-4. Outcome clarity (know what happened)
-5. Behavior (decide what to do)
-
-Never skip a stage.
-
-## Scope Control
-
-Do NOT mix into orchestration revisions:
-
-- UI changes
-- Voice system changes
-- Feature development
-- Folder restructuring
-- `main.py` redesign
-
-These are separate phases.
-
-## Controlled Improvement Suggestions
-
-If you identify a potential improvement while analyzing or implementing a revision:
-
-- Do NOT include it in the current patch
-- Do NOT expand the scope of the current revision
-- Do NOT combine it with the active change
-
-Instead:
-
-1. Clearly call out the improvement separately
-2. Explain why it is beneficial
-3. Propose it as a future revision
-4. Keep it within one-fix-per-revision discipline
-
-Example format:
-
-Suggested Future Revision:
-
-- Description of the improvement
-- Why it should be done
-- Which files would likely be affected
-- Why it is not included in the current revision
-
-## Rule
-
-Improvements must be proposed, not silently implemented.
-
-Scope expansion without explicit approval is not allowed.
-
-## Goal
-
-Jarvis must behave as a:
-
-- Observable system
-- Controllable system
-- Self-correcting system
-
-Not a black box.
-
-## Versioning Philosophy
-
-Each version should focus on a single system layer.
-
-Examples:
-
-- Logging work should focus on observability and traceability
-- Orchestration work should focus on startup control, recovery, and lifecycle behavior
-- Behavior work should focus on decision-making and policy
-
-Do not mix major system layers across versions unless explicitly planned as a dedicated transition.
-
-Each revision (`revX`) must introduce only one controlled change within that version's scope.
-
-## Documentation Rule
-
-Important architecture, orchestration, and behavior decisions should be written into repo docs rather than left only in chat history.
-
-Project docs are part of the source of truth and should be read before planning future revisions.
-
-Use `docs/Main.md` as the source-of-truth index and prompt-baseline map for future Jarvis tasks.
-
-When a workstream has a consolidated canonical planning or design doc, future prompts and task baselines should prefer that canonical doc over the full stack of superseded slice docs.
-
-Superseded slice docs may still be used for historical traceability, earlier revision review, or conflict checking, but they should not continue to be listed as equal-weight prompt inputs once a canonical consolidation exists.
-
-Future prompts should usually prefer:
-
-- `docs/development_rules.md`
-- `docs/Main.md`
-- only the directly relevant canonical doc or docs
-- only the relevant evidence inputs
-
-Closeout docs, historical docs, and optional planning references should be added only when the task materially depends on them.
-
-Core code progression is prioritized over repeated separate doc-only micro-passes.
-
-When a code workstream directly establishes or changes truth that should be recorded, the required truth-doc updates may be bundled into that same approved workstream if:
-
-- the doc updates directly support or record the active code task
-- the edits do not widen architecture or backlog scope
-- batching the doc sync keeps the repo more accurate than delaying it
-
-Prefer milestone-level or canonical doc sync when meaningful, rather than forcing repeated separate micro-passes for every small code slice, unless a docs-only clarification is the safest boundary-setting move.
-
-When using Codex or ChatGPT for project tasks, prefer the structured prompt format in `docs/orin_task_template.md` so requests include clear goal, context, evidence, constraints, allowed surfaces, and done-when criteria.
 
 ## Historical Intelligence Rules
 
-Cross-run intelligence must be contract-defined in repo docs before implementation begins.
+Cross-run intelligence must stay contract-defined in repo docs before implementation changes begin.
 
 That contract must define:
 
-- versioned history schema
-- run identity rules
+- schema and versioning
+- run identity
 - failure fingerprint rules
 - provenance labeling
 - retention and reset behavior
 - corruption and fallback behavior
 
-Historical intelligence must remain a derived layer over current-run truth.
-It must not become a second source of runtime truth.
+Historical intelligence must remain explainable and deterministic rather than becoming a second hidden truth source.
 
-Confidence may be used only as explanatory metadata.
-It must never be treated as authoritative runtime policy.
+## Documentation And Carry-Forward Review
 
-If historical state is missing, unreadable, or corrupt, the system must degrade cleanly to the last finalized non-historical behavior.
+Important architecture, orchestration, planning, and validation decisions should live in repo docs rather than only in chat history.
 
-## Backlog Integration
+For every post-merge, post-release, or next-lane review, classify prior recommendations as:
 
-If a new idea or improvement is identified:
+- carry forward
+- defer
+- discard
 
-- It must be added to docs/feature_backlog.md
-- It must NOT be implemented immediately
-- It must be assigned a suggested version and revision
-- It must follow one-fix-per-revision discipline
+Never treat prior suggestions as automatic scope.
 
-Ideas are only implemented after being explicitly selected from the backlog.
+Use `Docs/Main.md` as the routing index for the merged canon.
 
-## Backlog Control
+## Backlog Governance
 
-The backlog file (docs/feature_backlog.md) is the controlled planning layer for future work.
-
-### Codex Permissions
-
-Codex may:
-- propose new backlog items
-- format backlog entries
-- suggest updates to backlog items
-
-Codex may NOT:
-- silently edit the backlog
-- mark items complete without approval
-- change status of existing items without approval
-- reorder or reprioritize items
-- delete backlog items
-
-Backlog state changes must be explicitly approved and performed by the user.
-
-### Required Backlog Workflow
-
-If a new idea, improvement, or follow-up work is identified:
-
-1. Codex must propose a backlog update first
-2. The proposal must include:
-   - Type (new item / status update / notes / completion)
-   - Title
-   - Reason
-   - Exact markdown change
-3. Codex must wait for explicit user approval
-4. Only after approval may Codex edit docs/feature_backlog.md
-
-### Execution Rules
-
-- Backlog updates must remain minimal and scoped
-- Backlog changes may be made alongside other files ONLY after approval
-- If no backlog update is required, do not modify the backlog
-
-### Control Principle
-
-The backlog is a planning and control layer.
-
-Codex assists in managing it, but the user retains final authority over:
-- prioritization
-- status changes
-- completion
-
-## Backlog Grouping And Planning Rule
-
-When planning future work, Codex may scan the backlog for related ideas by type or subsystem so the user can choose a more organized workstream model.
-
-Examples:
-
-- several UI / UX ideas grouped into one UI / UX lane
-- several interaction-surface ideas grouped into one interaction lane
-- several workflow / tooling ideas grouped into one infrastructure lane
+`Docs/feature_backlog.md` is a controlled registry layer.
 
 Codex may:
 
-- identify clusters of related ideas
-- recommend a grouped workstream branch
-- suggest which items should travel together versus stay separate
+- propose backlog changes
+- draft exact backlog markdown for approval
+- carry approved state changes during an explicitly authorized docs pass
 
 Codex may not:
 
-- silently reorder backlog items into categories
-- silently relabel backlog status or priority
-- silently create a new grouped workstream in backlog truth without approval
+- silently add backlog items
+- silently change priority or status outside approved work
+- silently mark work complete because a branch merely looks clean
 
-Grouped-workstream planning must still preserve:
+## Relationship To `Docs/orin_task_template.md`
 
-- backlog control
-- explicit user approval
-- clear subsystem boundaries
-- minimal per-revision scope inside the larger lane
+`Docs/orin_task_template.md` remains the per-task execution scaffold.
 
-## GitHub / Tooling Expansion Rule
-
-Potential GitHub follow-through such as:
-
-- repo scripts
-- helper automation
-- bots
-- workflow tooling
-- multi-developer coordination helpers
-
-should be treated as explicit infrastructure work, not as silent side work attached to product slices.
-
-Codex may recommend those expansions when they materially improve project organization, validation, or collaboration.
-
-Codex must not silently add them without:
-
-- a clear explanation of why they are worth adding
-- a recommendation for where they belong
-- explicit user approval for the resulting workstream
+This document defines repo-wide rules.
+The task template defines the structure of a specific request.

--- a/Docs/feature_backlog.md
+++ b/Docs/feature_backlog.md
@@ -1,1619 +1,358 @@
-# Jarvis Feature Backlog
+# Nexus Feature Backlog
 
-This file is the controlled backlog for future revisions and ideas.
+This file is the controlled registry for tracked work, deferred planning items, historical implemented items, and future promoted bug identities.
 
 Rules:
-- Ideas must NOT be implemented immediately
-- Ideas must NOT expand current revision scope
-- Ideas must be proposed as future revisions
-- Each idea should remain small and scoped when possible
-- All backlog changes must follow the backlog control rules defined in development_rules.md
-- Backlog items must not be added, modified, or completed without approval
 
----
+- ideas must not be implemented immediately
+- ideas must not silently expand current scope
+- backlog identity remains controlled and approval-gated
+- `Status` is the delivery or work field
+- `Record State` is the canonical-record lifecycle field
+- allowed `Record State` values are `Registry-only`, `Promoted`, and `Closed`
+- if `Record State` is not `Registry-only`, `Canonical Workstream Doc` must exist
+- backlog entries keep the short registry story, not the full execution story
 
-## Backlog Items
+Historical note:
 
-### [ID: FB-001] Repeated identical crash early escalation
+- older implemented entries may preserve older Jarvis-era titles as historical identity
+- those preserved titles are not current runtime-path claims
 
-Status: Implemented (v1.6.0)  
-Priority: Medium  
-Suggested Version: v1.6.0  
-Suggested Revision: rev12  
-
-Description:
-Add early escalation when two consecutive startup attempts fail with the same normalized crash outcome.
-
-Why it matters:
-Repeated identical crashes are a stronger signal than generic failures and should not silently consume retries.
-
-Proposed Change:
-If two consecutive non-STARTUP_ABORT attempts have the same normalized failure_cause, stop retries and escalate.
-
-Likely Files Affected:
-- jarvis_desktop_launcher.pyw
-
-Scope:
-- launcher-only
-- repeated identical crash handling
-
-Out of Scope:
-- mixed-pattern policy
-- startup-abort policy changes
-
-Notes:
-This should remain a narrow escalation rule for repeated identical crash outcomes only.
-
----
-
-### [ID: FB-002] Mixed failure-pattern policy
-
-Status: Implemented (v1.6.0)  
-Priority: Medium  
-Suggested Version: v1.6.0  
-Suggested Revision: TBD  
-
-Description:
-Define behavior for mixed failure sequences such as crash then abort or abort then crash.
-
-Why it matters:
-Mixed failure patterns may indicate unstable startup conditions, but they are weaker signals than repeated identical failures and need careful classification.
-
-Proposed Change:
-Classify mixed failure sequences separately from repeated identical crash or repeated STARTUP_ABORT outcomes and define whether they should continue retrying or escalate earlier.
-
-Likely Files Affected:
-- jarvis_desktop_launcher.pyw
-
-Scope:
-- launcher-only
-- mixed failure-sequence classification
-- conservative escalation guidance
-
-Out of Scope:
-- repeated identical crash policy
-- repeated STARTUP_ABORT policy
-- renderer changes
-
-Notes:
-This conservative mixed-sequence contract is already satisfied by the stabilized `v1.6.0` launcher behavior. Current launcher behavior recognizes `CRASH_TO_STARTUP_ABORT` and `STARTUP_ABORT_TO_CRASH`, keeps first-observed cross-kind sequences non-terminal, allows them to feed instability labeling, diagnostics-priority reporting, and attempt-pattern reporting, and does not treat them as a new early-exhaustion trigger. Conservative retry continuation remains in place unless an existing `FB-003` terminal class is reached.
-
----
-
-### [ID: FB-003] Retry limit and diagnostics escalation policy
-
-Status: Implemented (v1.9.0 rev1)  
-Priority: Medium  
-Suggested Version: v1.9.0  
-Suggested Revision: rev1  
-
-Description:
-Define when repeated failures should escalate to diagnostics instead of continuing to retry.
-
-Why it matters:
-The launcher should avoid silent recovery loops and should escalate in a predictable, evidence-based way when retries stop adding value.
-
-Proposed Change:
-Refine retry-limit behavior and define clear thresholds for entering the existing diagnostics completion path based on observed repeated failure patterns.
-
-Likely Files Affected:
-- jarvis_desktop_launcher.pyw
-
-Scope:
-- launcher-only
-- retry and diagnostics escalation boundaries
-
-Out of Scope:
-- diagnostics UI redesign
-- renderer changes
-- broad orchestration refactor
-
-Notes:
-This is now implemented through `v1.9.0` `rev1a` and `rev1b`. `rev1a` defined the retry-exhaustion and diagnostics-entry policy contract for repeated `STARTUP_ABORT` outcomes and repeated identical crash outcomes only. `rev1b` implemented the first coherent launcher behavior slice so those two evidence classes now terminate as first-class outcomes, propagate actual attempts used into terminal finalization and runtime summary output, use reason-correct terminal wording, and reuse the existing diagnostics completion path unchanged. Mixed failure-sequence policy remains separate `FB-002` work.
-
----
+## Registry Items
 
 ### [ID: FB-004] Future boot orchestrator layer
 
-Status: Deferred (planning groundwork complete enough to pause)  
-Priority: High  
-Suggested Version: v2.0  
-Suggested Revision: rev1  
-Release Stage: Slice-staged  
-
-Description:
-Design and later implement top-level boot orchestration above the desktop launcher.
-
-Why it matters:
-The long-term product direction is for Jarvis to feel like the system-facing experience, with a higher-level boot flow coordinating the transition into the stabilized desktop phase.
-
-Proposed Change:
-For current repo truth, establish the minimal future boot-orchestrator planning model without authorizing runtime implementation, then defer later implementation-facing work until a separate explicitly approved slice.
-
-Likely Files Affected:
-- main.py
-- launch_jarvis_desktop.vbs
-- desktop launcher entry files
-- orchestration documentation
-
-Scope:
-- top-level boot orchestration design
-- startup-to-desktop phase coordination
-
-Out of Scope:
-- current desktop-phase launcher stabilization
-- folder reorganization
-- voice or UI feature expansion
-
-Notes:
-Current planning truth already includes the minimal future boot-orchestrator stage model in `docs/architecture.md` and aligned boot-access planning language in `docs/boot_access_design.md`. That completed groundwork is now complete enough to pause. This item therefore remains deferred only for later implementation-facing planning or runtime work and should not be mixed into current desktop orchestration revisions.
-
-Additional future-product requirement now preserved:
-
-- before `Beta`, the Boot portion of Nexus Desktop AI should become a user-controlled preference rather than an assumed default path
-- if enabling that Boot path requires Windows login, startup, or boot-configuration changes, the product should provide a detailed guided setup flow rather than relying on ad hoc manual system changes
-- that enable/disable and setup model remains future planning only until a dedicated boot/setup slice is explicitly selected
-
-Release-stage mapping:
-
-- completed planning groundwork is historical completion, not future-stage work
-- later internal implementation-facing groundwork belongs to `pre-Beta`
-- any later packaged or installable user-facing boot-orchestrator delivery belongs no earlier than `Beta`
-- broader mature boot-layer delivery belongs to `Full`
-
----
+Status: Deferred (planning groundwork complete enough to pause)
+Record State: Registry-only
+Priority: High
+Release Stage: Slice-staged
+Target Version: v2.0
+Summary: Preserve the future top-level boot-orchestrator direction above the desktop launcher without authorizing runtime delivery yet.
+Why it matters: Keeps the longer-term boot-to-desktop product direction explicit while current desktop and diagnostics work stays bounded.
 
 ### [ID: FB-005] Workspace and folder organization
 
-Status: Deferred (partial implementation through Step 4)  
-Priority: Low  
-Suggested Version: v2.0  
-Suggested Revision: rev1  
-Release Stage: Slice-staged  
-
-Description:
-Continue staged project-directory cleanup for clarity and scalability while keeping top-level entrypoint and broader workspace restructuring deferred.
-
-Why it matters:
-As the project grows, clearer folder boundaries will make ownership, startup flow, audio systems, diagnostics, and future subsystems easier to maintain.
-
-Proposed Change:
-Carry workspace organization only through explicitly approved, path-sensitive slices rather than broad folder cleanup.
-
-Likely Files Affected:
-- multiple project directories
-- startup scripts
-- documentation references
-
-Scope:
-- folder and workspace organization
-- path cleanup required by the reorganization
-
-Out of Scope:
-- orchestration policy changes
-- feature additions
-- unrelated refactors
-
-Notes:
-Current repo truth no longer reflects an untouched deferred item.
-Completed slices now include:
-
-- Step 3: `jarvis_desktop_main.py` and `jarvis_desktop_test.py` moved under `desktop/`, and the launcher's target-script assumption now points at the moved desktop entrypoint
-- Step 4: `jarvis_voice.py` moved under `Audio/` as `Audio/jarvis_voice.py`
-- Step 4: `main.py` now imports `Audio.jarvis_voice`
-- Step 4: the launcher-owned diagnostics/error voice path remained valid and unchanged at `Audio/jarvis_error_voice.py`
-
-Step 5 and broader workspace work remain intentionally deferred.
-That means:
-
-- the current `FB-005` workspace slice is closed at the completed Step 4 boundary
-- `main.py` remains root-owned
-- `launch_jarvis_desktop.vbs` remains root-owned
-- the remaining root-owned entrypoint boundary no longer belongs to the active workspace-cleanup lane and should be treated as later boot / entrypoint-ownership work outside `FB-005`
-- broader folder cleanup, broader `Audio` casing normalization, and `logs/` reorganization remain out of scope until a later explicitly approved slice
-
-Release-stage mapping:
-
-- completed Steps 3 and 4 are historical completion, not future-stage work
-- Step 5 is a later `pre-Beta` internal path-shaping slice if intentionally resumed
-- broader workspace follow-through should remain separately approved rather than being treated as an automatic `Beta` or `Full` product feature lane
-
----
-
-### [ID: FB-006] Threshold-based recovery outcome summary refinement
-
-Status: Implemented (v1.6.0)  
-Priority: Low  
-Suggested Version: v1.6.0  
-Suggested Revision: TBD  
-
-Description:
-Refine final runtime and crash summaries so threshold-based early escalations are described differently from max-attempt exhaustion.
-
-Why it matters:
-Current final artifacts still use a generic recovery-outcome sentence even when recovery stopped early due to a specific launcher threshold.
-
-Proposed Change:
-Adjust launcher-generated summary wording so repeated STARTUP_ABORT escalation and repeated identical crash escalation produce threshold-specific recovery outcome text.
-
-Likely Files Affected:
-- jarvis_desktop_launcher.pyw
-
-Scope:
-- launcher-only
-- summary wording refinement
-
-Out of Scope:
-- retry policy changes
-- diagnostics UI changes
-- renderer changes
-
-Notes:
-This should remain a reporting refinement only and must not change launcher behavior.
-
----
-
-### [ID: FB-007] Max-attempt identical-failure attempt-pattern correction
-
-Status: Implemented (v1.6.0)  
-Priority: Low  
-Suggested Version: v1.6.0  
-Suggested Revision: TBD  
-
-Description:
-Correct the final failed-run attempt-pattern summary when all max recovery attempts end with the same non-threshold failure.
-
-Why it matters:
-The current fallback attempt-pattern wording can describe a stable repeated failure as varied, which weakens final summary accuracy.
-
-Proposed Change:
-Refine launcher attempt-pattern selection so max-attempt identical failures produce a stable repeated-failure pattern instead of the generic varied-failure pattern.
-
-Likely Files Affected:
-- jarvis_desktop_launcher.pyw
-
-Scope:
-- launcher-only
-- summary wording correction
-
-Out of Scope:
-- retry policy changes
-- threshold changes
-- diagnostics UI changes
-- renderer changes
-
-Notes:
-This should remain a reporting refinement only and must not change launcher behavior.
-
----
-
-### [ID: FB-008] Shutdown voice degradation effect
-
-Status: Implemented (v2.2.0 rev2)  
-Priority: Low  
-Suggested Version: v2.2.0  
-Suggested Revision: rev2  
-
-Description:
-Refine the existing staged degradation effect on the final "Shutting down" voice line so Jarvis sounds more convincingly like he is losing power during terminal shutdown.
-
-Why it matters:
-Shutdown-line tuning would make Jarvis feel more state-aware and physically present during failure termination without widening the diagnostics/error voice path.
-
-Proposed Change:
-Implemented model:
-- the final `Shutting down.` line remains routed through the existing dedicated shutdown-only path in `Audio/jarvis_error_voice.py`
-- the late shutdown envelope is now tuned so the collapse stays concentrated on `down` while the tail remains degraded but intelligible
-- the existing dev-only voice regression harness remains the regression guard for the launcher-owned shutdown line, and its normal-voice probe path now matches the current `Audio/jarvis_voice.py` repo layout
-
-Likely Files Affected:
-- C:/Jarvis/Audio/jarvis_error_voice.py
-- C:/Jarvis/dev/jarvis_voice_regression_harness.py
-
-Scope:
-- shutdown voice-effect refinement
-- final shutdown line only
-
-Out of Scope:
-- orchestration policy changes
-- diagnostics behavior changes
-- renderer changes
-
-Notes:
-This item is now implemented as a tiny shutdown-line-only refinement.
-Current repo truth already includes:
-
-- the pre-existing dedicated shutdown-only effect path for the final `Shutting down.` line inside the diagnostics/error voice script
-- a bounded late-tail tuning pass in `apply_shutdown_source_slowdown()` so the collapse remains focused on `down` without over-dragging the final suffix
-- a directly supportive dev-only voice-harness path correction so the normal-voice probe resolves the live `Audio/jarvis_voice.py` location
-- passing voice-regression evidence across repeated-crash, startup-abort, direct diagnostics/error probes, and direct normal-voice probe coverage
-
----
-
-### [ID: FB-009] Align crash-origin mixed markers with stable repeated-failure summaries
-
-Status: Implemented (v1.6.0)  
-Priority: Low  
-Suggested Version: v1.6.0  
-Suggested Revision: TBD  
-
-Description:
-Align mixed-pattern classification with final failed-run summaries when the failure cause stays identical across attempts but failure origin changes.
-
-Why it matters:
-The launcher can currently emit a mixed crash-pattern marker while the final summary intentionally describes the same run as a repeated identical failure, which weakens summary consistency.
-
-Proposed Change:
-Refine mixed crash-pattern classification so identical-cause runs that are intentionally summarized as repeated identical failure do not also emit a conflicting mixed-pattern interpretation unless that distinction is explicitly desired.
-
-Likely Files Affected:
-- jarvis_desktop_launcher.pyw
-
-Scope:
-- launcher-only
-- reporting and classification consistency
-
-Out of Scope:
-- retry policy changes
-- threshold changes
-- diagnostics UI changes
-- renderer changes
-
-Notes:
-This should remain a summary and classification consistency refinement only and must not change launcher behavior.
-
----
-
-### [ID: FB-010] v1.6.0 closeout and documentation sync
-
-Status: Implemented (v1.6.0)  
-Priority: Medium  
-Suggested Version: v1.6.0  
-Suggested Revision: closeout  
-
-Description:
-Synchronize source-of-truth docs and backlog history with the final rev24 orchestration state before transitioning into v1.7.0.
-
-Why it matters:
-The launcher runtime is now internally consistent and stable, but the repo docs and backlog do not yet reflect the final implemented version state. A closeout sync reduces handoff risk and prevents future work from relying on outdated version context.
-
-Proposed Change:
-Update architecture and orchestration version context, record final verified scenario coverage, and move implemented v1.6.0 backlog items into completed history.
-
-Likely Files Affected:
-- C:/Jarvis/docs/architecture.md
-- C:/Jarvis/docs/orchestration.md
-- C:/Jarvis/docs/feature_backlog.md
-- optional closeout note in C:/Jarvis/docs
-
-Scope:
-- documentation only
-- backlog history and status sync
-- version handoff clarity
-
-Out of Scope:
-- launcher policy changes
-- renderer changes
-- diagnostics UI changes
-- new orchestration behavior
-
-Notes:
-This is the documentation-only closeout pass for the finalized `v1.6.0` orchestration layer.
-
----
-
-### [ID: FB-011] Historical memory contract
-
-Status: Implemented (v1.7.0)  
-Priority: High  
-Suggested Version: v1.7.0  
-Suggested Revision: TBD  
-
-Description:
-Define the contract for a passive cross-run historical memory layer before any historical intelligence is implemented.
-
-Why it matters:
-Without a contract, later history, advisory, and diagnostics work can drift into a second truth source or become nondeterministic.
-
-Proposed Change:
-Define a versioned history schema, run identity rules, retention and reset rules, provenance requirements, and corruption fallback behavior for the cross-run memory layer.
-
-Likely Files Affected:
-- C:/Jarvis/docs/development_rules.md
-- C:/Jarvis/docs/architecture.md
-- C:/Jarvis/docs/orchestration.md
-- future historical-memory implementation files
-
-Scope:
-- planning and architecture contract
-- passive historical-memory rules
-
-Out of Scope:
-- runtime behavior changes
-- retry changes
-- escalation changes
-- boot-level control
-
-Notes:
-This contract was defined in repo docs before implementation began and remains the governing rule for `v1.7.0` historical-memory work.
-
----
-
-### [ID: FB-012] Failure fingerprint and recurrence model
-
-Status: Implemented (v1.8.0)  
-Priority: High  
-Suggested Version: v1.8.0  
-Suggested Revision: rev2  
-
-Description:
-Define how the system recognizes recurring outcomes across launches without changing the closed `v1.6.0` runtime classification model.
-
-Why it matters:
-Cross-run recurrence and trend analysis require stable fingerprint rules or historical intelligence will misclassify repeated failures.
-
-Proposed Change:
-Define failure fingerprint rules, recurrence grouping rules, and stability trend semantics for cross-run analysis using existing `v1.6.0` truth signals.
-
-Likely Files Affected:
-- C:/Jarvis/docs/architecture.md
-- C:/Jarvis/docs/orchestration.md
-- future historical-memory implementation files
-
-Scope:
-- cross-run identity
-- recurrence tracking
-- stability trend model
-
-Out of Scope:
-- runtime classification changes
-- retry changes
-- escalation changes
-
-Notes:
-This is now implemented through `v1.8.0 rev2a` and `v1.8.0 rev2b`, which together formalized the strict failure-fingerprint contract, strict recurrence equality, and deterministic recent-history stability model without reopening `v1.6.0` behavior. The next intended implementation track remains `FB-013`.
-
----
-
-### [ID: FB-013] Advisory provenance and confidence semantics
-
-Status: Implemented (v1.8.0)  
-Priority: Medium  
-Suggested Version: v1.8.0  
-Suggested Revision: rev3  
-
-Description:
-Define how advisory outputs describe provenance, confidence, and evidence quality without becoming authoritative policy.
-
-Why it matters:
-Advisory intelligence can become misleading if the system does not clearly distinguish current-run truth, historical recurrence, and inference.
-
-Proposed Change:
-Define provenance labels and confidence semantics so confidence remains explanatory only and advisory outputs remain non-binding.
-
-Likely Files Affected:
-- C:/Jarvis/docs/development_rules.md
-- C:/Jarvis/docs/orchestration.md
-- future advisory-layer implementation files
-
-Scope:
-- advisory semantics
-- provenance labels
-- confidence meaning
-
-Out of Scope:
-- behavior changes
-- retry changes
-- escalation changes
-
-Notes:
-This is now implemented through `v1.8.0 rev3a` and `v1.8.0 rev3b`, which together formalized provenance-first advisory semantics and internal-only confidence meaning without introducing surfaced confidence output, runtime coupling, or policy significance. This completes `FB-013` for `v1.8.0`.
-
----
-
-### [ID: FB-014] Multi-run orchestration regression harness
-
-Status: Implemented (v1.8.0 rev1)  
-Priority: Medium  
-Suggested Version: v1.8.0  
-Suggested Revision: rev1  
-
-Description:
-Create a reusable multi-run validation concept for historical-memory, diagnostics-enrichment, and advisory-only orchestration work.
-
-Why it matters:
-`v1.7.0` introduces cross-run reasoning, which requires repeatable multi-launch verification instead of only single-run scenario checks.
-
-Proposed Change:
-Define and later build a scenario-based regression harness that can validate recurrence, stability trends, fallback behavior, and advisory outputs across multiple launches.
-
-Likely Files Affected:
-- orchestration validation tooling
-- documentation for scenario expectations
-
-Scope:
-- validation tooling
-- multi-run scenario replay
-
-Out of Scope:
-- launcher policy changes
-- renderer behavior changes
-- UI redesign
-
-Notes:
-This was the safest first implementation target for `v1.8.0` and is now implemented as the validation-first harness foundation through rev1a, rev1b, and rev1c without reopening `v1.6.0` behavior. The next intended implementation track remains `FB-012`.
-
----
+Status: Deferred (partial implementation through Step 4)
+Record State: Registry-only
+Priority: Low
+Release Stage: Slice-staged
+Target Version: v2.0
+Summary: Continue workspace organization only through explicitly approved path-sensitive slices.
+Why it matters: Keeps folder and ownership cleanup deliberate instead of letting it blur into unrelated feature work.
 
 ### [ID: FB-015] Boot and desktop phase-boundary model
 
-Status: Deferred (rev1a clarification complete enough to pause)  
-Priority: Medium  
-Suggested Version: v2.0  
-Suggested Revision: rev1a  
-Release Stage: Slice-staged  
-
-Description:
-Define the conceptual boundary between future boot-stage orchestration and the already stabilized desktop-stage launcher layer.
-
-Why it matters:
-Later boot-level orchestration will need a clean contract for how boot-stage history, diagnostics, and advisory signals relate to desktop-stage truth.
-
-Proposed Change:
-For current repo truth, document phase-boundary rules, ownership boundaries, and downstream-input assumptions between a future boot orchestrator and the existing desktop launcher, then defer any later follow-through beyond that clarification.
-
-Likely Files Affected:
-- C:/Jarvis/docs/architecture.md
-- C:/Jarvis/docs/orchestration.md
-- future boot-orchestrator planning docs
-
-Scope:
-- architecture modeling
-- future phase-boundary preparation
-
-Out of Scope:
-- boot-level control
-- adaptive retry logic
-- launcher behavior changes
-
-Notes:
-This remains preparation work only. Current planning truth already includes the architecture-level `FB-015 rev1a` phase-boundary contract in `docs/architecture.md` plus the aligned downstream-input contract in `docs/boot_access_design.md`. That clarification work is now complete enough to pause. Any later boot-planning follow-through remains deferred, this item must not introduce boot-level runtime control, and it still does not authorize `FB-004` implementation work.
-
-Release-stage mapping:
-
-- completed `rev1a` clarification is historical completion, not future-stage work
-- any later follow-through remains `pre-Beta` internal clarification unless a separate later slice explicitly widens beyond that planning boundary
-
----
-
-### [ID: FB-016] Recorder-only historical memory groundwork
-
-Status: Implemented (v1.7.0)  
-Priority: High  
-Suggested Version: v1.7.0  
-Suggested Revision: rev1  
-
-Description:
-Implement the first passive historical-memory slice as a recorder-only layer with versioned schema scaffolding and zero readback into runtime behavior.
-
-Why it matters:
-This is the narrowest implementation step that proves the historical-memory architecture can record deterministic per-run facts without altering the finalized `v1.6.0` control model.
-
-Proposed Change:
-Add a write-only history recorder that stores finalized per-run outcomes using the `v1.7.0` historical memory contract, including schema versioning, run identity, failure fingerprint capture, and corruption-safe fallback behavior.
-
-Likely Files Affected:
-- C:/Jarvis/docs/architecture.md
-- C:/Jarvis/docs/development_rules.md
-- C:/Jarvis/docs/orchestration.md
-- future historical-memory implementation files
-
-Scope:
-- recorder-only groundwork
-- versioned schema scaffolding
-- run identity capture
-- failure fingerprint capture
-- write-only passive recording
-
-Out of Scope:
-- diagnostics enrichment
-- advisory recommendations
-- historical summary output
-- runtime behavior changes
-- retry changes
-- escalation changes
-
-Notes:
-Rev1 should record only finalized facts from the closed `v1.6.0` truth layer and must not read history back into control flow.
-Implemented in `v1.7.0` rev1.
-
----
-
-### [ID: FB-017] Support bundle and GitHub issue prefill
-
-Status: Implemented (v1.9.0 rev1)  
-Priority: Medium  
-Suggested Version: v1.9.0  
-Suggested Revision: rev1  
-
-Description:
-Add a user-friendly issue-reporting flow that generates a support bundle and opens a prefilled GitHub issue page.
-
-Why it matters:
-End users should be able to report crashes or failures without manually hunting for the right files. A guided support flow would keep reporting simple for users while giving developers a more consistent debug package.
-
-Proposed Change:
-Add a `Report Issue` flow that generates a support bundle containing the current runtime log, crash log, version, environment details, and a small manifest, then opens a prefilled GitHub issue form for the user to review and submit manually.
-
-Likely Files Affected:
-- issue reporting UI flow
-- support bundle generation code
-- diagnostics/support documentation
-- optional GitHub issue template integration
-
-Scope:
-- support bundle generation
-- GitHub issue prefill
-- user-guided issue reporting flow
-
-Out of Scope:
-- silent log uploads
-- fully automatic GitHub submission
-- forced inclusion of internal historical-memory files
-- unrelated diagnostics policy changes
-
-Notes:
-The first coherent manual reporting flow is now implemented as a privacy-safe diagnostics-window `Report Issue` action. It generates a local support bundle, writes the manifest, opens a prefilled GitHub issue page for manual completion, keeps attachment and submission manual, and includes a crash log only when the runtime-to-crash match is trustworthily determinable. The support bundle remains simple by default, with advanced/internal artifacts included only if explicitly needed later. The repo now also includes a contained offscreen validator for the production diagnostics `Report Issue` path that verifies support-bundle creation, manifest/manual-submission contract fields, and GitHub issue-prefill URL plus open-attempt handling without changing production behavior. That validator is now reachable through a dedicated VBS launcher and a report-aware lane in the accepted PySide dev toolkit.
-
-Current approved future follow-through above the same reporting boundary:
-
-- a bounded UX confirmation/warning step may later be added ahead of the `Report Issue` action so the user is explicitly told that a local support bundle will be created, the bundle folder will open, a GitHub issue draft will open, and final attachment/submission remain manual
-- that confirmation follow-through should preserve the existing privacy-safe manual reporting contract rather than redesigning diagnostics policy or introducing automatic upload behavior
-- broader recoverable-incident diagnostics triggering remains separate failure-class work and should not be folded into `FB-017` by default
-
----
-
-### [ID: FB-018] Voice-path regression validation harness
-
-Status: Implemented (v1.9.0 rev1)  
-Priority: Medium  
-Suggested Version: v1.9.0  
-Suggested Revision: rev1  
-
-Description:
-Add a small contained regression harness for Jarvis voice-path validation across the current launcher and diagnostics/manual test lanes.
-
-Why it matters:
-Recent shutdown-line debugging showed that voice regressions can hide inside contained recovery flows even when the launcher still appears to behave correctly. A small voice-focused validation pass would catch missing final lines, broken status sync, bad effect output, or callback drift earlier.
-
-Proposed Change:
-Create a narrow validation path that exercises the current contained voice lanes and verifies expected `VOICE_SYNC` / `VOICE_FINAL` status output for the key launcher-owned lines without changing launcher policy or unifying the distinct normal-versus-diagnostics voice roles.
-
-Likely Files Affected:
-- developer validation tooling
-- voice-path validation helpers
-- optional docs for validation usage only if needed
-
-Scope:
-- contained voice regression validation
-- launcher-owned failure-line verification
-- diagnostics voice status verification
-
-Out of Scope:
-- voice redesign
-- unifying normal and diagnostics voice behavior
-- launcher retry or escalation policy changes
-- broader devtools framework expansion
-
-Notes:
-The first coherent validation-first slice is now implemented as a contained voice regression harness. The repo now includes the harness script, a one-click VBS launcher, toolkit surfacing in the accepted PySide dev toolkit, launcher-owned repeated-crash and startup-abort lane coverage, direct diagnostics/error `VOICE_SYNC` / `VOICE_FINAL` probes, and stronger normal-voice direct-probe evidence beyond exit-code-only smoke validation. The current product direction still intentionally keeps the normal startup/desktop Jarvis voice path distinct from the diagnostics/error Jarvis voice path, so this item remains about guarding those paths, not merging them.
-
----
-
-### [ID: FB-019] Support bundle to repro triage helper
-
-Status: Implemented (v1.9.0 rev1)  
-Priority: Medium  
-Suggested Version: v1.9.0  
-Suggested Revision: rev1  
-
-Description:
-Add a small internal triage helper that reads a user-generated support bundle and maps it to the closest known failure class and internal repro path.
-
-Why it matters:
-The implemented `Report Issue` flow now gives developers a consistent support bundle, but engineers still have to manually inspect the manifest, runtime log, and crash log to decide which existing harness or contained validation lane best matches the incident. A small dev-only triage helper would shorten the path from user report to reproducible engineering case without changing the end-user reporting flow.
-
-Proposed Change:
-Create a dev-only support-bundle triage helper that parses the support bundle manifest plus available runtime/crash artifacts, identifies the most likely launcher-owned failure class or validation lane, and emits a compact internal summary with suggested next repro steps.
-
-Likely Files Affected:
-- dev-only support bundle triage tooling
-- support bundle manifest parser/helpers
-- optional internal triage documentation if needed
-
-Scope:
-- dev-only bundle parsing
-- failure-class suggestion
-- harness/repro-path suggestion
-- compact internal triage summary
-
-Out of Scope:
-- exact replay of the user machine state
-- end-user UI changes
-- silent uploads
-- automatic GitHub issue submission
-- launcher policy changes
-- diagnostics UI redesign
-
-Notes:
-The first coherent `FB-019` slice is now implemented as a dev-only support-bundle triage helper plus a contained regression harness. The repo now includes support-bundle zip and extracted-folder intake, parsing of the existing manifest plus bundled runtime/crash artifacts, conservative classification for the current launcher-owned terminal failure classes, compact `.txt` / `.json` triage reports, and reusable validation coverage for supported cases plus safe `unknown` fallback. The raw helper is reachable through the accepted PySide dev toolkit, and the repo also includes a contained offscreen validator for that raw-helper toolkit flow that is reachable through a dedicated VBS launcher and a report-aware lane in the accepted PySide dev toolkit. Production support-bundle generation and the end-user `Report Issue` flow remain unchanged; this item is about faster internal mapping from production evidence to the right contained repro path.
-
----
-
-### [ID: FB-020] Dev Toolkit utility split and dev-only evidence roots
-
-Status: Implemented (v2.0 rev2)  
-Priority: High  
-Suggested Version: v2.0  
-Suggested Revision: rev2  
-
-Description:
-Split the Dev Toolkit utility surface into stable global utilities versus lane-aware custom-launch utilities, add a separate previous-launch per-run history and exact-artifact reopen flow, and move toolkit-facing dev writes into dedicated `C:/Jarvis/dev/logs/<lane>/...` roots instead of the active client-facing `logs` / `crash` roots.
-
-Why it matters:
-The Dev Toolkit is easier to learn when stable navigation is separated from lane-dependent evidence, current-session utilities only appear when relevant, and historical runs can be reopened precisely without collapsing to the newest lane snapshot. Keeping developer-triggered runtime, report, and crash artifacts under `dev/logs` also prevents dev validation output from polluting the active client-facing `logs` area.
-
-Proposed Change:
-Implemented model:
-- `Global Utilities` opens stable developer locations such as the Jarvis root, Dev folder, Dev logs root, and Dev launchers folder.
-- `Custom Launch Utilities` follows the selected lane, stays hidden until relevant to the current selection, and only enables after that lane produces current-session evidence.
-- current launch and previous-launch flows start in explicit chooser-based empty states rather than preselected lane state.
-- `Previous Launches` is a true per-run history browser rather than a latest-per-lane snapshot.
-- `Previous Launch Utilities` reopens the exact runtime, report, crash, or evidence-root artifacts for the selected saved run.
-- toolkit-facing dev and test writes land under `C:/Jarvis/dev/logs/<lane>/...`
-- lane-local crash artifacts stay under each lane root as `...\\crash`
-- active client-facing `C:/Jarvis/logs` remains read-only investigation context where needed, such as support-bundle picking
-
-Likely Files Affected:
-- C:/Jarvis/dev/launchers/jarvis_dev_launcher.pyw
-- C:/Jarvis/dev/launchers/launch_jarvis_diagnostics_manual_test.vbs
-- C:/Jarvis/dev/launchers/launch_jarvis_launcher_failure_manual_test.vbs
-- C:/Jarvis/dev/launchers/launch_jarvis_launcher_failure_manual_test_with_voice.vbs
-- C:/Jarvis/dev/launchers/launch_jarvis_launcher_startup_abort_manual_test.vbs
-- C:/Jarvis/dev/launchers/launch_jarvis_launcher_startup_abort_manual_test_with_voice.vbs
-- directly relevant dev validation and harness scripts that define toolkit-facing evidence roots
-
-Scope:
-- Dev Toolkit utility split
-- global versus lane-scoped utility boundaries
-- previous-launch evidence reopen flow
-- previous-launch true per-run history
-- exact selected-run artifact reopening
-- dev-only evidence-root migration under `dev/logs`
-- lane-specific dev runtime/report/crash root normalization
-- current empty-state and utility-visibility hardening needed to make the toolkit surface accurate and usable
-
-Out of Scope:
-- boot planning
-- workspace reorganization
-- production launcher log/crash policy changes
-- support bundle contract redesign
-- shutdown voice refinement
-
-Notes:
-Rev1 and rev2 are now implemented in code. The current repo truth uses lane-local crash folders under each lane root rather than a shared `dev/logs/crashes` bucket, and includes later Dev Toolkit UX hardening needed to make the split utility model usable without preselected state or stale artifact reopening. `FB-008` remains intentionally on hold behind this delivered toolkit and dev-evidence cleanup lane.
-
----
-
-### [ID: FB-021] Dev-only Boot Jarvis test lane
-
-Status: Implemented (v2.1.0 rev1)  
-Priority: High  
-Suggested Version: v2.1.0  
-Suggested Revision: rev1  
-
-Description:
-Build out the dev-only Boot Jarvis test lane around `main.py` so boot/login behavior and the boot-to-desktop transition are faster to reproduce without turning `main.py` into the normal product entrypoint.
-
-Why it matters:
-Boot and transition testing is currently much slower than desktop-path testing unless the repo keeps a narrow internal harness model for `main.py`.
-
-Proposed Change:
-Implemented model:
-- `main.py` now includes Phase 1 boot-harness seams for boot profile, audio mode, dedicated `dev/logs` runtime roots, structured `BOOT_MAIN|...` milestones, and auto-handoff skip-import support
-- dev-only hidden-window boot launchers now exist under `dev/launchers/` for manual versus auto-handoff and quiet versus voice
-- Boot Jarvis transition work stayed inside the dev-only harness and did not turn `main.py` into a normal product entrypoint
-
-Likely Files Affected:
-- C:/Jarvis/main.py
-- C:/Jarvis/dev/launchers/launch_jarvis_main_*.vbs
-
-Scope:
-- dev-only boot/login harness support
-- faster contained boot-to-desktop repro
-- dedicated dev launchers for the existing boot prompt chain
-- contained boot transition behavior and evidence inside the dev-only harness
-
-Out of Scope:
-- making `main.py` a user-facing launcher
-- changing `launch_jarvis_desktop.vbs`
-- trust or auth behavior changes
-- full boot orchestrator implementation
-- Dev Toolkit surfacing in the same slice
-
-Notes:
-This item is now implemented as a reusable dev-only boot test lane.
-Current repo truth also includes later helper follow-through such as:
-
-- monitor preflight
-- boot-to-desktop handoff verification
-- transition capture
-
-Those later helper surfaces remain dev-only and still must not blur the line between the boot harness and the normal desktop launch path.
-
----
-
-### [ID: FB-022] Boot & Transition Checks Dev Toolkit surfacing
-
-Status: Implemented (v2.1.0 rev2)  
-Priority: Medium  
-Suggested Version: v2.1.0  
-Suggested Revision: rev2  
-
-Description:
-Add a dedicated `Boot & Transition Checks` purpose group to the Dev Toolkit once the boot helper seams and launchers are stable enough to surface safely.
-
-Why it matters:
-The Dev Toolkit should eventually expose repeatable boot and transition checks without requiring direct file launches, but it should only surface stable helpers rather than inventing them inside the toolkit UI.
-
-Proposed Change:
-Implemented model:
-- the Dev Toolkit now includes a dedicated `Boot & Transition Checks` purpose group
-- it reuses the existing quiet/voice launch-mode model rather than inventing a separate boot audio system
-- the current surfaced lanes are:
-  - `Boot Jarvis Manual Flow`
-  - `Boot Jarvis Auto Handoff (Skip Import)`
-  - `Boot To Desktop Handoff Verification`
-  - `Boot Transition Capture`
-  - `Boot Monitor Preflight`
-  - `Boot Helper Toolkit Validation`
-
-Likely Files Affected:
-- C:/Jarvis/dev/launchers/jarvis_dev_launcher.pyw
-- C:/Jarvis/dev/launchers/launch_jarvis_main_manual_test*.vbs
-- C:/Jarvis/dev/launchers/launch_jarvis_main_auto_handoff_skip_import*.vbs
-
-Scope:
-- Dev Toolkit purpose grouping for boot checks
-- boot-specific lane surfacing after helper stability
-- reuse of existing quiet versus voice launch-mode patterns
-
-Out of Scope:
-- inventing new boot helper seams inside the toolkit
-- user-facing boot launchers
-- trust or product behavior changes
-- desktop launcher policy changes
-
-Notes:
-This item is now implemented.
-Later Dev Toolkit follow-through in the same branch also added:
-
-- Toolkit session runtime logging
-- top-level smoke validation in a separate purpose group
-- live background status/progress
-- latest-artifact convenience utilities
-
-Those later QoL additions build on this surfacing rather than changing its core ownership model.
-
----
-
-### [ID: FB-023] Desktop renderer observability gap closure
-
-Status: Implemented (v2.1.0 rev3)  
-Priority: High  
-Suggested Version: v2.1.0  
-Suggested Revision: rev3  
-
-Description:
-Add the smallest missing renderer-side runtime markers for the controlled desktop path so renderer failures and shutdown behavior are easier to diagnose from logs.
-
-Why it matters:
-Current desktop logs cover startup well but remain thinner on page-load failure, desktop-mode attach results, and renderer-side shutdown milestones.
-
-Proposed Change:
-Implemented model:
-- `desktop/desktop_renderer.py` now emits the first narrow renderer-side observability markers for:
-  - visual page ready versus load failed
-  - desktop mode enable begin
-  - desktop attach result
-  - renderer shutdown begin
-- directly supportive WorkerW host-discovery probe evidence then landed to explain a real attach-path blind spot
-- a guarded `Progman` fallback followed as machine-specific host-selection follow-through after the new markers surfaced the failed next-WorkerW assumption
-
-Likely Files Affected:
-- C:/Jarvis/desktop/desktop_renderer.py
-- C:/Jarvis/desktop/jarvis_desktop_main.py
-
-Scope:
-- desktop renderer observability only
-- missing failure-path and shutdown markers
-- improved outcome clarity for the controlled desktop lane
-
-Out of Scope:
-- launcher policy changes
-- boot-harness changes
-- Dev Toolkit work
-- raw verbosity increases
-- UI redesign
-
-Notes:
-This item is now implemented as the first coherent desktop renderer observability slice, with directly supportive attach-path follow-through after the newly surfaced evidence showed the old WorkerW selection assumption was wrong on this machine.
-
----
-
-### [ID: FB-024] Boot harness edge-path observability refinement
-  
-Status: Implemented (v2.1.0 rev4)  
-Priority: Medium  
-Suggested Version: v2.1.0  
-Suggested Revision: rev4  
-
-Description:
-Fill in the remaining Boot Jarvis edge-path runtime markers so invalid prompt loops and interrupted handoff paths can be diagnosed without inferring behavior from missing happy-path milestones.
-
-Why it matters:
-The current boot harness now records the main happy path well, but unrecognized command loops, invalid import responses, and interrupted shutdown/handoff paths still leave evidence gaps.
-
-Proposed Change:
-Implemented model:
-- `main.py` now emits the remaining narrow boot edge-path markers for:
-  - rejected first-command input
-  - rejected import yes/no input
-  - typed shutdown accepted at command stage 1 or 2
-  - hotkey-triggered shutdown
-  - handoff signal emitted versus dropped
-- the marker pass stayed inside the existing boot harness and did not redesign prompt flow or alter boot behavior
-
-Likely Files Affected:
-- C:/Jarvis/main.py
-
-Scope:
-- boot-harness milestone refinement only
-- prompt edge-path evidence
-- abnormal exit and interrupted handoff evidence
-
-Out of Scope:
-- prompt copy rewrite
-- monitor preflight helper implementation
-- desktop renderer changes
-- Dev Toolkit surfacing
-- trust or auth behavior changes
-
-Notes:
- Current repo truth for this item includes:
-  
-- Phase 1 boot-harness seams in `main.py`
-- structured `BOOT_MAIN|...` milestones across the happy path
-- quiet and auto-handoff skip-import support
-- dev-only boot launchers
-- a more continuous boot-to-desktop handoff
-- helper follow-through such as monitor preflight, handoff verification, transition capture, and boot-helper Toolkit validation
-- landed edge-path markers for rejected input, shutdown source, and handoff signal outcome
-
-Later naming cleanup should continue only if a later explicitly selected slice justifies it.
-
----
-
-### [ID: FB-025] Boot and desktop milestone taxonomy clarification
-
-Status: Implemented (v1.2.5-prebeta)
-Priority: Low
-Suggested Version: v1.2.5-prebeta
-Suggested Revision: rev5
-Release Stage: pre-Beta
-
-Description:
-Clarify the shared naming shape between `BOOT_MAIN|...` and `RENDERER_MAIN|...` milestone families once both lanes have enough core markers to make cross-lane evidence easier to compare.
-
-Why it matters:
-Boot and desktop ownership should stay separate, but a small later taxonomy pass could make mixed evidence easier to read without collapsing the two lanes into a single logging system.
-
-Proposed Change:
-Implemented lane truth:
-
-- keep boot and desktop milestone ownership separate
-- do one tiny naming and taxonomy clarification pass only where shared marker shape improves cross-lane diagnostics
-- clarify the specific boot-to-desktop handoff wording so request-versus-visible transitions are easier to compare across `BOOT_MAIN|...` and `RENDERER_MAIN|...`
-- defer any broader logging-contract, launcher-policy, or verbosity follow-through until later evidence justifies it
-
-Likely Files Affected:
-- C:/Nexus Desktop AI/main.py
-- C:/Nexus Desktop AI/desktop/orin_desktop_main.py
-- C:/Nexus Desktop AI/dev/orin_boot_transition_capture.py
-- C:/Nexus Desktop AI/dev/orin_boot_transition_verification.py
-- C:/Nexus Desktop AI/dev/orin_desktop_entrypoint_validation.py
-- C:/Nexus Desktop AI/dev/orin_desktop_launcher_healthy_validation.py
-- directly coupled boot/desktop validation helpers
-- optional directly supportive canonical planning docs
-
-Scope:
-- naming and taxonomy clarification only
-- cross-lane diagnostic readability
-
-Out of Scope:
-- full shared logging contract implementation
-- launcher policy changes
-- raw verbosity increases
-- behavior changes
-
-Notes:
-Released in `v1.2.5-prebeta`.
-
----
-
-### [ID: FB-026] Dev Toolkit uploaded-bundle intake surface
-
-Status: Implemented (v2.2.0 rev1)  
-Priority: Medium  
-Suggested Version: v2.2.0  
-Suggested Revision: rev1  
-
-Description:
-Add a dedicated bottom-of-toolkit intake surface for user-submitted debug bundles so engineers can pick a zip or extracted folder, see what was received, and route it into the right internal helper without leaving the Dev Toolkit.
-
-Why it matters:
-The current toolkit already has support-bundle triage coverage, but intake still feels fragmented. A small, explicit uploaded-bundle area would make the toolkit feel like a one-stop internal debugging surface instead of a set of separate helper entrypoints.
-
-Proposed Change:
-Implemented model:
-- the Dev Toolkit now includes a dedicated lower `Uploads` intake area
-- the intake surface supports separate support-bundle zip selection and extracted-folder selection
-- the currently staged source is displayed clearly before triage is launched
-- the staged source routes into the existing Support Bundle Triage Helper path rather than a new parallel helper flow
-- dev-only Toolkit validation now covers the staged zip and extracted-folder intake flow end to end
-
-Likely Files Affected:
-- C:/Jarvis/dev/launchers/jarvis_dev_launcher.pyw
-- C:/Jarvis/dev/jarvis_support_bundle_triage_toolkit_validation.py
-
-Scope:
-- dev-only uploaded-bundle intake UI
-- zip and extracted-folder picking
-- clearer one-stop routing into existing bundle-debug helpers
-
-Out of Scope:
-- silent uploads
-- cloud transfer or remote storage
-- product-facing upload UI
-- automatic issue submission redesign
-
-Notes:
-This item is now implemented.
-Current repo truth already includes:
-
-- the existing support-bundle triage helper and its Toolkit surfacing
-- Toolkit session logging
-- live status/progress for background lanes
-- latest-artifact convenience utilities
-
-This landed as a bounded dev-tools-only intake slice and did not change production reporting behavior, issue-submission behavior, or support-bundle schema.
-
----
+Status: Deferred (rev1a clarification complete enough to pause)
+Record State: Registry-only
+Priority: Medium
+Release Stage: Slice-staged
+Target Version: v2.0
+Summary: Preserve the future boot and desktop phase-boundary model above the already-closed milestone taxonomy work.
+Why it matters: Keeps boot-versus-desktop ownership planning explicit without reopening the closed taxonomy milestone by inertia.
 
 ### [ID: FB-027] Jarvis interaction surfaces and shared action model
 
-Status: Deferred (first pre-Beta slice implemented in v2.2.1 rev1)  
-Priority: High  
-Suggested Version: TBD  
-Suggested Revision: rev2  
-Release Stage: Slice-staged  
-
-Description:
-Define and later deliver the Jarvis interaction system as a voice-first, typed-sufficient, user-customizable command surface with one shared action model underneath typed commands, future voice commands, aliases, routines, and profiles.
-
-Why it matters:
-This is the clearest future product-facing lane for turning Jarvis from a stabilized orchestration foundation into a system-facing interaction layer the user can actually shape and use day to day.
-
-Proposed Change:
-For current repo truth, keep the canonical interaction architecture in `docs/orin_interaction_architecture.md` and deliver it through staged slices rather than one broad feature push.
-
-Likely Files Affected:
-- C:/Nexus Desktop AI/Docs/orin_interaction_architecture.md
-- future typed command overlay surfaces
-- future shared action-model surfaces
-- future action-customization surfaces
-- future install and setup surfaces
-
-Scope:
-- Jarvis interaction planning and staged delivery
-- typed command overlay
-- shared action model
-- customizable actions, aliases, routines, and profiles
-- later voice-first parity through the same model
-
-Out of Scope:
-- auth or trust mechanics
-- launcher-policy changes
-- shell, tray, renderer, or notification implementation mechanics
-- plugin implementation mechanics
-- broader boot-orchestrator runtime implementation
-
-Notes:
-Current planning truth already lives in `docs/orin_interaction_architecture.md`.
-
-Current repo truth now includes the first implemented `pre-Beta` slice in `v2.2.1 rev1`:
-
-- `Ctrl+Alt+Home` opens and closes a dismissible desktop quick-command overlay
-- typed command entry now exists inside the controlled desktop runtime through a local click-armed input surface rather than global printable-key capture
-- a minimal direct-action / alias model resolves exact title-or-alias matches for the first bounded desktop command set
-- one unique match enters explicit confirmation before execution
-- zero-match and ambiguous-match outcomes stay non-executing and visible inside the overlay
-- confirmed execution shows a brief result state and then returns the desktop to passive mode
-- directly supportive route-parity and stability follow-through in the same lane closed desktop host positioning, overlay input-ownership, and Boot-handoff reset-churn issues for the first slice
-
-Current merged follow-through above that same foundation now also includes:
-
-- command-overlay target clarity follow-through so ambiguous choices and confirmation make path-sensitive destinations easier to tell apart before execution
-- overlay-usability follow-through so opening the overlay from the hotkey path now leaves entry ready for immediate typing
-- bounded keyboard-first ambiguous selection so visible ambiguous choices can be resolved locally with number keys before the existing confirmation step
-- preserved explicit confirmation before execution for both mouse and keyboard choice paths
-- preserved local-only typing behavior with no restored global printable-key capture outside the visible overlay
-- alternate desktop hotkeys now also exist on `main`:
-  - `Ctrl+Alt+1` as an alternate overlay toggle path alongside `Ctrl+Alt+Home`
-  - `Ctrl+Alt+2` as an alternate shutdown path alongside `Ctrl+Alt+End`
-- a first reusable shared action model extraction so the built-in desktop action definitions and shared helpers no longer live only inside the overlay-local model
-- overlay consumption normalization through a cohesive shared action catalog surface rather than scattered helper/default imports
-- a first bounded non-UI saved-action source seam for direct actions and aliases above the shared action model
-- strict built-in fallback when the saved-action source is missing, unreadable, empty, or invalid
-- conservative saved-action validation for supported target kinds plus id/title/alias collision rejection against built-ins or other saved actions
-- a first restart-based starter bootstrap path for `saved_actions.json` inside the saved-action source layer
-- built-in direct actions to open the default saved-actions file and its containing folder from the current typed command surface
-- backward-compatible preservation of unrelated valid saved actions when legacy saved-actions file or folder helpers collide with those built-ins
-- starter-file auto-creation only for the default runtime path, while explicit custom source paths remain conservative and fallback-only
-
-These merged follow-through items remain part of the same staged `FB-027` interaction lane rather than separate backlog items.
-
-Current NCP hardening and sequencing truth for that same follow-through now lives in `docs/ncp_hardening_assessment.md`.
-That document should be treated as the canonical reference for:
-
-- what is complete enough now in the typed-first NCP hardening lane
-- what is mostly hardened but still under-validated
-- what still remains a meaningful near-term hardening candidate
-
-Current repo truth remains conservative:
-
-- NCP hardening is still FB-027 follow-through, not a separate backlog item
-- the approved NCP hardening lane is now closed on `main`, with no current repo-truth need for another automatic NCP hardening patch
-- the shared-action-model, saved-action-source, starter-bootstrap, and first saved-action-usability follow-through slices are now merged on `main`, with that saved-action usability milestone shipped in `v1.2.1-prebeta`
-- the next pre-Beta interaction step, if resumed later, should start above the current shared action model, saved-action bootstrap, and released saved-actions access foundation rather than reopening NCP hardening by inertia
-
-Release-stage mapping:
-
-- `pre-Beta`: the typed-first interaction foundation, shared action model, first saved-action-source seam, and first starter bootstrap path are now implemented on `main`; later pre-Beta work remains limited to additional interaction-model follow-through above that same desktop overlay and shared-action foundation
-- `Beta`: packaged and installable user-facing release with practical setup expectations and broader customization beyond the first internal slice
-- `Full`: later wake-word voice invocation, richer routines and profiles, and any future plugin capability if the shared action model proves stable enough
-
-This item must be staged by slice rather than treated as one single blanket stage.
-
----
-
-### [ID: FB-028] Relocate launcher history state out of root logs
-
-Status: Implemented (v1.2.3-prebeta)  
-Priority: Medium  
-Suggested Version: v1.2.3-prebeta  
-Suggested Revision: rev1  
-Release Stage: pre-Beta  
-
-Description:
-Move the launcher-owned historical-memory file out of the user-visible root logs tree into a dedicated launcher-owned runtime state location.
-
-Why it matters:
-`jarvis_history_v1.jsonl` is not a runtime log, crash artifact, or dev evidence root. Keeping it in `C:/Jarvis/logs` makes internal cross-run state look like user-facing log clutter and conflicts with the current root-logs governance rule that the live root logs tree should stay reserved for already-approved launcher/runtime truth surfaces only.
-
-Proposed Change:
-Implemented lane truth:
-
-- normal runtime history now resolves under `%LOCALAPPDATA%/Nexus Desktop AI/state/jarvis_history_v1.jsonl`
-- successful migration no longer leaves the legacy root-log history file exposed after the new state-root copy succeeds
-- fail-safe degradation remains in place if migration or new-state writes fail
-- contained history harness and direct consumers now follow the relocated path contract while contained runs remain isolated under the contained harness log root
-- runtime logs, crash logs, and support-bundle locations remain unchanged
-
-Likely Files Affected:
-- C:/Jarvis/desktop/jarvis_desktop_launcher.pyw
-- C:/Jarvis/desktop/jarvis_history_harness_runner.py
-- C:/Jarvis/docs/development_rules.md
-- C:/Jarvis/docs/architecture.md
-- C:/Jarvis/docs/feature_backlog.md
-
-Scope:
-- launcher-owned historical-state relocation only
-- one-time migration and fallback behavior
-- keeping live runtime/crash roots and dev evidence roots unchanged
-
-Out of Scope:
-- moving runtime logs
-- moving crash logs
-- changing support-bundle locations
-- redesigning historical-memory semantics
-- dev evidence-root cleanup beyond the history file itself
-
-Notes:
-Released in `v1.2.3-prebeta`.
-
-Detailed future plan:
-
-- use a later explicitly selected follow-through item only if future evidence shows the released relocation behavior needs more bounded refinement
-
----
+Status: Deferred (first pre-Beta slice released in v2.2.1 rev1)
+Record State: Registry-only
+Priority: High
+Release Stage: Slice-staged
+Target Version: TBD
+Summary: Continue the long-term interaction-system lane above the existing typed overlay, shared action model, and saved-action foundation.
+Why it matters: This remains the clearest future product-facing interaction lane, but it should resume only through an explicitly chosen next slice.
 
 ### [ID: FB-029] ORIN legal-safe rebrand, future ARIA persona option, and repo licensing hardening
 
-Status: Deferred  
-Priority: High  
-Suggested Version: v2.2.1  
-Suggested Revision: rev1  
-Release Stage: pre-Beta  
-
-Description:
-Replace the current Jarvis product identity with ORIN, remove Marvel-adjacent branding from tracked repo surfaces, establish the future persona roadmap where ORIN is the shipped male identity for pre-Beta and Beta while ARIA is reserved as a later optional female identity, and harden the repo ownership posture with an explicit licensing and copyright plan.
-
-Why it matters:
-The current Jarvis / Stark-coded identity creates avoidable infringement and confusion risk, and the repo also needs a clear ownership posture so public source availability does not create ambiguity about what others are allowed to do with the work.
-
-Proposed Change:
-Perform one coordinated tracked-source rebrand to ORIN (`Operational Response and Intelligence Nexus`), remove explicit Marvel-coded branding, rename tracked `jarvis_*` and `launch_jarvis_*` source files and references, rewrite tracked historical docs to the new name, add a neutral persona contract that supports a later ARIA (`Adaptive Runtime Intelligence Assistant`) option without exposing that choice in pre-Beta or Beta, and add a repo licensing track that introduces an explicit root `LICENSE`, copyright notice, and README policy language aligned to a closed/proprietary release posture unless a later decision explicitly approves open-source licensing.
-
-Likely Files Affected:
-- current truth docs and supporting docs
-- desktop launcher, diagnostics, support-reporting, renderer, and single-instance surfaces
-- boot harness and voice layer
-- dev toolkit and dev launchers
-- tracked visual assets, filenames, modules, scripts, and path references
-- C:/Jarvis/LICENSE
-- C:/Jarvis/README.md
-- future ownership-notice surfaces such as `NOTICE`, `COPYRIGHT.md`, or contributor policy docs if external contributions are later enabled
-
-Scope:
-- legal-safe ORIN rebrand
-- Marvel-affiliation removal
-- tracked file/module/script rename
-- env var, mutex/event, support-bundle, local-folder, and path rename
-- tracked historical doc rewrite
-- persona contract for future ORIN / ARIA choice
-- repo licensing and copyright notice hardening
-- clear README usage and permission language for a non-open-source release posture
-
-Out of Scope:
-- behavior redesign
-- new feature work unrelated to naming/persona
-- editing generated logs, support bundles, or caches
-- exposing ARIA as a user-facing choice in pre-Beta or Beta
-- choosing a permissive open-source license for public reuse
-- trademark filing or legal opinion
-
-Notes:
-Release-stage rule:
-
-- pre-Beta ships ORIN only
-- Beta ships ORIN only
-- Full may expose user choice between ORIN and ARIA once the persona-selection slice is explicitly approved
-
-Licensing rule:
-
-- add an explicit root `LICENSE` before broader public release so repo permissions are not left ambiguous
-- default recommendation is a restrictive proprietary / all-rights-reserved posture unless a later explicit decision approves open-source licensing
-- track copyright notice updates in public docs and consider copyright registration as a pre-release legal gate if U.S. infringement enforcement is desired
-
-Current branch-local tracking:
-
-- the repair-first ORIN manual desktop path on `codex/orin-rebrand-foundation` is now working well enough to continue through the current manual launch chain
-- manual validation also surfaced a brief visual glitch/stutter during the ORIN manual desktop launch / handoff path
-- that glitch was not fixed in the later command-label follow-up, which only corrected the visible command-surface wording
-- the glitch is now tracked in GitHub Issue #17: `Investigate brief visual glitch/stutter during ORIN manual desktop launch`
-- GitHub issue link: `https://github.com/GiribaldiTTV/Jarvis/issues/17`
-- future work that closes this launch/handoff glitch should also resolve and close GitHub Issue #17
-- additional observed symptom now preserved under the same issue linkage: during the glitch, Jarvis appears to jump briefly toward the cursor and then return to center
-- unless later evidence clearly separates it, that cursor-jump symptom should continue to be treated as more evidence for GitHub Issue #17 rather than a separate issue
-- observed context to preserve:
-  - the issue was seen during manual ORIN desktop launch validation after the first launch-chain repair was working
-  - the ORIN visual asset chain was loading well enough to continue
-  - diagnostics and error-voice flow were not part of the observed glitch report
-- later Dev Toolkit launcher organization should keep the main user-facing Toolkit launcher forward-facing while moving non-forward-facing helper launchers used by the Toolkit into a separate helper-launchers folder
-- that Toolkit launcher reorganization remains planned follow-through only and should not be mixed into the current repair-first runtime slices until a dedicated path-organization slice is selected
-- the Slice 3 Diagnostics UI Test lane now opens visibly again from the current quiet-mode Dev Toolkit path, the diagnostics shell is inspectable, ORIN remains the assistant persona where intended, and no obvious remaining launch issue was reported for that lane after the narrow launcher-path follow-up
-- canonical display-level ORIN naming guidance now lives in `docs/orin_display_naming_guidance.md`; future wording follow-through should use that source instead of ad hoc per-surface naming choices
-- latest Slice 4A validation now also preserves:
-  - the boot overlay opens correctly
-  - the shell identity is now `Nexus Desktop AI`
-  - the startup subtitle `SYSTEM STARTUP INTERFACE` looked correct
-  - no remaining visible Jarvis-era wording was observed in the changed boot/runtime text
-  - desktop handoff still felt normal
-  - no regression was observed in the manual desktop path
-- current boot-reveal preference to preserve for later implementation evaluation:
-  - the reveal title may be better as `O.R.I.N.` instead of `ORIN`
-  - the reveal subtitle `Operational Response and Intelligence Nexus` looked correct
-  - treat that reveal-title preference as a targeted pending evaluation note, not a universal hard rule, until a later approved implementation and validation pass confirms it
-
----
+Status: Deferred
+Record State: Registry-only
+Priority: High
+Release Stage: pre-Beta
+Target Version: v2.2.1
+Summary: Track future ORIN-era naming, persona, and licensing hardening work without treating the local rebrand overlay as merged truth.
+Why it matters: Product identity, legal posture, and repo ownership still need durable future treatment, but not by accidental carry-forward.
 
 ### [ID: FB-030] ORIN voice/audio direction refinement
 
-Status: Deferred  
-Priority: Medium  
-Suggested Version: TBD  
-Suggested Revision: rev1  
-Release Stage: pre-Beta  
-
-Description:
-Refine the current ORIN assistant voice/audio direction so the speaking assistant feels more like the intended ORIN persona rather than only a functional default voice path.
-
-Why it matters:
-The rebrand direction now depends on ORIN feeling distinct as a persona. If the normal assistant voice does not support that identity well enough, the product presentation will lag behind the rest of the rebrand work.
-
-Proposed Change:
-Do a later bounded ORIN normal-voice direction pass that evaluates voice choice, pacing, delivery, and any light supportive processing so the assistant feels:
-
-- organic human
-- slight AI in how it speaks
-- futuristic in nature
-
-Likely Files Affected:
-- C:/Jarvis/Audio/orin_voice.py
-- C:/Jarvis/assistant_personas.py
-- optional directly supportive ORIN voice-test helpers if needed
-
-Scope:
-- ORIN normal assistant voice direction
-- persona-facing delivery refinement
-- bounded voice/presentation tuning for the shipped ORIN path
-
-Out of Scope:
-- ARIA implementation
-- diagnostics/error voice redesign unless explicitly approved later
-- speech-to-text or wake-word work
-- broad audio engine replacement
-- unrelated rebrand/file-rename cleanup
-
-Notes:
-This is a future persona-direction slice, not part of the current repair-first path-coherence work.
-
----
+Status: Deferred
+Record State: Registry-only
+Priority: Medium
+Release Stage: pre-Beta
+Target Version: TBD
+Summary: Preserve future ORIN voice-direction refinement as its own bounded persona-facing lane.
+Why it matters: Voice identity should be intentional and should not piggyback on unrelated runtime or canon work.
 
 ### [ID: FB-031] Nexus Desktop AI UI/UX overhaul planning
 
-Status: Deferred  
-Priority: Medium  
-Suggested Version: TBD  
-Suggested Revision: rev1  
-Release Stage: pre-Beta  
-
-Description:
-Plan a future UI/UX overhaul for Nexus Desktop AI so the product presentation can be updated intentionally rather than through piecemeal visual drift during repair-first rebrand work.
-
-Why it matters:
-The current repair-first branch is focused on path coherence and visible naming cleanup, not a full product-experience redesign. A separate tracked planning item is needed so later UI/UX changes can be shaped deliberately across desktop visuals, shell presentation, and user-facing polish.
-
-Proposed Change:
-Do a later bounded planning-first UI/UX pass that defines the desired Nexus-era visual language, presentation priorities, and rollout boundaries before broader implementation begins.
-
-Likely Files Affected:
-- C:/Jarvis/jarvis_visual/*
-- C:/Jarvis/desktop/desktop_renderer.py
-- C:/Jarvis/desktop/orin_desktop_main.py
-- C:/Jarvis/dev/launchers/orin_dev_launcher.pyw
-- future directly supportive design/planning docs
-
-Scope:
-- future UI/UX overhaul planning
-- visual language and presentation direction
-- staged rollout boundaries for later implementation
-
-Out of Scope:
-- current repair-first path fixes
-- ARIA implementation
-- voice/audio redesign implementation
-- repo rename or release-line work
-
-Notes:
-This is planning-only for now. It should remain separate from current path-coherence slices until a dedicated design/planning slice is explicitly selected.
-
-Current future-design notes now preserved here:
-
-- the current Boot shell text placement can visually cover the core render and should be revisited in the later UI/UX overhaul rather than being patched ad hoc during repair-first runtime slices
-- future text styling direction should feel more futuristic and more intentionally system-like rather than staying near plain utility styling
-- those presentation follow-through items should be evaluated together with the broader Nexus-era visual-language pass instead of as isolated micro-tweaks
-- later Dev Toolkit chrome follow-through should evaluate whether the current top banner is visually redundant with the main manual-validation surface, and whether minimize / dismiss controls should be folded into the lower surface instead of being repeated in separate stacked bars
-- later Dev Toolkit launch-status follow-through should evaluate replacing or de-emphasizing the current progress bar in favor of a clearer recent-history trace that can show 2-4 lines of status context plus an explicit terminal outcome for when a custom launch ends by design, by user action, or by error
-- later Dev Toolkit launch-control follow-through should evaluate whether custom launches need a bounded max runtime or explicit post-slice timeout model, and whether additional logging is needed to support a trustworthy terminal status display
-
----
+Status: Deferred
+Record State: Registry-only
+Priority: Medium
+Release Stage: pre-Beta
+Target Version: TBD
+Summary: Preserve future UI/UX overhaul planning as a deliberate design lane rather than piecemeal visual drift.
+Why it matters: The Nexus-era visual language should be planned coherently when the repo is ready for that design pass.
 
 ### [ID: FB-032] Nexus-era vision and source-of-truth migration
 
-Status: Deferred  
-Priority: Medium  
-Suggested Version: TBD  
-Suggested Revision: rev1  
-Release Stage: pre-Beta  
+Status: Deferred
+Record State: Registry-only
+Priority: Medium
+Release Stage: pre-Beta
+Target Version: TBD
+Summary: Track the broader Nexus-era vision and source-of-truth migration above the current phase-one canon foundation rebuild.
+Why it matters: The repo still needs deeper identity and wording normalization after the foundation layer is rebuilt.
 
-Description:
-Migrate the current product-vision and source-of-truth framing from Jarvis-era wording to Nexus Desktop AI / ORIN-era framing in a bounded, canonical-doc-first pass once the naming architecture is stable enough to do so cleanly.
+## Closed Canonical Workstreams
 
-Why it matters:
-Current canonical vision/routing layers still carry older Jarvis-era framing in places. If that migration is not tracked explicitly, the repo risks keeping split identity language across source-of-truth docs even after the runtime rebrand direction is clearer.
+### [ID: FB-025] Boot and desktop milestone taxonomy clarification
 
-Proposed Change:
-Do a later bounded source-of-truth migration pass that updates vision and routing docs to the Nexus-era product identity while preserving historical traceability and avoiding retroactive rewrite of old release history.
+Status: Released (v1.2.5-prebeta)
+Record State: Closed
+Priority: Low
+Release Stage: pre-Beta
+Target Version: v1.2.5-prebeta
+Canonical Workstream Doc: Docs/workstreams/FB-025_boot_desktop_milestone_taxonomy_clarification.md
+Summary: Clarified shared milestone taxonomy between `BOOT_MAIN|...` and `RENDERER_MAIN|...` without collapsing ownership.
+Why it matters: Keeps boot and desktop evidence easier to compare while preserving separate ownership boundaries.
 
-Likely Files Affected:
-- C:/Jarvis/docs/orin_vision.md
-- C:/Jarvis/docs/Main.md
-- C:/Jarvis/docs/architecture.md
-- C:/Jarvis/docs/feature_backlog.md
-- optional directly supportive canonical planning docs
+### [ID: FB-028] Relocate launcher history state out of root logs
 
-Scope:
-- vision-layer wording migration
-- source-of-truth routing cleanup
-- canonical-doc identity alignment
-
-Out of Scope:
-- runtime/code changes
-- repo rename execution
-- release history rewrite
-- README or LICENSE work unless separately approved
-
-Notes:
-This should be treated as a future source-of-truth migration item, not a broad immediate rewrite. The existing `docs/orin_vision.md` remains usable current truth until that dedicated migration pass is intentionally selected.
-
----
+Status: Released (v1.2.3-prebeta)
+Record State: Closed
+Priority: Medium
+Release Stage: pre-Beta
+Target Version: v1.2.3-prebeta
+Canonical Workstream Doc: Docs/workstreams/FB-028_history_state_relocation.md
+Summary: Moved launcher-owned historical state out of the live root logs tree into a dedicated state location.
+Why it matters: Keeps historical state out of user-visible runtime logs while preserving behavior and fallback rules.
 
 ### [ID: FB-033] Dev-only startup snapshot harness follow-through
 
-Status: Implemented (v1.2.4-prebeta)
+Status: Released (v1.2.4-prebeta)
+Record State: Closed
 Priority: Medium
-Suggested Version: v1.2.4-prebeta
-Suggested Revision: rev1
 Release Stage: pre-Beta
-
-Description:
-Track the current env-gated startup snapshot harness as intentional dev-only debugging infrastructure so future desktop-launch investigations can reuse it cleanly without turning it into normal product behavior.
-
-Why it matters:
-Issue `#17` showed that normal desktop capture APIs can be unreliable or blind once the ORIN desktop child is reparented under the desktop shell. A small startup snapshot harness gives developers a direct evidence path for first-visible startup behavior, zero-state versus warm-start comparison, and bounded attach/reveal debugging.
-
-Proposed Change:
-Implemented lane truth:
-
-- keep the startup snapshot path strictly harness-gated and dev-only
-- stabilize the owned trigger/env contract and output location for contained launch investigations
-- add a bounded contained validation path that proves healthy and failure-oriented startup behavior without spilling artifacts into live root logs or normal runtime state by default
-- defer permanent timing-set decisions and any dedicated dev-launcher surfacing until later evidence justifies them
-
-Likely Files Affected:
-- C:/Nexus Desktop AI/desktop/desktop_renderer.py
-- C:/Nexus Desktop AI/dev/orin_startup_snapshot_harness_validation.py
-- optional directly supportive dev-only launch/test surfaces
-- optional directly supportive canonical docs for dev-only usage guidance
-
-Scope:
-- env-gated startup snapshot debugging
-- first-visible frame evidence capture for desktop launch investigations
-- bounded dev-only follow-through for repeatable startup diagnostics
-
-Out of Scope:
-- normal user-facing screenshot or recording features
-- always-on runtime capture
-- release or support-bundle changes
-- broad desktop renderer redesign
-- unrelated Dev Toolkit expansion unless explicitly approved later
-
-Notes:
-Released in `v1.2.4-prebeta`.
-
----
+Target Version: v1.2.4-prebeta
+Canonical Workstream Doc: Docs/workstreams/FB-033_startup_snapshot_harness_follow_through.md
+Summary: Stabilized the env-gated startup snapshot harness as bounded dev-only debugging infrastructure.
+Why it matters: Preserves a repeatable startup evidence path without turning it into normal user-facing behavior.
 
 ### [ID: FB-034] Recoverable incident diagnostics surface and failure-class follow-through
 
-Status: Implemented (v1.2.6-prebeta)
+Status: Released (v1.2.6-prebeta)
+Record State: Closed
 Priority: Medium
-Suggested Version: v1.2.6-prebeta
-Suggested Revision: rev2
 Release Stage: pre-Beta
-
-Description:
-Track any later bounded follow-through beyond the first shipped recoverable-diagnostics milestone, without collapsing recoverable incidents into the fatal launcher diagnostics path.
-
-Why it matters:
-Current repo truth now includes one bounded recoverable-operational-incident path in `v1.2.2-prebeta`, but that does not authorize automatic continuation into broader diagnostics triggers, reporting-policy expansion, or voice-path widening. A deferred follow-through item keeps future work explicit and revalidatable.
-
-Proposed Change:
-Implemented lane truth:
-
-- select one recoverable high-signal incident class only: repeated identical `launch_failed` for the same action in a still-running session
-- make the current Class 2-to-Class 3 boundary explicit enough in renderer evidence that the branch would still read as a meaningful recoverable-diagnostics milestone if squashed and merged on its own
-- preserve the existing local/manual support-bundle and issue-draft boundary
-- keep directly coupled same-incident follow-through on the same lane only when it is still required to make that repeated identical `launch_failed` milestone feel complete
-- keep fatal launcher/runtime diagnostics completion behavior separate and unchanged
-- defer any broader recoverable diagnostics surface, voice, or launcher-policy follow-through until later evidence justifies it
-
-Likely Files Affected:
-- C:/Nexus Desktop AI/Docs/architecture.md
-- C:/Nexus Desktop AI/Docs/feature_backlog.md
-- C:/Nexus Desktop AI/Docs/prebeta_roadmap.md
-- C:/Nexus Desktop AI/desktop/desktop_renderer.py
-- C:/Nexus Desktop AI/desktop/orin_support_reporting.py
-- C:/Nexus Desktop AI/dev/orin_recoverable_launch_failed_validation.py
-
-Scope:
-- one recoverable incident class only
-- explicit Class 2/Class 3 boundary evidence and directly coupled same-incident follow-through only for the selected class
-- preserving manual-reporting boundaries while clarifying incident-class behavior
-
-Out of Scope:
-- treating every recoverable issue as a diagnostics popup
-- silent or background upload behavior
-- fully automatic GitHub submission
-- launcher retry, escalation, threshold, or fatal diagnostics-entry policy redesign
-- broad diagnostics UI redesign
-- broad voice redesign unrelated to failure-class semantics
-- automatic continuation of the current NCP hardening lane
-
-Notes:
-Released in `v1.2.6-prebeta`.
-
-The current released lane now keeps repeated identical `launch_failed` as the one selected recoverable incident class, makes the Class 2/Class 3 boundary explicit in renderer evidence, preserves the local/manual support-bundle and issue-draft boundary, and keeps report artifacts on truthful latest-public-prerelease context.
-
----
+Target Version: v1.2.6-prebeta
+Canonical Workstream Doc: Docs/workstreams/FB-034_recoverable_diagnostics.md
+Summary: Closed the first recoverable-diagnostics milestone for one explicitly bounded repeated-identical `launch_failed` incident class.
+Why it matters: Makes the Class 2/Class 3 boundary explicit without widening diagnostics policy or breaking the manual-reporting boundary.
 
 ### [ID: FB-035] Support-report release-context fallback hardening
 
-Status: Active
+Status: Released (v1.2.7-prebeta)
+Record State: Closed
 Priority: Medium
-Suggested Version: v1.2.7-prebeta
-Suggested Revision: rev1
 Release Stage: pre-Beta
+Target Version: v1.2.7-prebeta
+Canonical Workstream Doc: Docs/workstreams/FB-035_release_context_fallback_hardening.md
+Summary: Hardened support-report fallback release-context derivation so generated artifacts use released-canon truth when `.git` metadata is unavailable.
+Why it matters: Prevents support bundles and issue drafts from reporting an unreleased higher planned prerelease.
 
-Description:
-Harden support-report release-context derivation so generated support bundles and issue drafts keep reporting the latest released public prerelease even when `.git` metadata is unavailable.
+## Historical Implemented Registry-Only Items
 
-Why it matters:
-Current support-reporting truth already uses live tags when `.git` is available, but the roadmap fallback can still select a higher planned prerelease target instead of the latest released public prerelease. That would stamp support artifacts with an unreleased baseline in packaged or metadata-poor workspaces, which weakens diagnostics triage accuracy.
+### [ID: FB-001] Repeated identical crash early escalation
 
-Proposed Change:
-Current active lane target:
+Status: Implemented (v1.6.0)
+Record State: Registry-only
+Priority: Medium
+Target Version: v1.6.0
+Summary: Early launcher escalation for repeated identical non-`STARTUP_ABORT` crash outcomes.
+Why it matters: Prevents stable repeated crash evidence from being masked by unnecessary retries.
 
-- keep the lane scoped to release-context fallback hardening only
-- derive fallback release truth from released-prerelease canon instead of from any highest planned prerelease tag
-- preserve existing support-bundle contents, privacy posture, and manual-reporting boundary
-- prove both `git`-present and `git`-unavailable paths carry the same truthful latest-public-prerelease context in generated report artifacts
+### [ID: FB-002] Mixed failure-pattern policy
 
-Likely Files Affected:
-- C:/Nexus Desktop AI/Docs/feature_backlog.md
-- C:/Nexus Desktop AI/Docs/prebeta_roadmap.md
-- C:/Nexus Desktop AI/desktop/orin_support_reporting.py
-- C:/Nexus Desktop AI/dev/orin_recoverable_launch_failed_validation.py
+Status: Implemented (v1.6.0)
+Record State: Registry-only
+Priority: Medium
+Target Version: v1.6.0
+Summary: Conservative launcher handling for mixed crash and abort failure sequences.
+Why it matters: Keeps mixed-pattern outcomes classified without overstating them as stronger than repeated identical failures.
 
-Scope:
-- support-report release-context fallback hardening
-- released-prerelease canon parsing for fallback truth
-- narrow validation for `git`-present and `git`-unavailable report-artifact context
+### [ID: FB-003] Retry limit and diagnostics escalation policy
 
-Out of Scope:
-- new incident classes
-- reporting-policy changes
-- upload-behavior changes
-- diagnostics UI redesign
-- launcher retry or escalation redesign
-- voice-path work
+Status: Implemented (v1.9.0 rev1)
+Record State: Registry-only
+Priority: Medium
+Target Version: v1.9.0
+Summary: Defined retry exhaustion and diagnostics-entry policy for repeated `STARTUP_ABORT` and repeated identical crash outcomes.
+Why it matters: Makes launcher escalation predictable and evidence-based.
 
-Notes:
-This lane carries the actionable Codex review finding from PR `#46`: the roadmap fallback should not choose a higher planned prerelease target when `.git` metadata is unavailable. Keep it hardening-only and stop before broader diagnostics or reporting follow-through.
+### [ID: FB-006] Threshold-based recovery outcome summary refinement
 
----
+Status: Implemented (v1.6.0)
+Record State: Registry-only
+Priority: Low
+Target Version: v1.6.0
+Summary: Refined launcher summary wording for threshold-based early escalation outcomes.
+Why it matters: Keeps final failed-run reporting aligned with the actual recovery path.
 
-## Completed Items
+### [ID: FB-007] Max-attempt identical-failure attempt-pattern correction
 
-Move completed backlog items here for history tracking.
+Status: Implemented (v1.6.0)
+Record State: Registry-only
+Priority: Low
+Target Version: v1.6.0
+Summary: Corrected final attempt-pattern reporting for max-attempt identical failures.
+Why it matters: Prevents stable repeated failures from being described as varied.
+
+### [ID: FB-008] Shutdown voice degradation effect
+
+Status: Implemented (v2.2.0 rev2)
+Record State: Registry-only
+Priority: Low
+Target Version: v2.2.0
+Summary: Tuned the shutdown-only voice path so the final line sounds more like controlled power loss.
+Why it matters: Improves late-shutdown presentation without widening diagnostics behavior.
+
+### [ID: FB-009] Align crash-origin mixed markers with stable repeated-failure summaries
+
+Status: Implemented (v1.6.0)
+Record State: Registry-only
+Priority: Low
+Target Version: v1.6.0
+Summary: Aligned mixed-pattern classification with final repeated-failure summaries when cause stayed identical.
+Why it matters: Keeps summary and classification evidence consistent.
+
+### [ID: FB-010] v1.6.0 closeout and documentation sync
+
+Status: Implemented (v1.6.0)
+Record State: Registry-only
+Priority: Medium
+Target Version: v1.6.0
+Summary: Historical closeout and documentation sync for the finalized `v1.6.0` orchestration layer.
+Why it matters: Preserved the old baseline before later historical-memory work.
+
+### [ID: FB-011] Historical memory contract
+
+Status: Implemented (v1.7.0)
+Record State: Registry-only
+Priority: High
+Target Version: v1.7.0
+Summary: Defined the contract for passive cross-run historical memory before implementation.
+Why it matters: Keeps later history and advisory work deterministic and explainable.
+
+### [ID: FB-012] Failure fingerprint and recurrence model
+
+Status: Implemented (v1.8.0)
+Record State: Registry-only
+Priority: High
+Target Version: v1.8.0
+Summary: Defined how recurring outcomes are recognized across launches without reopening closed runtime classification.
+Why it matters: Cross-run recurrence needs stable fingerprint rules to stay trustworthy.
+
+### [ID: FB-013] Advisory provenance and confidence semantics
+
+Status: Implemented (v1.8.0)
+Record State: Registry-only
+Priority: Medium
+Target Version: v1.8.0
+Summary: Defined provenance and confidence semantics for advisory outputs.
+Why it matters: Keeps advisory intelligence explanatory instead of becoming hidden policy.
+
+### [ID: FB-014] Multi-run orchestration regression harness
+
+Status: Implemented (v1.8.0 rev1)
+Record State: Registry-only
+Priority: Medium
+Target Version: v1.8.0
+Summary: Added a multi-run regression harness for orchestration and historical-memory validation.
+Why it matters: Gives repeated-run behavior a bounded regression surface.
+
+### [ID: FB-016] Recorder-only historical memory groundwork
+
+Status: Implemented (v1.7.0)
+Record State: Registry-only
+Priority: High
+Target Version: v1.7.0
+Summary: Established recorder-only groundwork for passive historical memory.
+Why it matters: Kept early history capture bounded before broader interpretation layers arrived.
+
+### [ID: FB-017] Support bundle and GitHub issue prefill
+
+Status: Implemented (v1.9.0 rev1)
+Record State: Registry-only
+Priority: Medium
+Target Version: v1.9.0
+Summary: Added support-bundle creation and issue-prefill groundwork around diagnostics workflows.
+Why it matters: Improved manual triage and reporting without automatic submission.
+
+### [ID: FB-018] Voice-path regression validation harness
+
+Status: Implemented (v1.9.0 rev1)
+Record State: Registry-only
+Priority: Medium
+Target Version: v1.9.0
+Summary: Added bounded regression coverage for voice-path behavior.
+Why it matters: Protects shutdown and diagnostics voice behavior from silent regression.
+
+### [ID: FB-019] Support bundle to repro triage helper
+
+Status: Implemented (v1.9.0 rev1)
+Record State: Registry-only
+Priority: Medium
+Target Version: v1.9.0
+Summary: Added a helper path for turning support-bundle artifacts into reproducible triage input.
+Why it matters: Improves internal debugging flow without changing product behavior.
+
+### [ID: FB-020] Dev Toolkit utility split and dev-only evidence roots
+
+Status: Implemented (v2.0 rev2)
+Record State: Registry-only
+Priority: High
+Target Version: v2.0
+Summary: Split Dev Toolkit utilities and formalized dev-only evidence roots.
+Why it matters: Keeps internal debugging surfaces structured and separate from live runtime logs.
+
+### [ID: FB-021] Dev-only Boot Jarvis test lane
+
+Status: Implemented (v2.1.0 rev1)
+Record State: Registry-only
+Priority: High
+Target Version: v2.1.0
+Summary: Added the first dev-only boot test lane for controlled boot-path validation.
+Why it matters: Made boot-path validation explicit and reusable inside the toolkit surface.
+
+### [ID: FB-022] Boot & Transition Checks Dev Toolkit surfacing
+
+Status: Implemented (v2.1.0 rev2)
+Record State: Registry-only
+Priority: Medium
+Target Version: v2.1.0
+Summary: Surfaced Boot and Transition Checks inside the Dev Toolkit.
+Why it matters: Made transition validation easier to run without ad hoc helper discovery.
+
+### [ID: FB-023] Desktop renderer observability gap closure
+
+Status: Implemented (v2.1.0 rev3)
+Record State: Registry-only
+Priority: High
+Target Version: v2.1.0
+Summary: Closed key renderer observability gaps needed for desktop-startup investigation.
+Why it matters: Strengthened evidence quality for renderer-owned behavior without broad redesign.
+
+### [ID: FB-024] Boot harness edge-path observability refinement
+
+Status: Implemented (v2.1.0 rev4)
+Record State: Registry-only
+Priority: Medium
+Target Version: v2.1.0
+Summary: Refined boot-harness observability for edge-path behavior.
+Why it matters: Improved branch and validation clarity for boot edge cases.
+
+### [ID: FB-026] Dev Toolkit uploaded-bundle intake surface
+
+Status: Implemented (v2.2.0 rev1)
+Record State: Registry-only
+Priority: Medium
+Target Version: v2.2.0
+Summary: Added a dedicated Dev Toolkit intake surface for uploaded support bundles and extracted folders.
+Why it matters: Makes internal bundle triage feel like one coherent tooling surface.

--- a/Docs/incident_patterns.md
+++ b/Docs/incident_patterns.md
@@ -1,0 +1,44 @@
+# Incident Patterns
+
+## Purpose
+
+This document captures short reusable debugging and validation patterns extracted from closed workstreams.
+
+It is a generalized knowledge layer, not a case-history diary.
+
+Use:
+
+- canonical workstream docs for the full story of a specific lane
+- this document for reusable symptom-to-fix patterns
+
+## Pattern: Released-Canon Fallback Must Not Use The Highest Planned Prerelease
+
+- symptom:
+  support bundles or issue drafts can report an unreleased baseline when `.git` metadata is unavailable
+- layer:
+  support reporting and release-context derivation
+- root-cause pattern:
+  fallback logic trusts sequencing or planning truth as if it were released-canon truth
+- fix pattern:
+  derive fallback release context from the latest released prerelease truth, not from the highest planned prerelease target
+- validation pattern:
+  prove both `git`-present and `git`-unavailable report-artifact paths resolve to the same released public prerelease truth
+- source references:
+  - `Docs/workstreams/FB-035_release_context_fallback_hardening.md`
+  - `Docs/prebeta_roadmap.md`
+
+## Pattern: Repeated-Identical Recoverable launch_failed Must Stay Bounded
+
+- symptom:
+  a repeated recoverable `launch_failed` class starts pulling diagnostics policy toward blanket popup or fatal-path behavior
+- layer:
+  recoverable diagnostics surface and failure-class handling
+- root-cause pattern:
+  a bounded high-signal recoverable class is treated as permission to widen every recoverable failure into the same diagnostics surface
+- fix pattern:
+  keep the selected incident class explicit, preserve the manual reporting boundary, and keep fatal launcher and runtime diagnostics behavior separate
+- validation pattern:
+  prove only the selected repeated-identical `launch_failed` class gets the intended recoverable handling while fatal-path behavior remains unchanged
+- source references:
+  - `Docs/workstreams/FB-034_recoverable_diagnostics.md`
+  - `Docs/architecture.md`

--- a/Docs/ncp_hardening_assessment.md
+++ b/Docs/ncp_hardening_assessment.md
@@ -2,151 +2,107 @@
 
 ## Purpose
 
-This document is the canonical hardening assessment for the current FB-027 Nexus Command Prompt (NCP) follow-through lane.
+This document preserves a stable assessment of typed-first hardening expectations for the Nexus Command Prompt interaction surface.
 
-Its purpose is to:
+It is a planning and reference document.
+It does not own backlog identity, roadmap sequencing, workstream closure, or branch-readiness decisions.
 
-- preserve the current NCP hardening truth outside chat history
-- distinguish what is complete enough now from what is only helper-strong
-- record the conservative next-step recommendation for the current branch state
-- give future FB-027 backlog wording a stable truth reference without changing backlog state in the same pass
+Use this document to:
 
-This document is an assessment and sequencing reference.
-It does not replace `docs/feature_backlog.md`, and it does not authorize automatic scope expansion.
+- describe the hardening domains that matter for the desktop command surface
+- summarize the current merged baseline
+- clarify what kinds of future issues would justify renewed hardening work
 
-## Scope Boundary For NCP Hardening
+## Relationship To The Source-Of-Truth Stack
 
-For current repo truth, NCP hardening means typed-first reliability follow-through for the current desktop command surface.
+This document is downstream of:
 
-That includes:
+- `Docs/orin_interaction_architecture.md` for interaction-system design
+- `Docs/orchestration.md` for runtime and failure-handling boundaries
+- `Docs/feature_backlog.md` for tracked identity
+- `Docs/prebeta_roadmap.md` for sequencing and release posture
+- `Docs/workstreams/` for promoted execution and closure records
 
-- keyboard ownership and containment inside the visible overlay
-- focus and reopen behavior
-- transition stability across `entry`, `choose`, `confirm`, and `result`
-- predictable reset and retry posture after success, back-out, or non-success outcomes
-- stable user-visible failure-state behavior for the currently implemented command surface
-- helper and regression validation for the exact typed-interaction risks already discovered
+It should support future planning and assessment without replacing those layers.
 
-That does not include:
+## Current Surface Definition
 
-- voice integration
-- Action Studio or later customization surfaces
-- shortcut customization beyond the already implemented bounded desktop hotkeys
-- command-set expansion
-- broad UI polish or redesign
-- broad architectural rewrite without a reproduced bug that requires it
+For current repo truth, the Nexus Command Prompt is the typed-first desktop command surface built around:
 
-## NCP Hardening Subsystems
+- the quick command overlay
+- explicit keyboard-owned interaction while the overlay is active
+- a bounded `entry` -> `choose` -> `confirm` -> `result` state flow
+- explicit confirmation before execution
+- shared action-model resolution for built-in and saved actions
+- bounded saved-action loading with strict fallback behavior when the saved source is missing or invalid
 
-The current meaningful NCP hardening areas are:
+This document covers hardening expectations for that surface only.
 
-- input ownership and capture stability
-- focus and reopen behavior
-- `entry` / `choose` / `confirm` transition integrity
-- `Enter` / digit / `Esc` containment guarantees
-- no-mirroring / no-underlay-leak guarantees
+It does not define:
+
+- voice invocation behavior
+- Action Studio authoring UI
+- broader shortcut customization
+- new command families
+- unrelated UI redesign
+
+## Hardening Domains
+
+The meaningful hardening domains for the current command surface are:
+
+- keyboard ownership and containment
+- focus and reopen stability
+- transition integrity across `entry`, `choose`, `confirm`, and `result`
+- predictable `Enter`, digit, and `Esc` behavior
 - result-state reset and reopen predictability
-- non-success-path predictability
-- target clarity and execution clarity
-- visual state consistency of the NCP surface
+- non-success-path clarity and recoverability
+- target clarity before execution
+- visual state consistency
 - helper and regression validation coverage
 
-## Complete Enough Now
+## Current Merged Baseline Assessment
 
-`Complete enough now` means good enough by current repo truth and live evidence for the current pre-Beta branch state, not theoretical perfection.
+Current repo truth supports the following baseline assessment:
 
-The following areas are complete enough now:
+- the typed-first command surface is stable enough for current pre-Beta use
+- the current command-state transitions are bounded and understandable
+- confirmation before execution is preserved
+- keyboard-first ambiguous-choice resolution is present
+- non-success handling now has a clearer bounded result path than earlier overlay iterations
+- the shared action model and saved-action seam create a more stable interaction foundation than an overlay-local catalog alone
 
-- input ownership and capture stability for the regression family already discovered
-- no-mirroring / no-underlay-leak guarantees for the currently validated typed paths
-- `Enter` / digit / `Esc` containment guarantees for the currently validated typed paths
-- focus and reopen behavior for the success-path and cancel/retry flows already exercised
-- `entry` / `choose` / `confirm` transition integrity for the current typed command surface
-- result-state reset and clean reopen behavior for the validated success path
-- `launch_failed` result handling and retry/reset posture for the current typed command surface
-- target clarity and execution clarity for the current command set
-- visual state consistency of the NCP surface, including compact reset after backing out of expanded states
+This assessment means the command surface has a usable hardening baseline.
+It does not claim that the surface is feature-complete or final.
 
-Current repo truth supports this classification because the merged overlay-usability lane and the current hardening branch already closed:
+## What Future Follow-Through Would Need To Be About
 
-- mirrored typing and underlay leakage regressions
-- first-`Enter` and second-`Enter` containment failures
-- delayed ambiguous number-selection failure without manual refocus
-- caret / visual state mismatch after focus leaves the NCP
-- `Esc` cancel-and-retry reliability issues
-- layout reset after `Esc` from `choose` / `confirm`
-- success-path clean result close / reopen reset
-- stale retry-state carry-over for current non-success back-out flows
-- `launch_failed` visible failure-result handling, clean reopen/reset posture, and retry cleanliness for the current command surface
+Future NCP hardening work should be justified by one or more of the following:
 
-## Mostly Hardened But Under-Validated
+- a reproduced runtime regression in the current command surface
+- a newly discovered failure class that the current interaction contract does not handle cleanly
+- a major new interaction capability that changes the command-surface risk profile
+- packaging, install, or broader user-testing evidence that exposes a current desktop interaction weakness
 
-`Mostly hardened but under-validated` means the model, runtime, or helper evidence is stronger than the current live user-validation depth.
+Future work should not be justified only by vague polish pressure or by re-opening already settled behavior without fresh evidence.
 
-No currently meaningful NCP subsystem remains in this category for the active branch scope.
+## What This Assessment Should Not Be Used For
 
-The helper / regression surface may still be stronger than the live validation depth for some future failure-oriented or cross-system paths.
-That is useful and intentional, but it is no longer the gating question for the current NCP hardening lane.
+This document should not be used to:
 
-## Still Needs Hardening
+- declare a lane active or closed
+- recommend branch readiness or closure
+- replace a workstream record
+- restate backlog or roadmap state
+- authorize automatic expansion into voice, Action Studio, or broader interaction redesign
 
-No currently reproduced runtime bug forces another NCP patch at the moment.
+Those decisions belong in the backlog, roadmap, and canonical workstream layers.
 
-No currently meaningful near-term NCP hardening candidate remains inside this lane before branch-level closure review.
+## Planning Boundary
 
-Broader failure-class, diagnostics-surface, reporting, or voice-role contract work now belongs to `docs/architecture.md` rather than this NCP hardening doc.
-That later cross-system work should not be treated as an automatic continuation of the current typed-first NCP hardening lane.
+This assessment is healthiest when it is used as:
 
-## Not In Work Yet
+- a reusable reference for future typed-first interaction hardening questions
+- a guardrail against re-opening settled command-surface behavior without evidence
+- a way to distinguish stable command-surface expectations from future broader interaction ambitions
 
-These items are relevant to future NCP follow-through but are not active work right now:
-
-- broader non-success-path polish beyond a reproduced issue
-- any later slice that is only justified if new live evidence reopens a typed-interaction regression
-
-## Not Ready Yet Due To Future Integration Dependencies
-
-These items are NCP-adjacent, but they should wait because later product layers are not yet ready:
-
-- voice-parity behavior above the same interaction model
-- Action Studio and later customization surfaces
-- broader shared-action-model expansion beyond the current typed-first hardening lane
-- later installable / packaged interaction behavior that depends on future Beta-stage delivery
-
-Future voice should build on the same interaction model as typed interaction.
-That does not make voice part of current NCP hardening.
-
-## Current Recommended Next Step
-
-The current recommended next step is:
-
-1. do not patch automatically
-2. treat the approved NCP hardening lane as runtime-complete enough for its current scope
-3. move to branch-level readiness / closure review for `feature/fb-027-ncp-hardening`
-
-This is the conservative next step because the latest returned live user validation closed the `launch_failed` validation-first question without reopening a new NCP runtime bug.
-
-## What Should Wait Until Later
-
-The following should stay out of the current NCP hardening lane:
-
-- voice integration
-- Action Studio
-- shortcut customization
-- `Shift+Home` or other QoL extras
-- broader UI polish
-- command expansion
-- broad architectural rewrites without a reproduced bug
-
-## How This Document Should Be Used Relative To The Relevant FB-027 Backlog Item
-
-This document should be used as the canonical NCP hardening reference for future FB-027 follow-through wording.
-
-That means:
-
-- `docs/feature_backlog.md` should remain the controlling backlog file
-- future approved FB-027 backlog updates may point to this assessment instead of restating the full hardening map
-- backlog wording should stay concise and should not duplicate this document unless a later approved slice materially changes the assessment
-
-Backlog changes remain approval-gated.
-This document exists so future backlog carry-forward can reference one stable source of truth instead of relying on chat history.
+It is drifting if it turns into a branch memo, a closure checklist, or a hidden workstream record.

--- a/Docs/orchestration.md
+++ b/Docs/orchestration.md
@@ -1,394 +1,126 @@
-# Jarvis Orchestration
+# Nexus Orchestration
 
 ## Purpose
 
-This document captures the orchestration-specific philosophy and behavior of the Jarvis launcher stack.
+This document captures the orchestration-specific philosophy and current behavior boundaries of the Nexus desktop launcher stack.
 
-It exists so future revisions can reference:
+It does not own:
 
-- how startup is classified
-- how control is applied
-- how recovery is routed
-- what order orchestration capabilities should be built in
+- backlog identity
+- roadmap sequencing
+- workstream execution history
 
-## Current Startup Path
+Use it for orchestration behavior and boundary truth.
 
-`launch_jarvis_desktop.vbs`
--> `jarvis_desktop_launcher.pyw`
--> `jarvis_desktop_main.py`
+## Current Orchestration Path
 
-## Orchestration Evolution (rev1-rev9)
+The current merged desktop orchestration path is:
 
-The orchestration system was built in stages:
+`launch_orin_desktop.vbs`
+-> `desktop/orin_desktop_launcher.pyw`
+-> `desktop/orin_desktop_main.py`
 
-1. Separate production from test harness
-2. Add renderer lifecycle instrumentation
-3. Add launcher observation
-4. Add slow-start and stall classification
-5. Add cooperative abort control
-6. Add abort classification
-7. Route abort into recovery
-8. Add automatic abort on confirmed stall
-9. Add repeated consecutive `STARTUP_ABORT` escalation
+This is the current runtime orchestration path, not a future boot-first shell path.
 
-This sequence must not be skipped in future systems.
+## Core Orchestration Philosophy
 
-New systems should follow:
+Build orchestration in this order:
 
-Observability -> Classification -> Control -> Outcome -> Behavior
+1. observability
+2. classification
+3. control
+4. outcome clarity
+5. behavior
 
-## Marker Glossary
+Do not skip stages.
 
-- `STARTUP_OBSERVE_BEGIN` -> launcher began watching the current attempt for startup readiness
-- `STARTUP_READY_OBSERVED` -> launcher confirmed the renderer reached readiness
-- `STARTUP_READY_NOT_OBSERVED_WITHIN_WINDOW` -> startup is slower than expected
-- `STARTUP_READY_STALL_CONFIRMED` -> startup still has not reached readiness at the later stall deadline
-- `STARTUP_ABORT_REQUESTED_ON_CONFIRMED_STALL` -> launcher requested the cooperative startup abort signal
-- `STARTUP_ABORT_OBSERVED` -> launcher observed the renderer's startup-abort milestone
-- `STARTUP_ABORT_COMPLETE` -> launcher completed the abort-specific cleanup and control-flow handoff
-- `NORMAL_EXIT_COMPLETE` -> launcher completed a healthy normal-exit path
+The system should behave like:
 
-## Startup Observation
+- an observable system
+- a controllable system
+- a self-correcting system
 
-Launcher monitors:
+not a black box.
 
-- renderer process spawn
-- readiness milestones
-- time to readiness
-- renderer process state
+## Current Control Boundaries
 
-## Stall Detection
+### Launcher-Owned
 
-Two-stage system:
+The launcher owns:
 
-1. Slow warning (early threshold)
-2. Confirmed stall (later threshold)
-
-## Threshold Guidance
-
-Current launcher thresholds are conservative stabilization values for the desktop startup phase.
-
-- The early warning threshold is meant to detect "slower than expected"
-- The later stall threshold is meant to detect "slow enough to justify cooperative action"
-
-These values should be tuned from observed evidence, not guesswork.
-Future boot or startup phases must not automatically inherit the desktop-phase thresholds.
-
-## Stall Response (Current)
-
-On confirmed stall:
-
-- Request cooperative abort once
-- Do not hard kill
-- Continue observing
-- Let existing abort classification and recovery routing handle the outcome
-
-## Abort Handling
-
-When renderer aborts during startup:
-
-- Renderer emits `RENDERER_MAIN|STARTUP_ABORTED`
-- Launcher classifies the abort distinctly
-- Launcher treats the attempt as a startup failure outcome
-- Launcher routes that outcome into recovery flow
-
-## Recovery Flow
-
-- Attempt restart
-- Track attempt index
-- Maintain logs and state markers
-- Preserve cleanup of transient control and status artifacts
-
-## Behavior Philosophy
-
-- Prefer cooperative control over forced control
-- Prefer classification before action
-- Prefer minimal intervention first
-- Avoid aggressive recovery unless proven necessary
-- Recovery policy should be staged and justified by observed behavior
-
-## Current Boundaries
-
-The launcher is responsible for:
-
-- observation
-- classification
-- control decisions
+- startup observation
+- readiness, stall, abort, and failure classification
+- cooperative control
 - recovery routing
+- final runtime and crash truth generation
 
-The renderer is responsible for:
+### Renderer-Owned
 
-- lifecycle milestones
-- UI ownership
-- cooperative response to launcher control signals
-- clean shutdown behavior
+The renderer owns:
 
-## Diagnostics-Surface Boundary
+- desktop presentation
+- renderer lifecycle milestones
+- cooperative response to launcher signals
+- clean renderer shutdown behavior
 
-Within orchestration truth, the launcher-owned diagnostics completion path is for fatal or instability-class launcher and renderer outcomes.
+### Reporting Boundary
 
-This document should not be read as implying that every recoverable incident in higher interaction layers should open the diagnostics UI.
+Current merged truth preserves:
 
-Contained recoverable failures in interaction surfaces may remain local to those surfaces unless a later explicitly approved failure-class contract says a bounded recoverable incident should surface a separate diagnostics or reporting view.
+- manual support-bundle handling
+- manual issue submission
+- no silent upload behavior
+- no background reporting-policy expansion
 
-That later clarification must not silently redesign launcher retry, escalation, threshold, or diagnostics-entry policy.
+### Recoverable Diagnostics Boundary
 
-## v1.6.0 Evolution (rev10-rev24)
+Current merged truth keeps recoverable diagnostics bounded.
 
-### rev10-rev12
-- Introduced cooperative startup abort
-- Added threshold-based early escalation
-- Established retry and recovery control boundaries
+That means:
 
-### rev13-rev17
-- Added mixed-pattern classification
-- Implemented attempt-pattern summaries
-- Introduced failure stability signal
-- Fixed classification correctness
+- the shipped recoverable surface remains intentionally limited
+- fatal launcher and runtime diagnostics behavior remains separate
+- broader recoverable diagnostics expansion is not implied by the current architecture
 
-### rev18-rev19
-- Surfaced instability into `diagnostics_status`
-- Aligned triage guidance with stability
+## Runtime Outcome Model
 
-### rev20-rev22
-- Established diagnostics parity across runtime and crash surfaces
-- Added instability end-reason classification
-- Added diagnostics priority signal
+Current orchestration still centers on:
 
-### rev23
-- Fixed mixed crash classification inconsistency
-- Aligned classifier with the summary layer
+- startup observation
+- readiness detection
+- stall detection
+- cooperative startup abort
+- failure classification
+- launcher-owned recovery handling
 
-### rev24
-- Normalized incident summaries
-- Propagated diagnostics priority across all surfaces
-- Removed triage wording duplication
+The renderer remains reactive inside that model.
 
-## Final State (v1.6.0)
+## Evidence And Logs
 
-The orchestration system is:
+Current runtime evidence boundaries remain:
 
-- behaviorally stable
-- fully observable
-- classification-consistent
-- summary-aligned
-- diagnostics-aligned
-- operator-guided correctly
+- live launcher/runtime truth under `C:/Jarvis/logs`
+- live crash truth under `C:/Jarvis/logs/crash`
+- dev, toolkit, and harness evidence under `C:/Jarvis/dev/logs/<lane>/...`
+- normal historical state under `%LOCALAPPDATA%/Nexus Desktop AI/state/jarvis_history_v1.jsonl`
 
-No contradictions exist between:
+These are current runtime boundaries, not historical-only notes.
 
-- runtime markers
-- classification
-- summaries
-- diagnostics
-- triage guidance
+## Future Orchestration Direction
 
-## v1.7.0 Boundary Note
+Future orchestration work may later expand upward into:
 
-`v1.7.0` may introduce historical memory and advisory intelligence, but it may not alter the closed `v1.6.0` runtime control model.
+- pre-desktop boot coordination
+- access or trust framing
+- post-login resident presence
 
-Allowed in `v1.7.0`:
+But current merged orchestration truth remains the desktop launcher stack.
 
-- cross-run outcome recording
-- recurrence and stability trend summaries
-- diagnostics enrichment using historical context
-- advisory recommendations with clear provenance
+Any future higher layer must consume launcher truth downstream rather than rewriting launcher-owned outcomes.
 
-Not allowed in `v1.7.0`:
+## Relationship To Other Canon Layers
 
-- retry changes
-- escalation changes
-- threshold changes
-- classification changes
-- diagnostics trigger changes
-- instability-driven behavior
-- adaptive retry behavior
-- boot-level runtime control
-
-Historical memory in `v1.7.0` must remain advisory-only.
-If history is missing, unreadable, or corrupt, runtime behavior must degrade cleanly to the finalized `v1.6.0` orchestration behavior.
-
-## v1.7.0 Implemented State (rev1-rev6)
-
-### rev1
-- recorder-only historical memory groundwork
-- versioned per-run history records written only after finalized run completion
-
-### rev2
-- recorder validation before write
-- storage-path hardening and fail-safe fallback
-
-### rev3
-- read-only internal summarizer groundwork
-- malformed-line-safe loading
-- simple recurrence and stability summarization using recorded failure fingerprints
-
-### rev4
-- diagnostics-only historical context on failed runs
-- historical context derived only from prior finalized failure history
-
-### rev5
-- diagnostics-only historical advisory hints on failed runs
-- advisory wording remains explicitly historical, non-authoritative, and non-binding
-
-### rev6
-- source-of-truth stabilization and doc/backlog sync
-- no launcher behavior change required from the audit
-
-## Current v1.7.0 Guarantees
-
-- no readback into runtime behavior
-- no retry, escalation, threshold, or classification changes
-- no diagnostics trigger changes
-- no changes to `v1.6.0` summary structure or triage guidance
-- historical context remains clearly separate from current-run truth
-- advisory output remains clearly separate from both current-run truth and runtime control
-- historical context and advisory wording remain diagnostics `TRACE` surfaces; crash reports and incident summaries remain current-run truth surfaces
-- if history is missing, malformed, unreadable, or hostile, the launcher degrades cleanly to finalized `v1.6.0` behavior plus existing fail-safe history handling
-
-## Final State (v1.7.0)
-
-`v1.7.0` is complete as a conservative historical-memory and diagnostics-only advisory layer.
-
-No contradictions remain between:
-
-- runtime log truth
-- crash report truth
-- diagnostics `TRACE` historical context
-- diagnostics `TRACE` advisory wording
-- documented version boundaries
-
-## v1.8.0 Validation-First Boundary
-
-`v1.8.0` should begin as a validation-first phase for the historical-intelligence layer introduced in `v1.7.0`.
-
-The safest first target is:
-
-- `FB-014` multi-run orchestration regression harness
-
-Allowed in early `v1.8.0`:
-
-- repeatable multi-run verification of history recording
-- recurrence and fallback validation across repeated launches
-- diagnostics historical-context verification
-- diagnostics advisory-surface verification
-
-Not allowed in early `v1.8.0`:
-
-- retry or escalation changes
-- threshold or classification changes
-- diagnostics-trigger changes
-- confidence scoring
-- broader advisory expansion
-- historical content added to crash-report or incident-summary truth surfaces
-- readback from history into runtime behavior
-
-Future `v1.8.0` work may formalize recurrence and provenance semantics only after validation infrastructure is in place.
-
-## v1.8.0 Implemented Rev1 State
-
-`FB-014` rev1 now exists as external validation tooling around the historical-intelligence layer.
-
-Implemented rev1 state:
-
-- rev1a added dormant launcher seams for contained execution without touching the live production logs tree
-- rev1b added the first reusable contained harness runner
-- rev1c expanded that runner to cover baseline prior-history and fallback scenarios
-
-This implemented rev1 state does not alter orchestration behavior.
-It validates the existing recorder, summarizer, diagnostics-context, and diagnostics-advisory surfaces from outside the runtime-control path.
-
-## Later Orchestration Topics
-
-Examples of later orchestration topics:
-
-- retry limits
-- diagnostics escalation thresholds
-- cooldown timing
-- differentiated handling for repeated crash vs repeated stall
-- longer-term recovery policy tuning
-
-These should be handled as dedicated revisions, not mixed into unrelated work.
-
-## FB-003 Rev1 Baseline and Implemented State
-
-`FB-003` began with a `rev1a` policy-contract pass and now includes an implemented `rev1b` launcher behavior slice.
-
-The `rev1a` baseline defines when retries stop adding value and when the launcher should enter the existing diagnostics completion path, using current launcher-owned failure classes and recovery outcomes rather than new UI or new control surfaces.
-
-Rev1a should stay grounded in the current high-signal desktop-phase evidence classes already recognized by the launcher:
-
-- repeated `STARTUP_ABORT` outcomes
-- repeated identical crash outcomes
-
-Rev1a may define:
-
-- when those repeated failure classes should be treated as retry-exhausting evidence
-- that retry exhaustion stops further recovery attempts for the current run
-- that the launcher then enters the existing diagnostics completion path rather than continuing silent recovery
-- that this transition reuses the current diagnostics completion surfaces rather than redesigning diagnostics behavior
-
-Implemented `rev1b` state:
-
-- repeated `STARTUP_ABORT` exhaustion now behaves as a first-class terminal outcome
-- repeated identical crash exhaustion now behaves as a first-class terminal outcome
-- actual attempts used now propagate into terminal finalization and runtime summary output
-- terminal crash-report wording now reflects the real end reason instead of generic max-attempt framing
-- the existing diagnostics completion path is reused unchanged
-
-`FB-003` must not define yet:
-
-- mixed failure-sequence policy such as crash-then-abort or abort-then-crash
-- threshold retuning
-- classification redesign
-- diagnostics UI changes
-- summary or triage wording changes
-- cooldown redesign
-
-Mixed failure-sequence policy remains separate `FB-002` work and must not be pulled into `FB-003` rev1a.
-
-## FB-002 Rev1 Baseline and Current Launcher State
-
-`FB-002` began with a `rev1a` policy-contract pass.
-
-The `rev1a` baseline defines the conservative policy meaning of cross-kind mixed failure sequences without retuning thresholds, redesigning classification broadly, or reopening the terminal classes already handled by `FB-003`.
-
-Rev1a should stay limited to the currently recognized cross-kind crash and abort transitions:
-
-- `CRASH_TO_STARTUP_ABORT`
-- `STARTUP_ABORT_TO_CRASH`
-
-Rev1a should treat those mixed sequences as weaker evidence than the `FB-003` terminal classes:
-
-- repeated `STARTUP_ABORT` outcomes
-- repeated identical crash outcomes
-
-Rev1a may define:
-
-- that a first observed `CRASH_TO_STARTUP_ABORT` or `STARTUP_ABORT_TO_CRASH` sequence remains non-terminal
-- that these mixed sequences may continue contributing to instability labeling
-- that these mixed sequences may continue contributing to diagnostics-priority and attempt-pattern reporting
-- that these mixed sequences do not become a new early-exhaustion trigger in rev1a
-- that the launcher should preserve conservative retry continuation unless stronger existing terminal evidence appears
-
-Current launcher state already satisfies this conservative `rev1a` baseline:
-
-- `CRASH_TO_STARTUP_ABORT` and `STARTUP_ABORT_TO_CRASH` are recognized as mixed cross-kind sequences
-- first-observed cross-kind mixed sequences remain non-terminal
-- these mixed sequences continue feeding instability labeling
-- these mixed sequences continue feeding diagnostics-priority and attempt-pattern reporting
-- these mixed sequences do not act as a new early-exhaustion trigger
-- conservative retry continuation remains in place unless an existing `FB-003` terminal class is reached
-
-Rev1a must not define yet:
-
-- threshold retuning
-- new early-escalation thresholds for mixed sequences
-- broader varied-failure policy beyond the two cross-kind crash and abort transitions above
-- classification redesign outside this mixed-sequence clarification
-- diagnostics UI changes
-- summary or triage redesign
-- cooldown redesign
-
-`FB-002` remains intentionally separate from `FB-003`.
-It may describe how mixed sequences relate to instability reporting and diagnostics entry, but it must not weaken or replace the existing `FB-003` terminal classes.
+- use `Docs/architecture.md` for system-level boundaries
+- use `Docs/orin_vision.md` for product intent
+- use `Docs/boot_access_design.md` for future boot and access planning
+- use `Docs/workstreams/...` for promoted-lane execution and closure records

--- a/Docs/orin_display_naming_guidance.md
+++ b/Docs/orin_display_naming_guidance.md
@@ -2,14 +2,27 @@
 
 ## Purpose
 
-This document is the canonical source-of-truth guidance for when display surfaces should use:
+This document defines how user-facing surfaces should present the ORIN persona.
+
+Use it to decide when display surfaces should use:
 
 - `ORIN`
 - `O.R.I.N.`
 - `Operational Response and Intelligence Nexus`
 
 It is a presentation and wording guide only.
-It does not authorize broad source renames, internal identifier rewrites, or repo-wide wording sweeps by itself.
+It does not own rollout sequencing, workstream status, repo-wide identifier changes, or broad source rewrites by itself.
+
+## Relationship To The Source-Of-Truth Stack
+
+This document is a reference layer under:
+
+- `Docs/Main.md` for routing
+- `Docs/orin_vision.md` for product and persona identity
+- `Docs/architecture.md` and `Docs/orchestration.md` for boundary truth
+- backlog, roadmap, and workstream docs for tracked work and sequencing
+
+It should be used to support wording decisions, not to replace those layers.
 
 ## Naming Boundary
 
@@ -25,6 +38,7 @@ This means:
 
 - use `Nexus Desktop AI` for product-level, tooling-shell, or platform identity
 - use ORIN naming guidance only where the assistant persona itself is being presented
+- keep legacy `Jarvis` wording only where the reference is historical or where a still-real runtime artifact continues to use that name
 
 ## Default Short Form
 
@@ -69,18 +83,18 @@ Preferred examples:
 
 ## Current Diagnostics Direction
 
-Current preferred direction from diagnostics validation:
+Current preferred diagnostics direction:
 
 - the diagnostics voice-trace area header may prefer the full expansion:
   - `Operational Response and Intelligence Nexus`
 - diagnostics trace and state text should prefer:
   - `O.R.I.N.`
 
-Future diagnostics wording changes should use this direction unless a later explicit planning decision replaces it.
+Use this as the default diagnostics direction unless later merged canon explicitly replaces it.
 
 ## Current Boot Reveal Evaluation
 
-Current preferred direction from the latest Slice 4A validation:
+Current preferred boot-reveal direction:
 
 - the assistant reveal title may be better as:
   - `O.R.I.N.`
@@ -88,7 +102,7 @@ Current preferred direction from the latest Slice 4A validation:
   - `Operational Response and Intelligence Nexus`
 
 This is not yet a universal hard rule.
-Treat it as a targeted current preference for the boot reveal surface that should be implemented and revalidated in a later approved slice before it replaces the default short-form rule more broadly.
+Treat it as a targeted display preference for the boot reveal surface rather than a global naming override.
 
 ## Future Persona Rule
 
@@ -99,3 +113,12 @@ If ARIA is later exposed as a user-facing persona, it should follow the same thr
 - full expansion when explanatory or header clarity is useful
 
 Do not assume the exact ARIA presentation rules are finalized yet.
+
+## Boundary Reminder
+
+This document should not be used to:
+
+- decide whether a workstream is active or closed
+- decide when a naming change ships
+- restate backlog, roadmap, or workstream execution detail
+- rewrite preserved historical records that intentionally keep older naming

--- a/Docs/orin_interaction_architecture.md
+++ b/Docs/orin_interaction_architecture.md
@@ -1,379 +1,232 @@
-# Jarvis Interaction Architecture
+# ORIN Interaction Architecture
 
 ## Purpose
 
-This document is the canonical planning baseline for Jarvis user interaction as a voice-first, typed-sufficient, user-customizable system layer.
+This document defines the interaction-system architecture for Nexus Desktop AI and the ORIN persona.
 
-It defines:
+It is a planning and boundary reference.
+It does not own workstream status, backlog state, roadmap sequencing, or release closure.
 
-- the primary user-facing interaction surfaces
-- the shared action model that should sit underneath voice and typed commands
-- the customization model for saved actions, routines, aliases, and profiles
-- the intended pre-Beta, Beta, and later Full release scope
+Use this document to define:
 
-This is still a planning artifact.
-It does not define implementation mechanics for wake-word detection, speech-to-text, auth backend behavior, shell integration, tray mechanics, renderer wiring, plugin loading, or concrete runtime execution logic.
+- the interaction surfaces the product should support
+- the shared concepts those surfaces should resolve through
+- the current merged interaction baseline
+- the long-term interaction architecture that future work should preserve
 
-## Relationship To Core Source-Of-Truth Docs
+## Relationship To The Source-Of-Truth Stack
 
 This document is downstream of:
 
-- `architecture.md` for launcher-owned desktop authority and higher-layer read-only limits
-- `orin_vision.md` for Jarvis as the intended system-facing experience
-- `boot_access_design.md` for future pre-desktop access, trust, recovery, and resident trust-state boundaries
-- `feature_backlog.md` for workstream status and scope control
+- `Docs/architecture.md` for desktop/runtime ownership boundaries
+- `Docs/orin_vision.md` for product identity and release-stage framing
+- `Docs/orchestration.md` for runtime behavior and orchestration boundaries
+- `Docs/boot_access_design.md` for future pre-desktop trust and access boundaries
+- `Docs/feature_backlog.md` for tracked identity
+- `Docs/prebeta_roadmap.md` for sequencing and release posture
+- `Docs/workstreams/` for promoted execution and closure truth
 
-This document does not replace those files.
-It narrows only the future Jarvis interaction surface and its customization model.
+This document does not replace those layers.
+It defines the stable interaction model that future work should align to.
+
+## Current Merged Baseline
+
+Current repo truth is a typed-first desktop interaction system with the following merged baseline:
+
+- a quick command overlay is the current primary user-facing interaction surface
+- the current default desktop hotkeys are `Ctrl+Alt+Home` and `Ctrl+Alt+1` for opening the overlay
+- the current desktop shutdown paths are `Ctrl+Alt+End` and `Ctrl+Alt+2`
+- the overlay uses a bounded `entry` -> `choose` -> `confirm` -> `result` interaction flow
+- the overlay preserves explicit confirmation before executing the resolved action
+- a shared action model now sits underneath the command surface
+- a saved-action source seam exists at `%LOCALAPPDATA%/Nexus Desktop AI/saved_actions.json`
+- built-in actions and saved actions resolve through the same shared catalog shape
+
+Current repo truth does not yet include a shipped voice-invocation surface, Action Studio UI, or broader shortcut-customization system.
 
 ## Product Intent
 
-Jarvis should evolve toward a system-facing interaction layer that feels more like a personal operator than a conventional desktop app launcher.
+Nexus Desktop AI should evolve toward an interaction system where ORIN feels like an understandable, inspectable operator surface rather than a brittle launcher or opaque automation engine.
 
-At the user level, that means:
+At product level, that means:
 
-- Jarvis is voice-first in personality and product direction
-- typed interaction remains fully sufficient
-- users can speak or type naturally rather than memorize rigid command syntax
-- Jarvis can map natural intent to reusable user-defined actions, routines, and environments
-- users can inspect, customize, and trust what Jarvis will do
-
-The system should feel closer to:
-
-- "Hey Jarvis, launch sim"
-- "Open Windows Explorer"
-- "I'd like you to open my sim setup"
-
-than to a brittle command console that only accepts one exact phrase.
+- voice-forward product direction without making voice the only valid interface
+- typed interaction remaining fully sufficient
+- natural-language requests resolving into one coherent action model
+- users being able to inspect what ORIN believes they asked for before execution
+- users being able to define, reuse, and later expand their own actions and routines
 
 ## Governing Interaction Principles
 
-- voice-first, not voice-only
-- typed-sufficient for all core interaction
-- one shared action system underneath all input surfaces
-- user-customizable by default rather than hardcoded around one machine
-- observable and inspectable rather than opaque
-- safe by default when actions could be risky or ambiguous
-- local product identity first, not a generic desktop launcher clone
+- voice-forward, not voice-exclusive
+- typed interaction is a first-class certainty path
+- one shared action model underneath all interaction surfaces
+- inspectable resolution before execution
+- safe handling when interpretation is ambiguous or execution could surprise the user
+- user-defined actions and aliases should be part of the architecture, not bolted on later
+- ORIN is the current assistant persona for interaction surfaces
 
-## Core Interaction Surfaces
+## Interaction Surfaces
 
-At planning level, Jarvis interaction should eventually be split across four primary user-facing surfaces:
+### Desktop Command Overlay
 
-### 1. Voice Invocation Surface
+The current merged interaction surface is the desktop command overlay.
 
-The long-term voice-first surface is the wake-word path, such as:
+Architecturally, it should remain:
 
-- `Jarvis`
-- `Hey Jarvis`
-
-This is the future always-ready interaction posture, but it is not required for the first pre-Beta slice.
-
-### 2. Quick Command Overlay
-
-The typed-first companion surface is a dismissible command overlay.
-
-At planning level, this should be:
-
-- fast to open
+- fast to invoke
 - fast to dismiss
-- usable as the typed equivalent of speaking to Jarvis
-- able to accept natural-language typed requests
+- keyboard-first for current pre-Beta use
+- capable of accepting natural-language typed requests
+- explicit about the resolved action before execution
 
-The current preferred default hotkey is:
+### Voice Invocation Surface
 
-- `Ctrl+Alt+Home`
+A future voice surface may later sit above the same shared action model.
 
-That hotkey should be treated as a planning-level default, not a permanently fixed non-configurable rule.
+That future surface should be treated as another entry path into the same interaction system, not as a separate product with separate logic.
 
-### Alternate Desktop Hotkey Direction
+This document does not define wake-word implementation, speech-to-text mechanics, or audio-pipeline execution details.
 
-For current Nexus-era desktop interaction, the default desktop hotkeys remain:
+### Action Authoring Surface
 
-- `Ctrl+Alt+Home` for the quick command overlay
-- `Ctrl+Alt+End` for the current desktop shutdown path
+A future authoring surface should let users define and inspect:
 
-Future interaction follow-through should preserve room for:
+- saved actions
+- aliases
+- routines
+- profiles
+- later bounded preferences that affect how supported actions resolve
 
-- one alternate user-usable binding for opening and closing the quick command overlay
-- one alternate user-usable binding for the current desktop shutdown path
+This authoring surface should stay downstream of the same shared action model already used by typed interaction.
 
-The purpose of this direction is:
+### Runtime And Status Surface
 
-- to reduce dependence on one exact physical-key path
-- to support broader usability across keyboards and user preference
-- to leave room for later bounded shortcut follow-through without forcing a full shortcut-customization system immediately
+The interaction system should expose what ORIN is doing, what it just resolved, and what the current command state is.
 
-This direction does not authorize immediate implementation of configurable shortcut management or a broad keybinding system.
+This supports:
 
-Current merged desktop follow-through now includes:
-
-- `Ctrl+Alt+1` as an alternate user-usable quick-command-overlay path alongside `Ctrl+Alt+Home`
-- `Ctrl+Alt+2` as an alternate user-usable desktop shutdown path alongside `Ctrl+Alt+End`
-
-This merged follow-through remains a bounded usability refinement only.
-It does not authorize broader shortcut customization, settings UI, or profile-based keybinding management.
-
-### 3. Action Studio
-
-The customization surface is the place where the user defines and edits saved actions, aliases, routines, and profiles.
-
-This is the closest conceptual analogue to a StreamDeck-style authoring surface, but it should remain Jarvis-shaped rather than becoming a clone of button-grid hardware software.
-
-### 4. Runtime And Status Surface
-
-Jarvis should expose a clear runtime/status surface that explains what it is doing now, what it just ran, and where a routine or command currently stands.
-
-This surface exists to preserve user trust and reduce "black box" behavior.
+- user trust
+- confirmation clarity
+- recoverability after non-success outcomes
+- better debugging and validation evidence
 
 ## Shared Action Model
 
-Voice and typed interaction must not become separate products.
-
-At planning level, both should resolve into one shared interaction model:
+Typed and future voice interaction should resolve through the same conceptual model:
 
 - `intent`
-  - what the user means
 - `action`
-  - one executable user-facing thing Jarvis can do
 - `routine`
-  - an ordered bundle of actions
 - `profile`
-  - a saved user-defined environment or context, such as a sim setup
 - `alias`
-  - alternate phrases that resolve to the same action or routine
 
-The key rule is:
+The architecture should not split into:
 
-- voice input and typed input should resolve into the same action, routine, alias, and profile model
+- one system for typed commands
+- one system for voice commands
+- one separate system for saved presets
 
-This prevents Jarvis from splitting into:
+The shared action model is the architectural seam that keeps those surfaces coherent.
 
-- one system for "voice commands"
-- another system for "typed commands"
-- a third system for "saved presets"
+## Command Resolution Contract
 
-## Natural-Language Command Contract
+The interaction layer should accept ordinary language variation rather than depending on one exact phrase.
 
-Jarvis should be open to ordinary language variation rather than one exact command syntax.
-
-At planning level, that means a user should be able to express similar intent in multiple ways, such as:
+Examples of equivalent user intent may include:
 
 - `open windows explorer`
 - `open file explorer`
-- `I'd like you to open Windows Explorer`
+- `open my Nexus docs`
 
-without the system being planned around one rigid phrase only.
+The architectural rule is flexible intent resolution with bounded, inspectable outcomes.
+It is not authorization for unconstrained AI action execution.
 
-This does not authorize freeform AI action execution without boundaries.
-It only defines the product-level expectation that intent matching should be flexible and user-friendly.
+## Confirmation Contract
 
-## Desktop-Mode Command Confirmation Contract
+Before execution, the interaction surface should make clear:
 
-At planning level, when Jarvis is already inside desktop mode and is about to run a user-requested command, Jarvis should confirm the interpreted action before execution.
+- what ORIN believes the user requested
+- which action, alias, routine, or target was resolved
+- what destination, app target, file, folder, or URL will be used when that matters
 
-That confirmation should make clear:
+For path-sensitive targets, the confirmation surface should show enough detail to distinguish similar options without becoming visually noisy.
 
-- what Jarvis believes the user asked for
-- which defined action, alias, routine, or target Jarvis resolved
-- which user-defined path, app target, or launch context Jarvis is about to use when that matters
+This contract preserves trust and reduces accidental execution when natural-language resolution is flexible.
 
-The purpose of this confirmation is:
+## Current Desktop Interaction Guarantees
 
-- to ensure Jarvis and the user share the same interpretation before execution
-- to keep desktop-mode command execution observable and trustworthy
-- to reduce accidental execution caused by ambiguous natural-language interpretation
+Current merged desktop interaction guarantees include:
 
-This planning contract does not define the exact UI phrasing, visual layout, or confirmation-control mechanics.
-It only defines the product rule that desktop-mode command execution should be explicitly confirmed before Jarvis runs the resolved action.
+- immediate typed-entry readiness when the overlay opens from the supported hotkey paths
+- bounded ambiguous-choice resolution through visible number-key selection
+- preserved explicit confirmation before execution after keyboard selection
+- clean `Esc` back-out behavior inside the visible overlay
+- local keyboard ownership while the overlay is active
+- reuse of the shared action model rather than an overlay-only command catalog
+- bounded saved-action sourcing with strict built-in fallback when the saved source is missing or invalid
 
-### Confirmation Clarity For Paths And Targets
+These are current baseline guarantees, not the full future interaction surface.
 
-When the resolved action points to a file, folder, URL, app target, or other path-sensitive destination, the confirmation surface should make the destination understandable before execution.
+## User-Facing Naming Boundary
 
-At planning level, that means:
+For current product truth:
 
-- show enough target detail that the user can tell what will open or run
-- use a compact or truncated path display when the full raw path would be visually noisy
-- avoid hiding the important distinguishing part of the target when multiple similar choices exist
+- `Nexus Desktop AI` is the product and tooling-shell identity
+- `ORIN` is the shipped assistant persona
 
-The purpose of this rule is:
+User-facing interaction surfaces should prefer current Nexus / ORIN naming.
 
-- to keep confirmation useful instead of decorative
-- to help the user understand why one match differs from another
-- to reduce accidental launches when multiple choices are similar
+Legacy `Jarvis` wording should appear only when:
 
-Current merged desktop overlay follow-through now also includes:
+- preserved historical context is being discussed
+- backward-compatible runtime artifacts still use that name
+- the user is explicitly interacting with older historical material
 
-- immediate typed-entry readiness when the overlay is opened from the current hotkey path
-- bounded keyboard-first ambiguous-choice resolution through visible number-key selection
-- preserved explicit confirmation before launch after keyboard selection
-- preserved clean `Esc` back-out behavior and local-only keyboard ownership inside the visible overlay
-- a reusable shared action model so the built-in desktop command actions and shared helpers no longer live only inside the overlay-local model
-- normalized overlay consumption of that shared action model through a cohesive shared catalog surface
-- a bounded non-UI saved-action source seam for direct actions and aliases with strict built-in fallback when the saved source is missing or invalid
+## Customization Boundary
 
-## Nexus-Era User-Facing Naming Rule
-
-For Nexus Desktop AI / ORIN-era interaction surfaces, user-facing command labels and choices should prefer current Nexus-era naming rather than legacy Jarvis branding unless the user is explicitly interacting with preserved historical context.
-
-This means future command-surface work should trend toward:
-
-- Nexus-facing names for Nexus-facing actions
-- ORIN-facing assistant presentation where assistant identity matters
-- avoiding legacy Jarvis naming in normal Nexus-facing command choices
-
-This is a user-facing interaction rule only.
-It does not authorize historical rewrite of preserved Jarvis release history.
-
-## Customization Contract
-
-Jarvis customization should allow users to define:
+The interaction architecture should support user-defined:
 
 - action names
-- aliases and alternate phrases
-- app, file, folder, URL, or command targets
-- ordered launch steps
-- saved routines or environment profiles
-- preferred starting posture for recurring contexts, such as sim-racing setups
+- aliases
+- targets
+- ordered routines
+- profiles and recurring contexts
 
-At planning level, this contract should support user-defined targets like:
+It may later support bounded user preferences for supported web-facing or external actions, but those capabilities should remain explicit and inspectable.
 
-- `Launch Sim`
-- `Start Racing`
-- `Open Work Setup`
+This document does not define the exact storage schema, editor UI, or execution engine for those features.
 
-without forcing every user into the same built-in command map.
+## Release-Stage View
 
-As the interaction model grows, customization should also allow bounded preference control over supported web-facing actions, such as:
+At architecture level:
 
-- which browser Nexus uses for supported search or web actions
-- which user-approved external web destination should be used when more than one valid route exists
+- `pre-Beta` proves the interaction model and current desktop command surface
+- `Beta` expands that model into a more installable and broadly testable product surface
+- `Full` may later widen into richer voice, authoring, and profile capabilities
 
-Those later capabilities should remain:
-
-- user-controlled
-- explicit
-- privacy-aware
-- downstream of the same shared action model rather than separate hardcoded pathways
-
-## Release-Stage Model
-
-At planning level, the release stages for this interaction lane should follow the product-wide release-stage framing in `orin_vision.md`:
-
-- `pre-Beta`
-  - internal or tightly controlled delivery of the first usable interaction slices
-  - architecture, interaction model, and command-surface proof rather than packaged user distribution
-- `Beta`
-  - a packaged, installable, user-facing release with a real `.exe` or installer path, stable setup expectations, and practical customization
-- `Full`
-  - the broader mature interaction system beyond the first installable/testing release
-
-## Pre-Beta Release Direction
-
-The pre-Beta phase should prioritize the smallest coherent user-visible interaction foundation.
-
-At planning level, pre-Beta should center on:
-
-- the quick command overlay
-- typed natural-language command entry
-- the shared action model underneath typed commands and future voice commands
-- saved actions, aliases, routines, and profiles
-- a clear runtime/status surface for launched actions
-
-Pre-Beta should aim to prove:
-
-- Jarvis can feel like a coherent command surface rather than a generic app menu
-- users can define reusable launch actions and routines for their own machine
-- typed interaction already uses the same model that future voice interaction will depend on
-
-## Pre-Beta First Deliverable Direction
-
-The first pre-Beta deliverable should be the smallest typed-first slice of this interaction model:
-
-- a dismissible quick command overlay
-- natural-language typed command entry
-- a minimal shared action model for direct actions and saved aliases
-- desktop-mode confirmation before executing the resolved action
-
-This first deliverable should not require the full Action Studio, wake-word support, or advanced routine graphing.
-
-Current merged repo truth is already one step beyond that first deliverable.
-
-The repo now also includes:
-
-- the first reusable shared action model underneath the typed command surface
-- the first bounded non-UI saved-action source seam above that shared action model
-- the first restart-based starter bootstrap path for `saved_actions.json` at the default runtime source location
-- built-in direct actions to open the default saved-actions file and its containing folder from the same typed command surface
-- backward-compatible preservation of unrelated valid saved actions when legacy saved-actions file or folder helpers collide with those built-ins
-- preserved exact-match resolution semantics and the existing typed-first confirm-before-execute contract while those architectural seams were introduced
-
-Current merged repo truth now reaches the first coherent saved-action usability milestone above that starter-bootstrap baseline.
-
-## Beta Release Direction
-
-At planning level, the Beta release should expand the proven pre-Beta interaction foundation into a packaged and installable user-facing release.
-
-Beta may later include:
-
-- a real `.exe` or installer path
-- stable install-time setup expectations
-- practical user-facing customization beyond the first internal slice
-- stronger reliability and usability for broader testing
-
-## Full Release Direction
-
-At planning level, the Full release may later expand into:
-
-- wake-word voice invocation
-- stronger voice parity with typed commands
-- optional spoken response or confirmation support for more hands-free interaction
-- richer saved routines and environment profiles
-- more advanced customization surfaces
-- import/export or sharing of user-defined actions
-- bounded user-approved external-assistant or web handoff actions if they remain privacy-aware and clearly inspectable
-- future plugin capability if the shared action model proves stable enough
-
-These later additions should remain downstream of the same shared action system rather than becoming parallel products.
+The release-stage view belongs here only as interaction-system framing.
+Specific sequencing belongs in the roadmap and specific execution belongs in workstream records.
 
 ## Explicit Deferrals
 
-This planning baseline intentionally defers:
+This architecture document does not define:
 
 - wake-word implementation mechanics
 - speech-to-text or local-audio pipeline mechanics
-- shell, tray, renderer, or notification mechanics
-- exact runtime execution engine mechanics
-- auth backend or trust mechanics
-- Windows Hello or TOTP implementation mechanics
-- plugin architecture and plugin lifecycle design
-- exact screen layout or UI flow details for the Action Studio
-- advanced node-graph or visual process-tree editing
+- tray, shell, renderer, or notification implementation details
+- auth or trust backend mechanics
+- plugin lifecycle design
+- exact Action Studio screen layout
+- detailed routine-graph editing UX
 
-## Out-Of-Bounds Patterns
+## Failure Modes To Avoid
 
-The following are out of bounds for this planning baseline:
+The interaction architecture is drifting if future work turns it into:
 
-- building separate logic stacks for voice commands and typed commands
-- treating voice-only interaction as sufficient
-- treating typed interaction as a temporary debug path rather than a first-class certainty path
-- collapsing Jarvis into a generic launcher with no user-defined action model
-- turning the first pre-Beta slice into plugin work
-- coupling the interaction layer to launcher-owned desktop authority or control decisions
+- a generic launcher with no coherent interaction identity
+- disconnected typed, voice, and saved-action systems
+- an opaque execution surface with weak confirmation
+- a system where typed input is treated as a temporary fallback instead of a first-class path
 
-## Success Criteria
-
-This planning baseline is heading in the right direction if future implementation makes it feel like:
-
-- Jarvis is the command surface
-- Jarvis is understandable and customizable
-- Jarvis can be shaped around the user's machine and habits
-- voice and typed interaction feel like two entry paths into one coherent system
-
-This planning baseline is drifting if future implementation makes it feel like:
-
-- a generic desktop app launcher
-- a brittle command parser with exact syntax only
-- an opaque automation engine the user cannot inspect
-- disconnected voice, typed, and preset systems pretending to be one product
+The architecture is holding together if future work keeps all interaction surfaces aligned to one inspectable shared action model.

--- a/Docs/orin_task_template.md
+++ b/Docs/orin_task_template.md
@@ -2,27 +2,30 @@
 
 You are working inside the Nexus Desktop AI project as an implementation and analysis partner.
 
-## Authoritative Source of Truth
+## Authoritative Source Of Truth
 
 Treat the following files as authoritative unless a direct verified implementation-state conflict is found:
 
-- C:\Nexus Desktop AI\Docs\development_rules.md
-- C:\Nexus Desktop AI\Docs\Main.md
-- C:\Nexus Desktop AI\Docs\architecture.md
-- C:\Nexus Desktop AI\Docs\orin_vision.md
-- C:\Nexus Desktop AI\Docs\feature_backlog.md
-- C:\Nexus Desktop AI\Docs\orchestration.md
-- C:\Nexus Desktop AI\Docs\[relevant consolidated canonical design docs]
-- C:\Nexus Desktop AI\Docs\[relevant prior version closeout docs]
+- `C:\Nexus Desktop AI\Docs\development_rules.md`
+- `C:\Nexus Desktop AI\Docs\Main.md`
+- `C:\Nexus Desktop AI\Docs\architecture.md`
+- `C:\Nexus Desktop AI\Docs\orin_vision.md`
+- `C:\Nexus Desktop AI\Docs\feature_backlog.md`
+- `C:\Nexus Desktop AI\Docs\orchestration.md`
+- `C:\Nexus Desktop AI\Docs\[relevant canonical workstream docs]`
+- `C:\Nexus Desktop AI\Docs\[relevant rebaseline or closeout docs]`
 
-If anything in this request conflicts with those docs, call it out explicitly before proceeding.
+If anything in the request conflicts with those docs, call it out explicitly before proceeding.
 
-Prompt hygiene:
-- Use `C:\Nexus Desktop AI\Docs\Main.md` as the index for selecting the smallest correct docs baseline.
-- The default prompt baseline should usually be `development_rules.md`, `Main.md`, the directly relevant canonical doc or docs, and only the relevant evidence inputs.
-- If a consolidated canonical design or planning doc exists for the active workstream, include that doc and omit superseded slice docs unless the task is explicitly tracing history or auditing the consolidation.
-- Do not bulk-list archival planning slice docs as equal-weight prompt inputs once a canonical consolidation exists.
+## Prompt Hygiene
+
+- Use `C:\Nexus Desktop AI\Docs\Main.md` as the routing index for selecting the correct authority baseline.
+- The default prompt baseline should usually be `development_rules.md`, `Main.md`, the directly relevant authority docs, and the evidence inputs needed to validate live truth.
+- If a canonical workstream, rebaseline, or consolidated design doc exists for the active question, prefer that authority doc over a stack of superseded slice docs.
 - Include prior closeout docs and older slice docs only when they are still materially relevant to the specific task.
+
+Concise prompts are acceptable.
+They do not reduce the required depth of analysis.
 
 ## Current Project State
 
@@ -35,27 +38,36 @@ Branch:
 Task mode:
 [analysis-only / planning-only / docs-only / patch / review / release-workflow]
 
-Note: Task mode defines the task type. Codex collaboration posture is defined separately in `C:\Nexus Desktop AI\Docs\codex_modes.md`.
+Note: task mode defines the task type. Codex collaboration posture is defined separately in `C:\Nexus Desktop AI\Docs\codex_modes.md`.
 
 Default expectation:
-- If task mode is `patch`, perform the change unless blocked by a real conflict.
-- If task mode is `analysis-only`, `planning-only`, or `docs-only`, do not patch.
-- If task mode is `patch`, prioritize the core code task and bundle only the directly supporting truth-doc updates needed to keep canonical docs aligned when that is safe and in scope.
 
-Current accepted state:
+- if task mode is `analysis-only` or `planning-only`, do not patch
+- if task mode is `docs-only`, change docs only inside the approved boundary
+- if task mode is `patch`, perform the approved implementation work unless blocked by a real conflict
+
+## Current Accepted State
+
 - [fill in the current version status]
 - [fill in the relevant completed revisions]
 - [fill in the relevant guarantees already established]
 
-Carry-forward / prompt reduction audit:
-- [what must be carried forward from the last closeout or prior canonical baseline]
-- [what can now be removed from this prompt because current source-of-truth docs already cover it]
+## Carry-Forward Review
 
-For the first planning prompt after a version closeout, this audit should be filled in explicitly.
+Classify prior suggestions, branch conclusions, or closeout output as:
+
+- carry forward
+- defer
+- discard
+
+Do not treat prior suggestions as automatic scope.
+
+For the first planning prompt after a merge or release, this review should be filled in explicitly.
 
 ## Evidence Inputs
 
 Use the following as part of the task evidence set when relevant:
+
 - [uploaded files]
 - [logs]
 - [screenshots]
@@ -67,12 +79,13 @@ If critical evidence is missing, say so explicitly.
 
 ## Locked Boundaries / Do Not Reopen
 
-Do not casually reopen or "small improve":
+Do not casually reopen:
+
 - [locked behavior 1]
 - [locked behavior 2]
 - [locked behavior 3]
 
-If any future version should intentionally change those, treat that as a deliberate new system phase, not a cleanup tweak.
+If any future version should intentionally change those, treat that as a deliberate new workstream or system phase, not a cleanup tweak.
 
 ## Task
 
@@ -81,29 +94,21 @@ Your job is to:
 
 ## Workstream Identity
 
-Use this section when the task is a coherent batched workstream:
+Use this section when the task is a coherent workstream:
 
 - subsystem: [one subsystem only]
 - end-state: [one concrete end-state]
 - approved subproblem: [one coherent approved subproblem]
 
-## Branch Milestone Value
+## Branch And Milestone Context
 
-Use this section for non-doc implementation branches:
+Use this section when the branch matters to the task:
 
-- milestone value: [why this branch is worth merging or releasing once complete]
-- same-branch follow-through: [dependent slices that still belong on this branch before readiness]
-- early-stop risk: [what would make the branch feel too small if it stopped after the first validated slice]
+- milestone value: [why this branch or docs program is worth completing]
+- same-branch follow-through: [dependent work that still belongs on this branch before readiness]
+- branch posture: [fresh branch from updated main / continue approved active branch / analysis only]
 
-## Approved Batch Chain
-
-Use this section only when the task intentionally batches dependent slices:
-
-1. [slice 1]
-2. [slice 2]
-3. [slice 3]
-4. [optional slice 4]
-5. [optional low-risk completion slice 5]
+If a lane was already closed, merged, or released, the next workstream should start from updated `main` on a fresh branch.
 
 ## Goal
 
@@ -113,11 +118,13 @@ The goal of this task is:
 ## Scope
 
 In scope:
+
 - [scope item 1]
 - [scope item 2]
 - [scope item 3]
 
 Out of scope:
+
 - [out-of-scope item 1]
 - [out-of-scope item 2]
 - [out-of-scope item 3]
@@ -125,77 +132,108 @@ Out of scope:
 ## Allowed Changes
 
 You may change:
+
 - [allowed file / module / doc 1]
 - [allowed file / module / doc 2]
 
 You may add only if required for the approved scope:
+
 - [new helper / runner / doc if needed]
 
 ## What Must Not Change
 
 Do not change:
+
 - [file, subsystem, or behavior 1]
 - [file, subsystem, or behavior 2]
 - [file, subsystem, or behavior 3]
 
-## Constraints
+## Analysis-Phase Rules
 
-Follow these strictly:
-- analyze first
-- patch second
+Before proposing implementation, Codex should:
+
+- validate live repo truth
+- scan broadly enough to understand the affected system
+- identify factual, structural, and authority drift where relevant
+- report risks, dependencies, and options clearly
+- avoid premature scope compression before the user and ChatGPT choose execution boundaries
+
+If the request is analysis-heavy, do not turn it into a bounded executor prompt too early.
+
+## Execution-Phase Rules
+
+After analysis is complete and execution scope is approved, follow these discipline rules:
+
 - verify exact failure path or behavior before changing logic
 - no blind iteration
-- one fix per revision
-- no regressions
-- minimal isolated changes only
+- one coherent approved subproblem per revision
 - preserve architecture boundaries
-- instrument first, patch second
 - keep source-of-truth docs aligned with actual implemented state
 - production behavior must remain unchanged unless explicitly in scope
 
+Execution-specific discipline such as:
+
+- minimal isolated changes
+- smallest coherent execution slice
+- bounded implementation
+- narrow fix pass
+
+belongs here, after scope has been selected.
+
 Additional task-specific constraints:
+
 - [constraint 1]
 - [constraint 2]
 - [constraint 3]
 
-For collaboration-mode and batched-workstream execution specifics, rely on `C:\Nexus Desktop AI\Docs\codex_modes.md` unless this task needs a deliberate task-specific override.
-
 ## Guidance
 
-Operate like a careful senior collaborator, not a narrow worker bee.
+Operate like a careful senior collaborator.
 
 That means:
+
 - validate assumptions against the docs and current repo state
-- choose the smallest worthwhile branch milestone first, then break it into the smallest safe or smallest coherent approved slices needed to complete that milestone
-- do not stop at the first validated slice if the branch would still be too small to justify its declared release floor
+- reason broadly before deciding execution shape
 - call out risks or drift clearly
 - avoid speculative rewrites
 - do not widen scope without justification
-- if the task is too broad, tighten it and explain why
-- when code work is the primary deliverable, prefer keeping directly supporting truth-doc sync inside that same workstream rather than forcing repeated separate doc-only micro-passes
+- when code work is the primary deliverable, keep directly supporting truth-doc sync inside the same approved workstream when that preserves canon coherence
+- when live truth shows a closed lane or released branch is no longer the right base, call that out and move the next workstream to updated `main` on a fresh branch
+
+If an execution task is too broad for one approved pass, explain the cleaner execution shapes after analysis rather than shrinking the investigation itself.
 
 ## Required Workflow
 
-Before patching:
-1. Read the source-of-truth docs
-2. Inspect the relevant repo/code state
-3. Inspect the provided evidence inputs
-4. Explain the exact planned scope, branch milestone value, and any same-branch follow-through that still belongs before readiness
-5. Call out any conflicts, risks, or cleaner narrower alternatives
+### Before Changing Anything
 
-Then:
-1. Perform only the approved narrow change
-2. Verify the result directly
-3. Report what changed and what was verified
+1. Read the source-of-truth docs.
+2. Inspect the relevant repo, code, or doc state.
+3. Inspect the provided evidence inputs.
+4. Validate branch, release, and current-truth posture when relevant.
+5. Report the actual state, risks, conflicts, and dependencies.
+
+### Before Execution
+
+1. Explain the approved execution scope.
+2. Explain the branch or workstream posture.
+3. Explain the validation plan.
+
+### During Execution
+
+1. Perform only the approved execution work.
+2. Verify the result directly.
+3. Report what changed and what was verified.
 
 ## Verification Requirements
 
 At minimum, verify:
+
 - [verification item 1]
 - [verification item 2]
 - [verification item 3]
 
 If applicable, also verify:
+
 - healthy path
 - failure path
 - artifact cleanup
@@ -205,42 +243,45 @@ If applicable, also verify:
 ## Done When
 
 This task is complete only when:
+
 - [done condition 1]
 - [done condition 2]
 - [done condition 3]
 - no unrelated behavior changed
-- the result stays inside scope
+- the result stays inside approved scope
 - verification evidence supports the claimed result
 
 ## Stop Conditions
 
 Stop and explicitly report if:
+
 - source-of-truth docs conflict with the request
 - critical evidence is missing
 - the task would require reopening locked architecture
-- the task is too broad for one revision
 - safe verification is not possible
+- the task needs a new branch basis because the current one is stale, merged, or no longer the right execution base
 
 ## Required Output Format
 
-A. Source-of-truth validation result  
-B. Recommended scope / implementation plan  
-C. Files changed or to be changed  
-D. Risks, conflicts, or notable design choices  
-E. Verification summary  
-F. Any doc updates made or why none were needed  
+A. Source-of-truth validation result
+B. Recommended plan or execution summary
+C. Files changed or to be changed
+D. Risks, conflicts, or notable design choices
+E. Verification summary
+F. Any doc updates made or why none were needed
 
-If relevant, also include:  
-G. Commit summary  
-H. Commit description  
-I. PR title  
-J. PR description  
+If relevant, also include:
+
+G. Commit summary
+H. Commit description
+I. PR title
+J. PR description
 
 ## Important
 
-- Do not write code if this is analysis-only
-- Do not patch files if this is planning-only
-- Do not reopen closed version behavior
-- Do not smuggle in policy or authority changes
-- Do not modify backlog status or add backlog items unless the task explicitly authorizes backlog updates
-- If the task is too broad, tighten it and explain why
+- Do not write code if this is analysis-only.
+- Do not patch files if this is planning-only.
+- Do not reopen closed version behavior without explicit approval.
+- Do not smuggle in policy or authority changes outside the approved task.
+- Do not modify backlog status or add backlog items unless the task explicitly authorizes backlog updates.
+- Do not force a docs-only canon repair onto a hypothetical implementation branch when live truth justifies standalone docs work.

--- a/Docs/orin_vision.md
+++ b/Docs/orin_vision.md
@@ -1,76 +1,78 @@
-# Jarvis Vision
+# Nexus / ORIN Vision
+
+## Purpose
+
+This document defines product intent for Nexus Desktop AI and the ORIN assistant layer.
+
+It does not own:
+
+- workstream closure
+- backlog identity
+- roadmap sequencing
+
+Use it for product direction, experience intent, and release-stage meaning.
 
 ## Core Product Goal
 
-Jarvis is not intended to feel like a normal desktop app that opens after Windows.
+Nexus Desktop AI should eventually feel like the system-facing experience layer, not just a normal desktop app launched after Windows.
 
-The long-term goal is:
+The long-term direction is:
 
 Windows boots
--> Jarvis startup and orchestration begins
--> Jarvis becomes the primary visible experience
--> the desktop exists underneath as the underlying operating system layer
-
-Jarvis should feel like the system-facing layer, not just a program running on top of Windows.
-
-## Experience Goal
-
-The user experience should feel like:
-
-- the machine is booting into Jarvis
-- Jarvis is coming online as the interface layer
-- Windows is present underneath, but not the star of the experience
-- Jarvis transitions from boot presence into desktop presence cleanly
+-> Nexus startup and orchestration begins
+-> ORIN becomes the primary visible assistant experience
+-> Windows remains the underlying host platform
 
 ## Current Reality
 
-Current architecture is still a staged desktop and orchestration subsystem:
+The current merged runtime is still a controlled desktop orchestration path:
 
-`launch_jarvis_desktop.vbs`
--> `jarvis_desktop_launcher.pyw`
--> `jarvis_desktop_main.py`
+`launch_orin_desktop.vbs`
+-> `desktop/orin_desktop_launcher.pyw`
+-> `desktop/orin_desktop_main.py`
 
-This is not yet the final boot experience.
-It is the current controlled orchestration path used to stabilize startup, recovery, and lifecycle behavior.
+That path is foundation work.
+It stabilizes startup, recovery, diagnostics, and lifecycle behavior.
+It is not yet the final boot-first product experience.
 
-## Long-Term Direction
+## Experience Intent
 
-Jarvis should eventually own or coordinate:
-
-- system startup presentation
-- boot-to-desktop transition
-- immersive visual handoff into the desktop state
-- startup voice timing
-- persistent desktop presence
-- controlled recovery and diagnostics behavior
-
-## Important Design Principle
-
-Do not confuse the current launcher path with the final product vision.
-
-Current launcher and orchestration work is foundation work.
-It exists to make the future boot-to-Jarvis experience stable, observable, and controllable.
-
-## Architectural Intent
-
-Windows is the host platform.
-Jarvis is the intended user-facing system layer.
-
-That means future design should trend toward:
+The experience should trend toward:
 
 - Windows as infrastructure
-- Jarvis as experience
+- Nexus Desktop AI as the visible experience layer
+- ORIN as the assistant presence that gives the product identity
 
-not:
+The product should not feel like:
 
-- Windows as experience
-- Jarvis as just another application
+- Windows as the experience and Nexus as a small overlay
+- a generic utility app running on top of the desktop
 
-## Scope Reminder
+## Product Principles
 
-This vision does not mean all boot ownership should be implemented immediately.
+Nexus Desktop AI should feel:
 
-Boot ownership, startup immersion, login and launch timing, shell behavior, and Windows integration should be handled as later dedicated revision tracks after orchestration is stable.
+- system-facing
+- intentional
+- calm under normal use
+- explicit when trust or recovery posture changes
+- recoverable rather than opaque
+
+The system should not rely on:
+
+- hidden state
+- unexplained automation
+- accidental authority drift between launcher, renderer, planning docs, and user-facing reporting
+
+## Release-Stage Meaning
+
+Across the product:
+
+- `pre-Beta` means architecture, runtime boundaries, validation, and internal product shape are still stabilizing
+- `Beta` means the product is coherent enough for broader user-facing evaluation and setup expectations
+- `Full` means the product has crossed from staged system foundation into mature product delivery
+
+This means the repo may contain meaningful `pre-Beta` implementation progress without claiming Beta readiness.
 
 ## Future Boot Preference Model
 
@@ -79,80 +81,33 @@ Before `Beta`, the Boot portion of Nexus Desktop AI should become a user-control
 That future model should mean:
 
 - the user can intentionally enable or disable the Boot experience
-- if setup requires Windows login, startup, or boot-configuration changes, the product should guide the user through a detailed setup flow rather than expecting manual system tweaking
-- the setup path should explain what is changing, why it is needed, and how to undo it safely
+- if setup requires Windows login, startup, or boot-configuration changes, the product should guide the user through that setup
+- the current desktop runtime path remains valid even when future boot-facing work is deferred
 
-This is future product and setup planning only.
-It does not authorize immediate boot-ownership implementation.
+## Trust And Recovery Posture
 
-## Product Release-Stage Framing
+Nexus should eventually present trust, recovery, and post-login continuity as one coherent experience layer, but the repo is not there yet.
 
-Across the Jarvis product, release stages should be understood as:
+Current merged truth should still be read as:
 
-- `pre-Beta`
-  - internal or tightly controlled delivery of the first usable system slices
-  - architecture proof, interaction proof, and product-shape validation rather than installable public-facing distribution
-- `Beta`
-  - a packaged, installable, user-facing release with a real `.exe` or installer path, practical setup expectations, and enough stability for broader real-world testing
-- `Full`
-  - the broader mature product beyond the first installable/testing release
+- desktop orchestration first
+- future boot and access planning deferred
+- product trust and resident presence concepts still living at planning level
 
-This means Jarvis may have meaningful pre-Beta implementation progress without yet being considered Beta.
+## Historical Relationship
 
-Beta should not be assumed merely because:
+The public Nexus release line begins after the preserved Jarvis historical release line.
 
-- a lane becomes user-visible internally
-- a planning doc defines a first deliverable
-- one subsystem becomes coherent enough for controlled internal use
+That means:
 
-The product should not be treated as Beta until the installable and user-facing release threshold is intentionally reached.
+- older Jarvis releases remain preserved as historical records
+- they do not define the active public Nexus release line
+- current vision and current release posture should be expressed in Nexus / ORIN terms unless a section is explicitly historical
 
-## Nexus Public Release Baseline
+## Relationship To Other Canon Layers
 
-The Nexus public release line begins after the preserved Jarvis historical release line.
-
-For the first Nexus public release baseline:
-
-- first public release title: `Nexus Desktop AI — Pre-Beta v1.0.0`
-- first public tag: `v1.0.0-prebeta`
-- next release after that: `v1.0.1-prebeta`
-- all `pre-Beta` and `Beta` GitHub releases must be published as prereleases
-- old Jarvis-tagged releases and tags remain preserved as legacy/internal historical records
-- old Jarvis-tagged releases and tags do not define the active Nexus public line
-- GitHub `Latest` handling for the Nexus public line must be chosen deliberately at release time rather than assumed automatically
-
-## Behavior Philosophy (Early Definition)
-
-Jarvis should behave conservatively first:
-
-- prefer cooperative control over forced control
-- prefer staged escalation over immediate action
-- prefer recovery over termination
-- avoid aggressive retry loops without classification
-
-Jarvis should not behave like a script.
-Jarvis should behave like a system that understands its own state.
-
-## Privacy And User Control Direction
-
-As Nexus Desktop AI grows beyond the first pre-Beta command slices, privacy and user control should remain first-class product constraints rather than later add-ons.
-
-At planning level, that means future Nexus-era behavior should prefer:
-
-- explicit user choice over hidden third-party routing
-- user-visible control over supported browser or web-destination preferences
-- minimizing unnecessary third-party tracking exposure where practical
-- clear user understanding of when Nexus is invoking a local action versus handing off to an external web or assistant surface
-
-This direction does not authorize immediate implementation of browser-routing features, tracking-blocking mechanics, or external-assistant integrations.
-It exists to preserve the intended product posture for later bounded planning and implementation work.
-
-## Product Direction Reminder
-
-The current desktop launcher path is a foundation layer, not the final identity of the product.
-
-Future decisions should be checked against this question:
-
-Does this make Jarvis feel more like the system-facing experience, or more like a normal Windows app?
-
-If it only improves the app layer while drifting away from the system-layer vision, that tradeoff should be called out explicitly before implementation.
+- use `Docs/architecture.md` for architectural boundaries
+- use `Docs/orchestration.md` for orchestration behavior and runtime ownership
+- use `Docs/boot_access_design.md` for future boot-access planning
+- use `Docs/prebeta_roadmap.md` for sequencing and release posture
+- use `Docs/workstreams/...` for promoted workstream history

--- a/Docs/ownership_ip_plan.md
+++ b/Docs/ownership_ip_plan.md
@@ -2,30 +2,40 @@
 
 ## Purpose
 
-This document preserves the current ownership, licensing, copyright, and future trademark-planning posture for the Jarvis repository and the Nexus Desktop AI product line.
+This document preserves the current ownership, licensing, copyright, and future trademark-planning posture for Nexus Desktop AI and its assistant personas.
 
 It is planning guidance only.
 It is not formal legal advice and does not replace qualified legal counsel.
 
-## Current Approved Posture
+## Current Identity Context
 
-Current approved repo-root posture:
+Current canon uses these identity boundaries:
+
+- repository and workspace identity: `Nexus Desktop AI`
+- product and platform identity: `Nexus Desktop AI`
+- current shipped assistant persona: `ORIN`
+- future optional persona: `ARIA`
+
+Historical `Jarvis` references may remain in preserved historical material or still-real runtime artifact names, but they do not define current product identity.
+
+## Current Approved Ownership And Licensing Posture
+
+Current approved posture is:
 
 - current copyright holder: `Anden Lee Schmitt`
 - copyright exists automatically upon creation
-- current repo-root licensing posture: restrictive proprietary / all-rights-reserved
-- current repo name remains `Jarvis`
-- current product/platform identity is `Nexus Desktop AI`
+- current repository licensing posture: restrictive proprietary / all-rights-reserved
+- repo permissions and public-facing wording should not imply open-source reuse rights unless an explicit later decision changes that posture
 
 This means the current practical default is:
 
 - hold ownership personally for now
-- keep repo permissions restrictive
-- avoid implying open-source reuse rights unless a later explicit decision changes that posture
+- keep repo permissions and license posture restrictive
+- avoid ambiguous wording that suggests broader reuse rights than intended
 
 ## Near-Term Ownership Recommendation
 
-If privacy, long-term commercial control, or cleaner business separation matter, the preferred later path is to move ownership into an LLC or other intentional legal entity before later public or commercial stages.
+If privacy, liability separation, or cleaner commercial structure become more important, the preferred later path is to move ownership into an LLC or other intentional legal entity before broader commercial stages.
 
 The currently acceptable interim path is:
 
@@ -33,83 +43,69 @@ The currently acceptable interim path is:
 2. form the LLC/entity later if and when that becomes practical
 3. transfer ownership from the personal holder to the LLC/entity by written agreement
 
-Until that later transfer happens, repo-root ownership references should continue to reflect the current approved personal owner.
+Until that transfer happens, ownership references should continue to reflect the current personal owner accurately.
 
 ## Milestone Breakpoints
 
-### Now / Current Branch Merge-Readiness
+### Current Stage
 
 Current practical posture:
 
 - use the approved personal owner: `Anden Lee Schmitt`
-- use restrictive proprietary / all-rights-reserved repo-root posture
-- keep repo-root licensing and ownership references explicit enough that repo permissions are not ambiguous
+- use restrictive proprietary / all-rights-reserved repo posture
+- keep ownership and licensing references explicit enough that repo rights are not ambiguous
 
 ### Before Beta
 
-Before `Beta`, review whether ownership should still remain personal or whether an LLC/entity should be formed first.
+Before `Beta`, review:
 
-If privacy, cleaner contracting, or commercial control matter by that stage, the preferred path is:
+- whether ownership should still remain personal
+- whether an LLC/entity should be formed first
+- whether the current restrictive license notice is still sufficient for the intended distribution posture
 
-- form the LLC/entity before broader public-facing or commercial stages if practical
-- decide whether repo-root ownership references should remain personal temporarily or be updated after written transfer
-- review whether the current root `LICENSE` should remain a minimal restrictive notice or be expanded into a fuller proprietary license instrument before broader public-facing distribution
+### Before Commercialization
 
-### Before Commercialization / Monetization
-
-Before meaningful commercialization, monetization, or broader productization:
+Before meaningful commercialization or broader productization:
 
 - re-check whether personal ownership is still the right posture
 - consider entity formation if it has not happened yet
-- make sure any later ownership transfer is handled in writing
-- consider replacing the minimal restrictive repo-root `LICENSE` with a fuller proprietary license text if the project is moving into broader public, commercial, or enforcement-sensitive use
+- make sure any later ownership transfer is documented in writing
+- review whether the repository license text should be expanded into a fuller proprietary instrument for broader public or enforcement-sensitive use
 
 ### After LLC / Entity Formation
 
 Once an LLC/entity exists and ownership is intentionally moved:
 
 - execute the ownership transfer in writing
-- update repo-root licensing and ownership references from the personal owner to the legal entity
-- keep the transfer record with project/business records
+- update ownership and licensing references from the personal owner to the legal entity
+- preserve the transfer record with project and business records
 
-### When The Codebase Reaches Meaningful Value / Shipping Maturity
+### When The Codebase Reaches Meaningful Value
 
 When the codebase becomes substantial enough or commercially meaningful enough, U.S. copyright registration should be considered.
 
-That is not required for copyright to exist.
-It is a later protection milestone to consider once the work has meaningful value, shipping weight, or enforcement importance.
+Registration is not required for copyright to exist.
+It is a later protection step that may matter once the work has meaningful shipping, commercial, or enforcement value.
 
 ## Future Trademark Path
 
-If `Nexus Desktop AI`, `ORIN`, and later `ARIA` become commercially meaningful names, trademark clearance/search should be considered before or around public `Beta` or commercialization.
-
-If the project moves toward real productization, later trademark filing in priority markets should also be considered.
+If `Nexus Desktop AI`, `ORIN`, or `ARIA` become commercially important names, trademark clearance and later filing should be considered before or around broader productization.
 
 Practical order:
 
-1. perform trademark clearance/search before relying on the names commercially
+1. perform trademark clearance before relying on the names commercially
 2. decide which names are important enough to protect
-3. consider filing in priority markets if the product is moving into real commercial use
+3. consider filing in priority markets if the product moves into real commercial use
 
-## Practical Rule Of Thumb
-
-Use this simple planning order:
-
-1. now: personal ownership plus restrictive proprietary / all-rights-reserved posture
-2. before `Beta`: review LLC/entity timing
-3. before commercialization: review ownership structure and trademark clearance
-4. after LLC/entity formation: transfer ownership in writing and update repo-root ownership references
-5. when the codebase becomes materially valuable: consider U.S. copyright registration
-
-## Scope Boundary
+## Boundary Reminder
 
 This document does not authorize:
 
 - legal filings
 - trademark filings
 - copyright registration work
-- repo rename work
-- release-line work
-- runtime/code changes
+- release work
+- repo or product renaming by itself
+- runtime or code changes
 
-It exists to preserve the intended ownership/IP protection path in one canonical source-of-truth location.
+It exists to preserve the intended ownership and IP-protection posture in one reference location that stays aligned to current product identity.

--- a/Docs/prebeta_roadmap.md
+++ b/Docs/prebeta_roadmap.md
@@ -1,276 +1,128 @@
-# Pre-Beta Roadmap
+# Nexus Pre-Beta Roadmap
 
 ## Purpose
 
-This document is the canonical near-term planning interface for current Nexus `pre-Beta` sequencing.
+This document is the sequencing and release-posture layer for current Nexus `pre-Beta` planning.
 
 Use it for:
 
-- the current near-term roadmap horizon
-- the current best next lane candidates
-- provisional sequencing
-- provisional release-floor and target-version planning
-- roadmap refresh triggers
-- roadmap entry lifecycle/status handling
+- latest public prerelease truth
+- release-debt posture
+- current sequencing posture
+- recently closed milestone context
 
-This document is intentionally:
-
-- provisional
-- near-term
-- subject to refresh after milestone merge, release, or meaningful baseline change
-
-This document is **not**:
+Do not use it as:
 
 - a second backlog
-- a release log
-- a fixed branch promise sheet
+- a workstream execution diary
+- a substitute for canonical workstream records
 
 ## Authority And Boundaries
 
 This roadmap is subordinate to:
 
-- `docs/development_rules.md`
-- `docs/codex_modes.md`
-- `docs/closeout_guidance.md`
-- `docs/orin_vision.md`
-- `docs/feature_backlog.md`
+- `Docs/development_rules.md`
+- `Docs/codex_modes.md`
+- `Docs/feature_backlog.md`
+- `Docs/workstreams/index.md`
+- `Docs/closeout_guidance.md`
 
 That means:
 
-- `development_rules.md` and `codex_modes.md` still own workflow, branch, and governance boundaries
-- `closeout_guidance.md` still owns closeout and rebaseline cadence
-- `orin_vision.md` still owns release-stage meaning for `pre-Beta`, `Beta`, and `Full`
-- `feature_backlog.md` still owns detailed future-work item truth, scope, and backlog control
+- backlog owns identity
+- workstream docs own promoted-work execution and closure truth
+- closeouts and rebaselines own epoch summaries
+- roadmap owns sequencing and release posture only
 
-If this roadmap conflicts with those docs, those docs win.
+## Lane Types And Release Fields
 
-## Lane Types, Release Floors, And Release States
-
-Use these lane types in this roadmap:
+Use these lane types:
 
 - `docs-only`
 - `implementation`
 - `rebaseline`
 
-Use these release floors in this roadmap:
+Use these release-floor values:
 
 - `no release`
 - `patch prerelease`
 - `minor prerelease`
 
-Use these release states when relevant:
+Use these release-state values when relevant:
 
 - `active delta`
 - `merged unreleased`
 - `released`
 - `closed`
 
-These fields are planning guidance only.
+## Current Release Posture
 
-They do not:
+Current merged truth indicates:
 
-- assign fixed future version numbers
-- guarantee that a listed branch will ship
-- turn a release floor into an approved release by itself
+- latest public prerelease: `v1.2.7-prebeta`
+- latest public release commit: `3168823`
+- no merged unreleased non-doc implementation debt currently exists on `main`
+- no active non-doc implementation lane is currently selected on merged truth
 
-Actual release decisions still depend on live repo truth, milestone value, and later readiness review.
+That means the repo is between implementation lanes, not automatically continuing the old FB-035 branch.
 
-Rules:
+## Recently Closed Workstreams
 
-- `no release` should normally be limited to `docs-only` or docs-only `rebaseline` lanes
-- non-doc `implementation` lanes should usually declare at least `patch prerelease`
-- larger subsystem or capability shifts may justify `minor prerelease`
-- if merged unreleased implementation work already exists on `main`, that should be treated as release debt rather than as normal background drift
+### FB-035 Release-Context Fallback Hardening
 
-## Entry Lifecycle
-
-Use only these statuses in this roadmap:
-
-- `candidate`
-- `active`
-- `merged`
-- `closed`
-- `deferred`
-- `superseded`
-
-Handling rule:
-
-- keep active near-term entries here while they remain useful for current sequencing
-- move closed or superseded items out of the active near-term horizon once they stop helping next-lane planning
-- keep detailed implementation truth in `docs/feature_backlog.md`, not here
-
-## Lane Milestone Fields
-
-For each `active` grouped lane, and for the current best next `candidate` when one is named here, include:
-
-- `lane type`
-- `milestone target`
-- `minimum merge-ready threshold`
-- `milestone value statement`
-- `expected same-branch follow-through`
-- `release floor`
-- `target version` for non-doc implementation lanes
-- `release state` when merged implementation work already exists for that lane
-
-These fields are still provisional planning guidance.
-
-They do not guarantee that a lane will continue unchanged if live repo truth shifts or a blocker appears.
-
-They do require Codex to judge PR-readiness against the lane milestone rather than against the first clean internal revision.
-
-They should be written in smallest-worthwhile-milestone terms rather than first-safe-slice terms.
-
-If a lane description would make a declared `patch prerelease` read like bookkeeping plus one tiny follow-through, the lane is undersized and should be restated before implementation begins.
-
-## Refresh Triggers
-
-Refresh this roadmap when:
-
-- a meaningful milestone merges to `main`
-- a public prerelease is cut
-- a docs-only rebaseline materially changes the planning baseline
-- the current best next lane changes lifecycle state between `candidate`, `active`, `merged`, `closed`, `deferred`, or `superseded`
-- the current release-debt posture changes
-- `main` materially advances beyond the latest public release and this roadmap no longer matches live repo truth
-
-This roadmap should usually be refreshed on the active implementation branch before PR, or as the first docs-only step on the next implementation branch after release, rather than being deferred into a standalone docs-only refresh branch by default.
-
-## Canon Freshness Timing
-
-For routine Nexus `pre-Beta` work:
-
-- active-lane truth must be synced on the implementation branch before PR packaging
-- release-dependent lifecycle closure should normally be carried on the next implementation branch as its first docs-only step
-- standalone docs-only roadmap or drift-refresh branches are no longer the default post-release cleanup path
-- if no safe next implementation branch can yet be chosen, Codex must call that out explicitly before requesting any exception path
-
-This roadmap should therefore stay fresh in two normal windows only:
-
-- on the active implementation branch before PR
-- at the start of the next implementation branch after a release, when release-closure facts now need to be recorded
-
-## Release-Debt Handling
-
-If `main` already contains merged unreleased non-doc implementation work beyond the latest public prerelease, treat that as release debt.
-
-While release debt exists:
-
-- docs-only governance, rebaseline, or release-support lanes may still proceed when they are directly needed
-- the current best next non-doc move should usually be release review, release prep, or an explicitly approved continuation of the same version-bearing milestone
-- another unrelated non-doc implementation lane should not merge by default
-
-## Current Near-Term Roadmap Horizon
-
-This is the current best provisional sequencing horizon from live repo truth after the live `v1.2.6-prebeta` release.
-
-The just-finished non-doc implementation lane is now:
-
-- `feature/fb-034-recoverable-diagnostics`
-
-That lane is now released and closed at `v1.2.6-prebeta`.
-
-## Current Active Lane
-
-### `feature/release-context-fallback-hardening`
-
-- status: `active`
+- status: `closed`
 - lane type: `implementation`
 - release floor: `patch prerelease`
 - target version: `v1.2.7-prebeta`
-- purpose: harden support-report release-context derivation so support bundles and issue drafts keep reporting the latest public prerelease truth even when `.git` metadata is unavailable
-- milestone target: derive release-context fallback truth from released-prerelease canon rather than from the highest planned prerelease tag, and prove both the `git`-present and `git`-unavailable report-artifact paths carry the same truthful latest-public-prerelease context
-- minimum merge-ready threshold: no new incident classes; no reporting-policy or upload-behavior changes; no diagnostics UI widening; no launcher retry or escalation redesign; no voice-path work; fallback logic derives latest released prerelease truth from canon instead of any highest planned prerelease tag; narrow validation proves both `git`-present and `git`-unavailable paths carry truthful release context; and the branch is strong enough to justify `patch prerelease` rather than reading as a parser tweak without proof
-- milestone value statement: if squashed today, this branch should still read as a worthwhile support-report hardening milestone that prevents unreleased-baseline drift in generated support artifacts rather than as only a tiny parser edit or review-note follow-up
-- expected same-branch follow-through: keep only directly coupled fallback parsing and release-context validation on this branch while needed to make the hardening milestone feel complete, but stop before broader reporting UX, diagnostics policy, or additional incident-class work
+- release state: `released`
+- canonical workstream doc: `Docs/workstreams/FB-035_release_context_fallback_hardening.md`
+- sequencing note: closed the support-report release-context hardening milestone and established the current release-context baseline
 
-This branch begins with the required canon-alignment step on the same implementation branch rather than through a separate standalone docs-only refresh branch.
-
-## Recently Closed Or Superseded Lanes
-
-These entries remain here only long enough to keep the post-`v1.2.6-prebeta` transition explicit.
-
-### `feature/fb-034-recoverable-diagnostics`
+### FB-034 Recoverable Diagnostics
 
 - status: `closed`
 - lane type: `implementation`
 - release floor: `patch prerelease`
 - target version: `v1.2.6-prebeta`
 - release state: `released`
-- purpose: deliver the first worthwhile recoverable-incident milestone that makes the current Class 2/Class 3 boundary explicit for one high-signal incident class without widening diagnostics policy
-- milestone target: keep repeated identical `launch_failed` for the same action as the only selected incident class, make the recoverable Class 2-to-Class 3 boundary explicit enough in renderer evidence that the merged lane reads as a meaningful recoverable-diagnostics milestone on its own, and preserve the existing local/manual reporting boundary without broad diagnostics UI work
-- minimum merge-ready threshold: one incident class only; no launcher retry or escalation redesign; no blanket recoverable diagnostics popup behavior; no broad diagnostics UI redesign; no voice-path work for the lane; fatal launcher/runtime diagnostics path unchanged; manual reporting boundary unchanged; narrow validation proves the selected class behaves as intended; and report artifacts carry truthful latest-public-prerelease context
+- canonical workstream doc: `Docs/workstreams/FB-034_recoverable_diagnostics.md`
+- sequencing note: remains a closed recoverable-diagnostics milestone, not an automatically active continuation lane
 
-### `feature/fb-025-boot-desktop-milestone-taxonomy-clarification`
+### FB-025 Boot/Desktop Taxonomy Clarification
 
 - status: `closed`
 - lane type: `implementation`
 - release floor: `patch prerelease`
 - target version: `v1.2.5-prebeta`
 - release state: `released`
-- purpose: do one tiny boot and desktop milestone taxonomy clarification pass that improves cross-lane diagnostic readability while preserving separate ownership between `BOOT_MAIN|...` and `RENDERER_MAIN|...`
-- milestone target: clarify the specific boot-to-desktop milestone naming shape so request-versus-visible transitions are easier to compare across boot and renderer evidence without broadening the logging contract
-- minimum merge-ready threshold: keep boot and desktop milestone ownership separate; limit the change to naming and taxonomy clarity only; do not change launcher policy, raw verbosity, or shared logging-contract scope; do not change normal user-facing behavior; and prove the affected boot and desktop markers still emit correctly under current flows
+- canonical workstream doc: `Docs/workstreams/FB-025_boot_desktop_milestone_taxonomy_clarification.md`
 
-### `feature/fb-033-startup-snapshot-harness-follow-through`
+### FB-033 Startup Snapshot Harness Follow-Through
 
 - status: `closed`
 - lane type: `implementation`
 - release floor: `patch prerelease`
 - target version: `v1.2.4-prebeta`
 - release state: `released`
-- purpose: finish the dev-only startup snapshot harness as intentional, opt-in debugging infrastructure around startup-state capture without changing normal user-facing startup behavior
-- milestone target: stabilize the current env-gated startup snapshot path as bounded dev-only debugging infrastructure with a repeatable contained validation path, while keeping the helper harness-gated and out of normal product behavior
-- minimum merge-ready threshold: the startup snapshot harness remains explicitly dev-only and opt-in; its owned trigger/env contract and output location are stable on-branch; it does not spill artifacts into live root logs or normal runtime state by default; it works against the current launcher/runtime contract on `main`; and narrow validation proves the intended startup capture path in both healthy and failure-oriented cases
+- canonical workstream doc: `Docs/workstreams/FB-033_startup_snapshot_harness_follow_through.md`
 
-### `feature/fb-028-history-state-relocation`
+### FB-028 History State Relocation
 
 - status: `closed`
 - lane type: `implementation`
 - release floor: `patch prerelease`
 - target version: `v1.2.3-prebeta`
 - release state: `released`
-- purpose: relocate launcher-owned historical state out of the live root `logs` tree without changing historical-memory semantics or widening logs/reporting policy
-- milestone target: move launcher-owned historical state out of the live root `logs` tree into a dedicated non-user-facing launcher-owned state root, with migration and clean fallback, without changing historical-memory semantics or widening logs/reporting policy
-- minimum merge-ready threshold: launcher history resolves to a dedicated state root outside live root `logs`; successful migration no longer leaves the legacy root-log history file exposed; failure to migrate or write still degrades cleanly to the last non-historical behavior; contained history harness and direct consumers follow the relocated path contract; validation proves history writes no longer spill into live root `logs`; runtime logs, crash logs, and support-bundle locations remain unchanged
+- canonical workstream doc: `Docs/workstreams/FB-028_history_state_relocation.md`
 
-### `feature/prebeta-roadmap-rebaseline`
+## Current Sequencing Reading
 
-- status: `merged`
-- lane type: `docs-only`
-- release floor: `no release`
-- release state: `closed`
-- purpose: docs-only governance and planning reset so near-term sequencing and provisional version-impact planning have one canonical interface
+Current merged truth indicates:
 
-### `feature/fb-027-saved-action-usability`
+- the released FB-035 lane is closed
+- the recent released workstreams above remain part of the locked current baseline
+- the next implementation lane must be chosen from refreshed backlog, workstream, and product-boundary truth
+- docs-only canon reconstruction does not itself choose the next implementation lane automatically
 
-- status: `closed`
-- lane type: `implementation`
-- release floor: `patch prerelease`
-- target version: `v1.2.1-prebeta`
-- release state: `released`
-- purpose: released FB-027 usability milestone above the current shared-action, saved-action-source, and starter-bootstrap baseline
-- milestone target: the first coherent saved-action usability milestone above the current starter-bootstrap baseline
-- minimum merge-ready threshold: the current command surface can do more than create the starter file; it must also help the user reach or use that source in a practical bounded way, and the resulting lane should be strong enough to justify the declared patch prerelease rather than another merge-only code delta
-
-### `feature/prebeta-v1.2.1-rebaseline`
-
-- status: `superseded`
-- lane type: `rebaseline`
-- release floor: `no release`
-- purpose: direct release execution plus this roadmap refresh closed the `v1.2.1-prebeta` baseline drift without needing a separate rebaseline branch
-
-## Current Reading
-
-Current repo truth indicates:
-
-- the latest public prerelease is now `v1.2.6-prebeta`
-- the `feature/fb-028-history-state-relocation` lane is now released and closed
-- the `feature/fb-033-startup-snapshot-harness-follow-through` lane is now released and closed
-- the `feature/fb-025-boot-desktop-milestone-taxonomy-clarification` lane is now released and closed
-- the `feature/fb-034-recoverable-diagnostics` lane is now released and closed
-- the prior release debt between `v1.2.5-prebeta` and `main` is cleared
-- no new implementation lane became active automatically just because the prior patch milestone released
-- fresh next-lane analysis on that released baseline selected `feature/release-context-fallback-hardening` as the next bounded implementation lane
-
-That does **not** mean every listed lane should automatically happen.
-It does mean non-doc implementation lanes should be treated as version-bearing milestones rather than as merge-only background follow-through.
+Use canonical workstream docs for execution detail.
+Use the backlog for item identity.

--- a/Docs/user_test_summary_guidance.md
+++ b/Docs/user_test_summary_guidance.md
@@ -2,49 +2,67 @@
 
 ## Purpose
 
-This document is the canonical source-of-truth guidance for when Jarvis work should produce:
+This document defines how Nexus Desktop AI uses User Test Summary (`UTS`) handoff.
 
-- a user-facing `User Test Summary` in the response
-- the desktop `User Test Summary.txt` file for the user
+`UTS` is a validation-contract layer.
+It is owned by the relevant workstream and this guidance document.
 
-It exists so future Codex work follows one consistent manual-test handoff model instead of recreating that behavior ad hoc in chat history.
+`UTS` is not:
 
-Returned `User Test Summary` files must be treated as active evidence inputs, not as disposable notes.
+- a backlog field
+- a roadmap field
+- a separate tracking system
+
+## Ownership Model
+
+Use this ownership split:
+
+- workstream doc = why the validation matters and how it fits the lane
+- `Docs/user_test_summary_guidance.md` = the structure and handling rules for the handoff
+- returned `UTS` evidence = user validation input that must be digested before recommending the next move
+
+Docs-only passes that do not require user-run validation normally do not need a `UTS`.
 
 ## When A User Test Summary Is Needed
 
-Create a `User Test Summary` whenever the active task results in a user-visible validation handoff, especially when the user needs to:
+Create a `UTS` when the active workstream needs user-run validation, especially for:
 
-- launch or relaunch a runtime path manually
-- verify a UI or visual change
-- exercise a Dev Toolkit lane or helper
-- confirm that a repaired path reaches the intended file, helper, or state
-- check for regression after a bounded patch
+- launch or relaunch flows
+- UI or visual confirmation
+- Dev Toolkit helpers
+- repaired runtime paths
+- bounded regression checks after an approved slice
 
-Do not add a separate `User Test Summary` for purely internal analysis or for docs-only work that does not require the user to run anything.
+## Required Structure
 
-## When The Desktop `User Test Summary.txt` File Is Needed
+When a `UTS` is needed, structure it around:
 
-Create or update the desktop `User Test Summary.txt` file when:
+- `Test Purpose`
+- `Scenario / Entry Point`
+- `Steps To Execute`
+- `Expected Behavior`
+- `Failure Conditions / Edge Cases`
+- `Validation Evidence Expectations`
 
-- the user explicitly asks for one
-- the manual test steps are long enough that a durable desktop copy will help
-- the task depends on a multi-step launch or validation flow that the user is likely to follow outside the chat window
-- the task uses a Dev Toolkit lane or helper and the exact launch/test metadata must be preserved cleanly
+Keep the steps concrete and action-oriented.
+Make the expected outcome specific enough that the user can tell what passed or failed.
 
-The desktop file should:
+## Desktop File Rule
 
-- mirror the user-facing manual steps given in the response
-- be written to the desktop location the user actually sees
-- prefer the visible OneDrive desktop path when the machine uses a OneDrive-backed desktop
-- use one uniform filename:
-  - `C:\Users\anden\OneDrive\Desktop\User Test Summary.txt`
-- be treated as the rolling current test handoff file rather than creating a new filename for each slice
-- be overwritten or refreshed with the newest test instructions whenever a new user-visible test handoff replaces the old one
+When a durable desktop copy is needed, use the rolling file:
 
-## Required Structure For The Desktop File
+- `C:\Users\anden\OneDrive\Desktop\User Test Summary.txt`
 
-When the desktop `User Test Summary.txt` file is created or refreshed, it should prefer this structure:
+Create or refresh that file when:
+
+- the user explicitly asks for it
+- the validation flow is long enough that a durable copy helps
+- the user is likely to test outside the chat window
+- Dev Toolkit launch metadata must be preserved exactly
+
+## Required Desktop File Sections
+
+When the desktop file is created or refreshed, prefer this structure:
 
 - `Workstream`
 - `What This Test Is Checking`
@@ -55,196 +73,56 @@ When the desktop `User Test Summary.txt` file is created or refreshed, it should
 - `Questions / Confusions Raised During Testing`
 - `Regression Notes`
 
-For any step that expects a user reply, the file should include an explicit response slot directly under that step, such as:
+If a step expects user feedback, include an explicit response slot directly under that step.
 
-- `Response:`
-- `Notes:`
+## Dev Toolkit Metadata Rule
 
-Do not force the user to guess where feedback should go.
-Do not make the user answer the same validation question again later in a second redundant section.
-
-If a later summary section exists, it should synthesize the step responses rather than repeat the same yes/no prompts.
-
-## User Additions During Testing
-
-User additions raised during testing must not be silently discarded just because they appear inside the `User Test Summary.txt` file.
-
-These additions may include:
-
-- new product ideas
-- new constraints
-- naming concerns
-- hotkey requests
-- privacy expectations
-- clarification requests
-- newly noticed bugs or regressions
-
-Codex should preserve those additions in the file under a clearly separate section such as:
-
-- `New Ideas / Requests Raised During Testing`
-- `Questions / Confusions Raised During Testing`
-- `Regression Notes`
-
-This separation is important:
-
-- test-result evidence should stay readable as test evidence
-- new ideas should still be captured for later digestion
-
-User additions should also be treated as raw inputs rather than final canon wording.
-
-That means Codex should:
-
-- preserve the user's original request or concern faithfully
-- refine or clarify the idea when helpful using repo truth, current architecture boundaries, and the product vision
-- avoid changing the intended meaning of the user's request while improving precision, scope clarity, or terminology
-- explicitly distinguish between the user's raw idea and Codex's refined recommendation when summarizing follow-through
-
-## Digest Rule After Submission
-
-After the user returns a filled `User Test Summary.txt`, Codex must explicitly digest it before recommending the next move.
-
-That digest should separate:
-
-- what passed
-- what failed
-- what remained unclear or confusing
-- what new ideas or requests were introduced during testing
-- what belongs to the current slice
-- what should be deferred into backlog or future source-of-truth consideration
-
-That digest should also include:
-
-- whether each new idea aligns with the current product vision and architecture boundaries
-- whether Codex recommends refining the user's wording before any truth-doc or backlog carry-forward
-- whether the idea is best treated as:
-  - current-slice follow-through
-  - future source-of-truth clarification
-  - future backlog candidate
-  - not currently recommended
-
-Codex should use project truth when refining ideas, including:
-
-- `docs/orin_vision.md`
-- `docs/architecture.md`
-- the canonical doc for the active workstream
-- any directly relevant closeout or planning doc
-
-Codex must not:
-
-- ignore newly introduced user requests
-- treat every new idea as automatically in scope for the current patch
-- leave the file unanalyzed after the user submits it
-
-## Approval Rule For Carry-Forward
-
-Ideas surfaced through a returned `User Test Summary.txt` must not be silently added to:
-
-- `docs/feature_backlog.md`
-- canonical planning docs
-- active source-of-truth docs that materially expand planned behavior
-
-until Codex first provides the user with:
-
-- a concise digest of the relevant test evidence
-- a summary of the extracted ideas
-- any recommended refinement to align the idea with repo truth, product vision, or architecture boundaries
-- a clear recommendation for where the idea belongs
-
-and the user explicitly approves that carry-forward.
-
-This approval rule exists even when the idea is good.
-
-The purpose is:
-
-- to preserve user control over backlog and canon growth
-- to avoid silent scope expansion from live testing feedback
-- to make sure Codex analyzes and refines ideas before proposing them as truth
-
-Directly supportive truth-doc updates for the active approved code task may still be bundled into the same workstream when the user has already approved that truth pass, but new ideas discovered during testing remain approval-gated.
-
-## Historical Summary Review Rule
-
-When the user explicitly asks Codex to revisit earlier `User Test Summary` submissions, Codex should review any recoverable prior summaries or directly preserved returned evidence before recommending new carry-forward.
-
-That review should separate:
-
-- what older summary artifacts are still recoverable
-- what ideas were already carried into canon or code
-- what ideas appear to have been missed
-- which missed ideas should now be proposed for approval-gated carry-forward
-
-If older summaries are no longer recoverable from the local environment, Codex should say so clearly and rely only on the evidence still available rather than pretending a historical review was complete.
-
-## Required Dev Toolkit Metadata
-
-If the user is asked to run a Dev Toolkit instruction, the `User Test Summary` must include the exact:
+For Dev Toolkit runs, copy these fields exactly as shown in the UI:
 
 - `Launch Mode`
 - `Purpose`
 - `Test / Helper`
 - `Delay`
 
-The desktop `User Test Summary.txt` file should carry the same four fields exactly when it is created or refreshed for a Dev Toolkit run.
+Do not paraphrase or shorten those labels.
 
-For Dev Toolkit runs, these fields must be copied from the visible Dev Toolkit dropdown selections exactly as shown in the UI.
+## Digest Rule After Submission
 
-- `Launch Mode` must use the exact combo label, for example `Quiet (No Audio / No Voice)` or `With Voice / Audio`
-- `Purpose` must use the exact Purpose dropdown group label, not a prose explanation
-- `Test / Helper` must use the exact lane label shown in the Test / Helper dropdown
-- `Delay` must use the exact Launch Delay dropdown label, for example `Now`, `3s`, `5s`, or `10s`
+When the user returns a filled `UTS`, Codex must digest it before recommending the next move.
 
-Do not replace these four fields with paraphrases such as:
+That digest should separate:
 
-- `quiet`
-- `none`
-- `Validate Slice 3 shell-branding neutralization`
-- `Dev Toolkit -> Diagnostics UI Test`
+- what passed
+- what failed
+- what remained unclear
+- what new ideas or requests appeared
+- what belongs to the current workstream
+- what should be deferred
 
-If a Dev Toolkit run is part of the handoff, the user-facing steps should also tell the user which exact dropdown options to choose before launching the lane.
+## Carry-Forward Approval Rule
 
-## Desktop File Convention
+Ideas surfaced through a returned `UTS` must not be silently added to:
 
-Use one stable desktop filename for user-facing manual test handoff:
+- `Docs/feature_backlog.md`
+- roadmap sequencing
+- canonical planning docs
 
-- `C:\Users\anden\OneDrive\Desktop\User Test Summary.txt`
+until Codex provides:
 
-Do not create a new slice-specific or workstream-specific desktop filename unless the user explicitly asks for a separate durable record.
+- a concise evidence digest
+- extracted ideas
+- any recommended refinement
+- a clear recommendation for where the idea belongs
 
-Default rule:
-
-- one rolling desktop file
-- same visible filename every time
-- newest active manual-test instructions replace the previous contents
-
-## Response Rule
+and the user explicitly approves the carry-forward.
 
 ## Self-Validation Before Handoff
 
-Before Codex gives the user a manual `User Test Summary` handoff for a runtime or UI path, Codex should first run that same path or the closest faithful equivalent when feasible.
+Before giving the user a manual `UTS` handoff for a runtime or UI path, Codex should run that same path or the closest faithful equivalent when feasible.
 
-When this is possible, the handoff should reflect what Codex already verified directly.
-
-When this is not possible, Codex must say so clearly and identify:
+If that is not possible, Codex must say:
 
 - what was self-validated
-- what was only helper-validated
+- what was helper-validated only
 - what still requires user-only validation
-- why the remaining gap could not be closed locally
-
-Codex must not imply that a user-facing path was personally verified if the actual path could not be run reliably from the current environment.
-
-When a `User Test Summary` is needed:
-
-- keep it short and action-oriented
-- include expected results, not just steps
-- explicitly call out anything that is intentionally not part of the current slice
-- keep the step wording concrete enough that the user can tell what visual or runtime outcome they are supposed to confirm
-- avoid redundant adjacent steps that sound like the same action unless the second step clearly explains the additional verification target
-- when two nearby steps are related but not identical, state the distinction directly so the user knows whether the second step means "launch it" versus "confirm a separate behavior after launch"
-
-When the desktop `User Test Summary.txt` file is also created or refreshed:
-
-- keep the response summary and desktop file aligned
-- do not let the desktop file contain extra hidden requirements that were not shown to the user in the response
-- reference the same desktop file path in the response rather than inventing a new filename for the current slice
-- make sure any prompted user response line has a visible blank line or direct `Response:` slot under it
+- why the gap could not be closed locally

--- a/Docs/workspace_layout_plan.md
+++ b/Docs/workspace_layout_plan.md
@@ -1,43 +1,54 @@
-# Jarvis Workspace Layout Plan
+# Nexus Workspace Layout Plan
 
 ## Purpose
 
-This document defines the first planning pass for `FB-005`.
+This document defines workspace-layout planning and ownership boundaries for the current repo.
 
-`rev1a` is planning-only.
-It does not move files, rewrite imports, or change runtime behavior.
+It is a planning and reference surface.
+It does not own:
 
-Its job is to:
+- backlog identity
+- roadmap sequencing
+- workstream execution history
 
-- inventory the current workspace at a practical level
-- define the target folder ownership model
-- identify path-sensitive files that require controlled migration
-- define a safe migration order for later approved implementation passes
+## Current Workspace Reality
 
-## Current Workspace Inventory
-
-### Repo Root
-
-Current repo-root items with planning significance:
+Current repo-root items with planning significance include:
 
 - `main.py`
-- `jarvis_voice.py`
-- `launch_jarvis_desktop.vbs`
+- `launch_orin_desktop.vbs`
 - `dev/`
 - `Audio/`
 - `desktop/`
-- `Docs/` / `docs/` references
+- `Docs/`
 - `jarvis_visual/`
 - `logs/`
 
-Repo metadata and environment artifacts that should remain root-owned:
+Current merged desktop runtime path is:
 
-- `.git/`
-- `.gitattributes`
-- `.gitignore`
-- root `__pycache__/`
+`launch_orin_desktop.vbs`
+-> `desktop/orin_desktop_launcher.pyw`
+-> `desktop/orin_desktop_main.py`
 
-### Current Major Folder Ownership
+Current desktop test entrypoint is:
+
+- `desktop/orin_desktop_test.py`
+
+Current audio runtime surfaces are:
+
+- `Audio/orin_voice.py`
+- `Audio/orin_error_voice.py`
+
+Current visual assets remain under:
+
+- `jarvis_visual/`
+
+Historical note:
+
+- older Jarvis-named move history remains historical context only
+- current repo truth for the desktop and audio surfaces is ORIN-named as listed above
+
+## Current Major Folder Ownership
 
 `desktop/`
 
@@ -46,319 +57,110 @@ Repo metadata and environment artifacts that should remain root-owned:
 - desktop entrypoints
 - desktop renderer support
 - desktop support-reporting helpers
-- harness tooling tied to desktop/runtime validation
 
 `dev/`
 
-- developer-only launchers
-- deterministic manual-test renderer targets
-- contained manual validation entry points that should not be treated as Windows-facing production shims
+- developer launchers
+- deterministic targets
+- validation helpers and toolkit-oriented support
 
 `Audio/`
 
-- failure and shutdown voice runtime path
-- audio-effect implementation for diagnostics and shutdown speech
+- voice and audio-effect implementation
 
 `jarvis_visual/`
 
-- HTML, CSS, and JS assets used by the current visual experience surfaces
+- current visual assets used by the desktop surfaces
 
-`docs/`
+`Docs/`
 
-- source-of-truth project docs
-- version closeouts
-- planning and task guidance
+- source-of-truth and planning documentation
 
 `logs/`
 
-- generated runtime logs
-- generated crash reports
-- generated verification artifacts
-- generated historical-memory storage
+- generated runtime, crash, and validation state only
 
-## Canonical Target Layout
-
-### What Should Remain At Repo Root
+## Root Ownership Boundary
 
 Repo root should stay limited to:
 
-- repo metadata and ignore files
+- repo metadata and environment files
 - top-level Windows-facing launch shims
-- top-level experience entrypoints that still belong to paused boot or top-level experience work
-- temporary compatibility wrappers during later migration passes only if needed
+- top-level experience entrypoints still tied to paused boot or top-level experience work
 
-For now, these should remain root-owned:
+Current root-owned planning-significant surfaces are:
 
-- `launch_jarvis_desktop.vbs`
+- `launch_orin_desktop.vbs`
 - `main.py`
 
-Developer-only launchers should not remain root-owned.
-They should live under `dev/launchers/`.
+That does not mean all future entrypoints should remain root-owned forever.
+It means current merged truth still keeps those surfaces at root.
 
-### What Should Belong Under Domain Folders
+## Domain Ownership Model
 
-`desktop/`
+`desktop/` should remain the home for:
 
-- desktop launcher
-- desktop diagnostics
-- desktop renderer support
-- desktop-specific helpers
-- desktop entrypoints
-- runtime harness helpers that are part of production-adjacent launcher behavior
+- launcher-owned desktop execution
+- renderer entrypoints
+- desktop helpers and diagnostics surfaces
 
-`dev/`
+`dev/` should remain the home for:
 
-- manual test launchers
-- deterministic manual renderer targets
-- developer-only helper surfaces for contained validation
+- developer launchers
+- contained validation surfaces
+- deterministic targets and helper scripts
 
-Desktop entrypoints now consolidated under `desktop/`:
+`Audio/` remains the current home for the voice layer.
 
-- `desktop/jarvis_desktop_main.py`
-- `desktop/jarvis_desktop_test.py`
+`jarvis_visual/` remains the current visual-asset home until a later explicitly chosen visual-layout change says otherwise.
 
-`audio/`
+## Naming And Path Normalization
 
-- voice and audio-effect implementation files
+Current merged truth includes mixed historical naming:
 
-Later move candidates into `audio/`:
+- product framing is Nexus Desktop AI / ORIN
+- some folder and artifact names remain older names for compatibility or historical continuity
 
-- current `Audio/jarvis_error_voice.py`
-- `jarvis_voice.py`
+Examples of still-current names:
 
-`jarvis_visual/`
+- `Audio/`
+- `jarvis_visual/`
+- `%LOCALAPPDATA%/Nexus Desktop AI/state/jarvis_history_v1.jsonl`
+- `C:/Jarvis/logs`
 
-- current visual assets for the Jarvis interface layer
+Those names should be treated as current runtime or repo truth where they still exist, not automatically rewritten in planning docs.
 
-This folder already has coherent ownership and can remain a dedicated visual-assets domain.
+## Path-Sensitive Planning Boundary
 
-`docs/`
+Path-sensitive surfaces still require deliberate handling when future layout work resumes.
 
-- all source-of-truth docs
-- planning docs
-- version closeouts
+Examples include:
 
-`logs/`
-
-- generated state only
-- never a source-code ownership area
-
-## Canonical Folder Naming
-
-Use lowercase canonical folder names for core repo domains:
-
-- `dev`
-- `audio`
-- `desktop`
-- `docs`
-- `logs`
-
-For current visual assets, keep the descriptive domain name:
-
-- `jarvis_visual`
-
-Known current naming inconsistency:
-
-- root inventory currently presents `Docs` while project references consistently use `docs`
-- root inventory currently presents `Audio` with uppercase casing
-
-Case normalization should be handled in a dedicated later move pass because case-only renames can be git-sensitive on Windows.
-
-## Path-Sensitive Inventory
-
-These files are sensitive enough that they must be migrated in a controlled order:
-
-`launch_jarvis_desktop.vbs`
-
-- Windows-facing launch shim
-- hardcodes the launcher path under `desktop/`
-
-`desktop/jarvis_desktop_launcher.pyw`
-
-- derives `ROOT_DIR`
-- targets `desktop/jarvis_desktop_main.py` as the default renderer entrypoint
-- assumes `logs/` lives under repo root
-- assumes `Audio/jarvis_error_voice.py` lives under repo root
-- launches sibling diagnostics script from `desktop/`
-
-`desktop/jarvis_desktop_main.py`
-
-- desktop entrypoint
-- imports `desktop.*`
-- resolves visual assets from `jarvis_visual/` relative to repo root
-
-`desktop/jarvis_desktop_test.py`
-
-- same path pattern as `desktop/jarvis_desktop_main.py`
-- moved in step with the desktop entrypoint layout and should remain paired with it
-
-`main.py`
-
-- top-level experience entrypoint
-- imports `jarvis_voice.py`
-- resolves visual assets from `jarvis_visual/`
-- should be treated as coupled to paused top-level experience and boot-adjacent work
-
-`jarvis_voice.py`
-
-- root-level voice helper
-- currently coupled to `main.py`
-- should not be moved independently from `main.py` without an approved paired pass
-
-`Audio/jarvis_error_voice.py`
-
-- current failure and shutdown voice script
-- path is referenced directly by the launcher
-
-`dev/launchers/*.vbs`
-
-- developer-only Windows launch shims
-- should remain separate from the root Windows-facing production launcher surface
-
-`dev/targets/*.pyw`
-
-- deterministic manual launcher-path test targets
-- safe to move independently from production runtime code because they are only selected through harness env overrides
-
-## Generated And Runtime State
-
-These areas are generated state and should not be reorganized first:
-
-- `logs/`
-- `logs/crash/`
-- harness and verification subfolders under `logs/`
-- `jarvis_history_v1.jsonl`
-- all `__pycache__/` directories
-
-Generated state should be classified and documented, but excluded from the first move pass.
-
-## Migration Order
-
-### Step 1
-
-Planning only.
-
-- approve this layout and ownership model
-- confirm canonical folder naming
-- confirm which root files are intentionally deferred
-
-### Step 2
-
-Low-risk naming and documentation alignment only.
-
-- normalize documentation references to canonical folder names
-- handle `Docs` / `docs` and `Audio` / `audio` casing only in a dedicated approved pass
-
-### Step 3
-
-Implemented.
-
-- `jarvis_desktop_main.py` moved into the `desktop/` domain
-- `jarvis_desktop_test.py` moved with it
-- the launcher's target-script assumption now points at the moved desktop entrypoint
-
-This was the first real code-moving pass because it addressed the clearest root-level ownership leak without crossing into paused boot work.
-
-### Step 4
-
-Audio-domain consolidation.
-
-- Implemented as a dedicated paired path-sensitive pass.
-- It was not treated as a generic isolated audio-folder cleanup.
-
-The in-bounds file set for this paired pass was:
-
+- `launch_orin_desktop.vbs`
 - `main.py`
-- `jarvis_voice.py`
-- `desktop/jarvis_desktop_launcher.pyw`
-- `Audio/jarvis_error_voice.py`
+- `desktop/orin_desktop_launcher.pyw`
+- `desktop/orin_desktop_main.py`
+- `desktop/orin_desktop_test.py`
+- `Audio/orin_voice.py`
+- `Audio/orin_error_voice.py`
+- `jarvis_visual/`
 
-Those four files were treated as one path-sensitive surface because:
+Future layout work should continue to treat those as controlled surfaces rather than casual rename targets.
 
-- `main.py` owned the normal-voice import path that had to move with `jarvis_voice.py`
-- `desktop/jarvis_desktop_launcher.pyw` owned the current `Audio/jarvis_error_voice.py` path assumption
-- the normal-voice and diagnostics/error-voice paths therefore could not be reorganized as unrelated one-file moves
+## Deferred Layout Work
 
-Step 4 did only this:
+The following remain planning-level or deferred topics:
 
-- moved `jarvis_voice.py` into `Audio/` as `Audio/jarvis_voice.py`
-- updated `main.py` to import `Audio.jarvis_voice`
-- left the launcher-owned diagnostics/error voice path valid and unchanged at `Audio/jarvis_error_voice.py`
-- kept the move limited to the paired path-sensitive surface without widening into broader folder cleanup
-
-Step 4 explicitly avoided:
-
-- moving `main.py`
-- touching `launch_jarvis_desktop.vbs`
-- broader folder cleanup outside this four-file surface
-- `Audio` casing cleanup beyond what the paired pass strictly required
-- launcher retry, recovery, diagnostics, or control-policy changes
-- diagnostics-policy changes
-- voice behavior or content changes
-- top-level experience restructuring
-
-This completed the bounded audio-domain follow-on move without widening it into an automatic continuation of broader workspace cleanup.
-
-### Step 5
-
-Defer top-level experience entrypoint work until later.
-
-- keep `main.py` root-owned until the paused boot or top-level experience track is explicitly resumed
-- keep `launch_jarvis_desktop.vbs` root-owned as the Windows-facing shim unless a dedicated entrypoint pass is approved
-
-## Current Pause Point After Step 4
-
-After the completed desktop-entrypoint consolidation and paired audio-domain follow-on move, no further `FB-005` implementation slice is currently approved.
-
-The remaining `FB-005` sequence is intentionally paused because:
-
-- Step 4 is now implemented and no broader Step 5 approval follows automatically from it
-- `main.py` remains root-owned and Step 5 still stays deferred
-- broader workspace reorganization remains deferred beyond the completed paired Step 4 surface
-
-This means the current plan should be read as:
-
-- Step 3 is complete
-- Step 4 is complete
-- Step 5 remains deferred
-- broader workspace reorganization remains paused rather than implicitly queued as the next implementation move
-
-## Areas Explicitly Deferred From The First Implementation Move Pass
-
-- `main.py`
-- `launch_jarvis_desktop.vbs`
-- `logs/`
-- generated verification artifacts
+- top-level experience entrypoint reshaping around `main.py`
+- any future root-to-domain ownership changes for boot-facing entry surfaces
+- case normalization such as `Audio` versus `audio`
 - broader visual-asset reorganization
-- boot-adjacent top-level experience restructuring
+- generated-state reorganization under `logs/`
 
-## Rev1a Non-Goals
+## Relationship To Other Canon Layers
 
-`rev1a` does not:
-
-- move files
-- rename folders
-- rewrite imports
-- rewrite launcher paths
-- change behavior
-- redesign orchestration
-- reopen boot planning
-
-## Risks And Blockers
-
-- case-only folder renames may be unreliable without a controlled git-aware pass on Windows
-- `launch_jarvis_desktop.vbs` hardcodes a root-to-desktop path
-- `desktop/jarvis_desktop_launcher.pyw` still assumes root-owned audio and log paths
-- `main.py` and `jarvis_voice.py` are coupled and should not be split casually
-- generated `logs/` content should not be mixed into source-layout refactors
-
-## Recommended First Implementation Move Pass After Rev1a
-
-This step is now completed as desktop-entrypoint consolidation:
-
-- `jarvis_desktop_main.py` moved under `desktop/`
-- `jarvis_desktop_test.py` moved with it
-- launcher path assumptions were updated accordingly
-
-No further `FB-005` implementation slice is approved by this document at the current planning layer.
-Broader workspace reorganization remains deferred.
+- use `Docs/architecture.md` for system boundaries
+- use `Docs/orchestration.md` for launcher and renderer ownership
+- use `Docs/boot_access_design.md` for future boot-layer planning
+- use `Docs/feature_backlog.md` for tracked layout-related identity
+- use `Docs/prebeta_roadmap.md` for sequencing

--- a/Docs/workstreams/FB-025_boot_desktop_milestone_taxonomy_clarification.md
+++ b/Docs/workstreams/FB-025_boot_desktop_milestone_taxonomy_clarification.md
@@ -1,0 +1,85 @@
+# FB-025 Boot And Desktop Milestone Taxonomy Clarification
+
+## ID And Title
+
+- ID: `FB-025`
+- Title: `Boot and desktop milestone taxonomy clarification`
+
+## Record State
+
+- `Closed`
+
+## Status
+
+- `Released (v1.2.5-prebeta)`
+
+## Release Stage
+
+- `pre-Beta`
+
+## Target Version
+
+- `v1.2.5-prebeta`
+
+## Purpose / Why It Matters
+
+Preserve the closed lane that clarified the shared naming shape between `BOOT_MAIN|...` and `RENDERER_MAIN|...` milestone families without collapsing boot and desktop ownership into one logging system.
+
+## Current Truth And Boundaries
+
+- boot and desktop milestone ownership remain separate
+- the lane was a naming and taxonomy clarification only
+- no launcher policy, raw verbosity, or shared logging-contract widening was part of the shipped milestone
+
+## Milestone Value Statement
+
+The lane closed as a small but worthwhile diagnostic-readability milestone that made request-versus-visible transitions easier to compare across boot and desktop evidence.
+
+## Scope
+
+- naming and taxonomy clarification only
+- cross-lane diagnostic readability
+
+## Non-Goals
+
+- full shared logging-contract implementation
+- launcher policy changes
+- behavior changes
+- broad logging expansion
+
+## Stages / Executed Stages
+
+1. clarified the boot and desktop milestone naming shape
+2. preserved separate ownership between `BOOT_MAIN|...` and `RENDERER_MAIN|...`
+3. released the bounded taxonomy pass in `v1.2.5-prebeta`
+
+## Same-Branch Follow-Through
+
+Closed. No same-branch follow-through remains for this lane.
+
+## Blockers / Holds / Stop Conditions
+
+Closed. Any broader logging-contract work should reopen as a separate future lane.
+
+## Validation / Evidence Summary
+
+Closure depended on narrow validation showing that the affected boot and desktop markers still emitted correctly under current flows after the naming clarification.
+
+## User Test Summary
+
+No separate ongoing User Test Summary artifact remains for this closed lane.
+
+## Closure Summary
+
+Released in `v1.2.5-prebeta` as a bounded taxonomy clarification milestone.
+
+## Deferred Forward
+
+- broader shared logging-contract work
+- later verbosity or policy follow-through
+
+## Related References
+
+- `Docs/feature_backlog.md`
+- `Docs/prebeta_roadmap.md`
+- `Docs/closeouts/nexus_prebeta_rebaseline_through_v1.2.7-prebeta.md`

--- a/Docs/workstreams/FB-028_history_state_relocation.md
+++ b/Docs/workstreams/FB-028_history_state_relocation.md
@@ -1,0 +1,88 @@
+# FB-028 History State Relocation
+
+## ID And Title
+
+- ID: `FB-028`
+- Title: `Relocate launcher history state out of root logs`
+
+## Record State
+
+- `Closed`
+
+## Status
+
+- `Released (v1.2.3-prebeta)`
+
+## Release Stage
+
+- `pre-Beta`
+
+## Target Version
+
+- `v1.2.3-prebeta`
+
+## Purpose / Why It Matters
+
+Preserve the closed lane that relocated launcher-owned historical state out of the user-visible root logs tree without changing historical-memory semantics or widening logs or reporting policy.
+
+## Current Truth And Boundaries
+
+- normal runtime history resolves under `%LOCALAPPDATA%/Nexus Desktop AI/state/jarvis_history_v1.jsonl`
+- successful migration no longer leaves the legacy root-log history file exposed
+- fail-safe degradation remains in place if migration or new-state writes fail
+- runtime logs, crash logs, and support-bundle locations remain unchanged
+
+## Milestone Value Statement
+
+The lane closed as a worthwhile root-logs-governance milestone because it removed launcher-owned history from live root logs without changing historical-memory behavior.
+
+## Scope
+
+- launcher-owned historical-state relocation only
+- one-time migration and fallback behavior
+- preserving live runtime and crash roots plus dev evidence roots
+
+## Non-Goals
+
+- moving runtime logs
+- moving crash logs
+- changing support-bundle locations
+- redesigning historical-memory semantics
+
+## Stages / Executed Stages
+
+1. relocated launcher-owned historical state to a dedicated non-user-facing state root
+2. preserved migration and fail-safe degradation behavior
+3. kept contained history harness runs isolated under contained roots
+4. released the lane in `v1.2.3-prebeta`
+
+## Same-Branch Follow-Through
+
+Closed. Only future evidence-driven refinement should reopen this area.
+
+## Blockers / Holds / Stop Conditions
+
+Closed. Wider logs-root cleanup remains out of scope for this preserved record.
+
+## Validation / Evidence Summary
+
+Closure depended on validation proving that history writes no longer spilled into live root logs while runtime logs, crash logs, and support-bundle locations remained unchanged.
+
+## User Test Summary
+
+No separate ongoing User Test Summary artifact remains for this closed lane.
+
+## Closure Summary
+
+Released in `v1.2.3-prebeta` as a bounded runtime-state relocation milestone.
+
+## Deferred Forward
+
+- later evidence-driven refinement only if the released relocation behavior needs it
+
+## Related References
+
+- `Docs/feature_backlog.md`
+- `Docs/prebeta_roadmap.md`
+- `Docs/development_rules.md`
+- `Docs/closeouts/nexus_prebeta_rebaseline_through_v1.2.7-prebeta.md`

--- a/Docs/workstreams/FB-033_startup_snapshot_harness_follow_through.md
+++ b/Docs/workstreams/FB-033_startup_snapshot_harness_follow_through.md
@@ -1,0 +1,89 @@
+# FB-033 Startup Snapshot Harness Follow-Through
+
+## ID And Title
+
+- ID: `FB-033`
+- Title: `Dev-only startup snapshot harness follow-through`
+
+## Record State
+
+- `Closed`
+
+## Status
+
+- `Released (v1.2.4-prebeta)`
+
+## Release Stage
+
+- `pre-Beta`
+
+## Target Version
+
+- `v1.2.4-prebeta`
+
+## Purpose / Why It Matters
+
+Preserve the closed lane that stabilized the dev-only startup snapshot harness as intentional debugging infrastructure without turning it into normal product behavior.
+
+## Current Truth And Boundaries
+
+- the startup snapshot harness remains explicitly dev-only and opt-in
+- the harness stays bounded to startup-state capture and related contained validation
+- it does not spill artifacts into live root logs or normal runtime state by default
+
+## Milestone Value Statement
+
+The lane closed as a worthwhile debugging-infrastructure milestone because it established a repeatable contained evidence path for startup capture without widening normal user behavior.
+
+## Scope
+
+- env-gated startup snapshot debugging
+- first-visible-frame evidence capture
+- bounded dev-only validation follow-through
+
+## Non-Goals
+
+- normal user-facing screenshot or recording features
+- always-on runtime capture
+- support-bundle changes
+- broad renderer redesign
+
+## Stages / Executed Stages
+
+1. kept the harness strictly env-gated and dev-only
+2. stabilized the output-location and validation contract
+3. proved healthy and failure-oriented contained validation paths
+4. released the lane in `v1.2.4-prebeta`
+
+## Same-Branch Follow-Through
+
+Closed. Any later harness expansion should reopen as a new bounded debugging lane.
+
+## Blockers / Holds / Stop Conditions
+
+Closed. The current hold is against widening the harness into normal product behavior.
+
+## Validation / Evidence Summary
+
+Closure depended on bounded validation proving the intended startup capture path in both healthy and failure-oriented cases while keeping the harness opt-in and dev-only.
+
+## User Test Summary
+
+No separate ongoing User Test Summary artifact remains for this closed lane.
+
+## Closure Summary
+
+Released in `v1.2.4-prebeta` as intentional dev-only startup debugging infrastructure.
+
+## Deferred Forward
+
+- permanent timing-set decisions
+- dedicated dev-launcher surfacing beyond the closed lane
+- any broader startup-capture product work
+
+## Related References
+
+- `Docs/feature_backlog.md`
+- `Docs/prebeta_roadmap.md`
+- `Docs/development_rules.md`
+- `Docs/closeouts/nexus_prebeta_rebaseline_through_v1.2.7-prebeta.md`

--- a/Docs/workstreams/FB-034_recoverable_diagnostics.md
+++ b/Docs/workstreams/FB-034_recoverable_diagnostics.md
@@ -1,0 +1,96 @@
+# FB-034 Recoverable Diagnostics
+
+## ID And Title
+
+- ID: `FB-034`
+- Title: `Recoverable incident diagnostics surface and failure-class follow-through`
+
+## Record State
+
+- `Closed`
+
+## Status
+
+- `Released (v1.2.6-prebeta)`
+
+## Release Stage
+
+- `pre-Beta`
+
+## Target Version
+
+- `v1.2.6-prebeta`
+
+## Purpose / Why It Matters
+
+Capture the first shipped recoverable-diagnostics milestone without collapsing recoverable incidents into the fatal launcher diagnostics path.
+
+## Current Truth And Boundaries
+
+- the released lane selected one recoverable high-signal incident class only
+- that class is repeated identical `launch_failed` for the same action in a still-running session
+- the lane kept the local and manual support-bundle and issue-draft boundary intact
+- fatal launcher and runtime diagnostics completion behavior stayed separate and unchanged
+
+## Milestone Value Statement
+
+The lane closed as a bounded recoverable-diagnostics milestone that made the Class 2/Class 3 boundary explicit for one incident class without widening diagnostics policy.
+
+## Scope
+
+- one recoverable incident class only
+- explicit Class 2/Class 3 boundary evidence for that class
+- preserving manual-reporting boundaries while clarifying incident-class behavior
+
+## Non-Goals
+
+- blanket recoverable diagnostics popup behavior
+- broad diagnostics UI redesign
+- launcher retry or escalation redesign
+- silent or background upload behavior
+- broad voice redesign unrelated to failure-class semantics
+
+## Stages / Executed Stages
+
+1. selected the bounded recoverable incident class
+2. made the recoverable and fatal boundary explicit in renderer evidence
+3. preserved truthful support-report context and manual-reporting boundaries
+4. released the lane in `v1.2.6-prebeta`
+
+## Same-Branch Follow-Through
+
+The directly coupled same-incident follow-through needed to make the milestone complete is already absorbed into the closed lane.
+
+## Blockers / Holds / Stop Conditions
+
+Closed. Future work should reopen only through a new explicitly bounded lane.
+
+## Validation / Evidence Summary
+
+Closure depended on:
+
+- narrow validation for the selected repeated-identical `launch_failed` class
+- preserved manual-reporting boundary
+- preserved fatal launcher and runtime diagnostics behavior
+- truthful release-context handling in report artifacts
+
+## User Test Summary
+
+No separate ongoing User Test Summary artifact remains. Any future manual validation beyond this closed milestone belongs to a new promoted workstream.
+
+## Closure Summary
+
+Released in `v1.2.6-prebeta`. The lane stands as the first closed recoverable-operational-incident milestone for one explicitly bounded incident class.
+
+## Deferred Forward
+
+- broader recoverable diagnostics surface work
+- broader reporting or voice follow-through
+- any later additional recoverable incident classes
+
+## Related References
+
+- `Docs/feature_backlog.md`
+- `Docs/prebeta_roadmap.md`
+- `Docs/incident_patterns.md`
+- `Docs/closeouts/nexus_prebeta_rebaseline_through_v1.2.7-prebeta.md`

--- a/Docs/workstreams/FB-035_release_context_fallback_hardening.md
+++ b/Docs/workstreams/FB-035_release_context_fallback_hardening.md
@@ -1,0 +1,99 @@
+# FB-035 Release-Context Fallback Hardening
+
+## ID And Title
+
+- ID: `FB-035`
+- Title: `Release-context fallback hardening`
+
+## Record State
+
+- `Closed`
+
+## Status
+
+- `Released (v1.2.7-prebeta)`
+
+## Release Stage
+
+- `pre-Beta`
+
+## Target Version
+
+- `v1.2.7-prebeta`
+
+## Purpose / Why It Matters
+
+Protect support-report release-context derivation so generated support bundles and issue drafts keep reporting the latest released public prerelease even when `.git` metadata is unavailable.
+
+## Current Truth And Boundaries
+
+- this lane shipped in `v1.2.7-prebeta`
+- release-context ownership remains centralized in `desktop/orin_support_reporting.py`
+- directly coupled validation remains centered in `dev/orin_recoverable_launch_failed_validation.py`
+- roadmap fallback now derives released-canon truth instead of selecting the highest planned prerelease target
+- the manual review and manual issue submission boundary remains intact
+- this lane did not widen into broader diagnostics policy, upload behavior, launcher policy, or voice work
+
+## Milestone Value Statement
+
+If squashed to one milestone, this lane still reads as a worthwhile support-report hardening release because it prevents unreleased-baseline drift in generated support artifacts.
+
+## Scope
+
+- release-context fallback hardening only
+- released-prerelease canon parsing for fallback truth
+- directly coupled validation for `git`-present and `git`-unavailable report-artifact paths
+
+## Non-Goals
+
+- new incident classes
+- reporting-policy changes
+- upload-behavior changes
+- diagnostics UI redesign
+- launcher retry or escalation redesign
+- voice-path work
+
+## Stages / Executed Stages
+
+1. identified that roadmap fallback could select an unreleased higher planned prerelease when `.git` metadata was unavailable
+2. hardened the support-report fallback path so only released-canon truth can supply fallback prerelease context
+3. validated both metadata-present and metadata-unavailable report-artifact paths
+4. released the lane in `v1.2.7-prebeta`
+
+## Same-Branch Follow-Through
+
+Closed. No same-branch follow-through remains for this bounded milestone.
+
+## Blockers / Holds / Stop Conditions
+
+Closed. Reopen only through a new explicitly bounded lane if later evidence requires broader reporting or diagnostics work.
+
+## Validation / Evidence Summary
+
+Closure evidence includes:
+
+- owner confirmation that release-context derivation remains centralized in `desktop/orin_support_reporting.py`
+- directly coupled validator evidence proving both `git`-present and forced `git`-unavailable paths resolved to the then-current latest public prerelease truth rather than a higher planned prerelease
+- preserved manual review and manual issue submission contract fields
+- released branch truth closed at `v1.2.7-prebeta`
+
+## User Test Summary
+
+No separate User Test Summary artifact is required for this closed lane. The relevant validation remained inside the lane and its directly coupled validator evidence.
+
+## Closure Summary
+
+Released in `v1.2.7-prebeta`. The lane now prevents support-report fallback logic from choosing an unreleased planned prerelease when `.git` metadata is unavailable while preserving the existing manual reporting boundary.
+
+## Deferred Forward
+
+- broader reporting UX follow-through
+- broader recoverable diagnostics or reporting-policy follow-through
+- any new incident-class work
+
+## Related References
+
+- `Docs/feature_backlog.md`
+- `Docs/prebeta_roadmap.md`
+- `Docs/incident_patterns.md`
+- `Docs/closeouts/nexus_prebeta_rebaseline_through_v1.2.7-prebeta.md`

--- a/Docs/workstreams/index.md
+++ b/Docs/workstreams/index.md
@@ -1,0 +1,43 @@
+# Workstream Records Index
+
+## Purpose
+
+This document is the routing index for canonical workstream records under `Docs/workstreams/`.
+
+Use this layer when a backlog item has been promoted and now needs:
+
+- a planning record
+- an execution record
+- a validation record
+- a closure record
+- a stable path before and after closure
+
+## Workstream Record Rules
+
+- workstream docs are the canonical planning, execution, validation, and closure truth for promoted work
+- `Record State` tracks whether the record is `Promoted` or `Closed`
+- `Status` remains the delivery or work field
+- backlog remains the identity registry and points here through `Canonical Workstream Doc`
+- roadmap consumes this layer for sequencing but does not duplicate its full execution story
+
+## Current Canonical Workstream Records
+
+### Active
+
+- none currently
+
+### Closed
+
+- `Docs/workstreams/FB-035_release_context_fallback_hardening.md`
+- `Docs/workstreams/FB-034_recoverable_diagnostics.md`
+- `Docs/workstreams/FB-025_boot_desktop_milestone_taxonomy_clarification.md`
+- `Docs/workstreams/FB-033_startup_snapshot_harness_follow_through.md`
+- `Docs/workstreams/FB-028_history_state_relocation.md`
+
+## Naming Pattern
+
+Use:
+
+- `Docs/workstreams/FB-XXX_slug.md`
+
+for backlog-backed canonical workstream records.

--- a/README.md
+++ b/README.md
@@ -1,83 +1,99 @@
 # Nexus Desktop AI
 
-This repository is the current engineering workspace for **Nexus Desktop AI**.
+This repository is the engineering workspace for `Nexus Desktop AI`.
 
-`Nexus Desktop AI` is the product/platform identity. `ORIN` is the shipped assistant persona for `pre-Beta` and `Beta`. `ARIA` is reserved as a future optional persona for `Full` and is not currently shipped.
+`Nexus Desktop AI` is the product and tooling-shell identity.
+`ORIN` is the current shipped assistant persona for the pre-Beta product line.
+`ARIA` remains a future optional persona rather than a currently shipped surface.
 
-Older legacy/internal releases and tags remain preserved as historical internal context. The future public product line begins later under `Nexus Desktop AI`; this README does not imply that public release work is already complete.
+This README is a repository orientation document.
+For merged governance, planning, routing, and lifecycle truth, start with `Docs/Main.md`.
 
-## Current Status
+## Current Product And Runtime Truth
 
-This repo is in active internal development.
+Current repo truth includes:
 
-What is currently true on this branch:
-- the manual desktop launch path is working well enough for continued validation
-- the dev/boot harness path remains separate from the normal desktop entrypoint
-- diagnostics and Dev Toolkit flows exist to support internal testing and repair-first iteration
+- a manual desktop launch path for the current desktop runtime
+- a separate Dev Toolkit surface for controlled testing and diagnostics work
+- a dev-only boot harness path used for boot-flow and transition validation
+- current pre-Beta delivery under the Nexus Desktop AI / ORIN identity
 
-This is an engineering README, not a public product-launch page.
+Latest public prerelease:
+
+- `v1.2.7-prebeta`
 
 ## Current Entry Paths
 
-### Manual desktop launch path
+### Manual Desktop Launch
 
-The current manual desktop entry path is:
+The normal manual desktop entry path is:
 
-`launch_orin_desktop.vbs`  
-`-> desktop/orin_desktop_launcher.pyw`  
+`launch_orin_desktop.vbs`
+`-> desktop/orin_desktop_launcher.pyw`
 `-> desktop/orin_desktop_main.py`
 
-This is the current normal desktop entrypoint for manual runs.
+### Dev Toolkit
 
-### Dev Toolkit entry
+The Dev Toolkit launcher is:
 
-The current Dev Toolkit entry is:
+`dev/launchers/launch_orin_dev_toolkit.vbs`
 
-`dev\launchers\launch_orin_dev_toolkit.vbs`
+The Dev Toolkit is an internal engineering surface for validators, diagnostics, launch helpers, and repair-first workflows.
 
-The Dev Toolkit is an internal testing surface used for launch lanes, diagnostics, validation helpers, and related repair-first workflows.
+### Boot Harness
 
-### Boot/dev harness path
+`main.py` remains the dev-only boot harness entry.
 
-`main.py` is the current dev-only boot harness path.
-
-It is not the normal user desktop entrypoint. It exists to support controlled boot-path testing, transition checks, and related internal validation work.
-
-## Naming And Release Posture
-
-- product/platform identity: `Nexus Desktop AI`
-- shipped persona in `pre-Beta` and `Beta`: `ORIN`
-- future persona option in `Full`: `ARIA`
-- older legacy/internal releases and tags remain preserved as historical internal context
-- the new public product line begins later under `Nexus Desktop AI`
+It is used for controlled boot-path testing and related validation.
+It is not the normal user desktop entrypoint.
 
 ## Repository Layout
 
 Top-level folders currently include:
-- `Audio/` for voice/audio code
-- `desktop/` for launcher, renderer, runtime, and diagnostics surfaces
-- `dev/` for toolkit, validators, harnesses, and related internal helpers
-- `docs/` for project truth, architecture, backlog, and guidance
-- the current visual assets and bridge-side UI resources
+
+- `Audio/` for voice and audio code
+- `desktop/` for launcher, renderer, interaction, and diagnostics runtime surfaces
+- `dev/` for toolkit surfaces, validators, harnesses, and internal helpers
+- `Docs/` for source-of-truth, architecture, planning, and guidance
+- `jarvis_visual/` for current visual assets and bridge-side UI resources
 - `logs/` for local runtime artifacts
 
-Top-level launch/runtime surfaces currently include:
-- `launch_orin_desktop.vbs`
-- `main.py`
+## Source-Of-Truth Routing
 
-## Current Working Boundary
+Use the merged canon through:
 
-This branch is being advanced through narrow, evidence-driven slices:
-- preserve working launch paths first
-- fix visible rebrand gaps before deeper cleanup
-- keep runtime behavior stable while reducing outdated pre-rebrand user-facing surfaces
-- defer larger UX, release, repo-rename, and public-launch work until separately approved
+- `Docs/Main.md` for routing authority
+- `Docs/development_rules.md` for development governance
+- `Docs/codex_modes.md` for collaboration and analysis/execution posture
 
-## Current Source Of Truth
+From there, route into the layer that owns the truth you need:
 
-For the current project truth and routing, use:
-- `docs/Main.md`
-- `docs/feature_backlog.md`
-- `docs/orin_display_naming_guidance.md`
-- `docs/orin_vision.md`
-- `docs/user_test_summary_guidance.md`
+- `Docs/feature_backlog.md` for tracked identity and registry state
+- `Docs/prebeta_roadmap.md` for sequencing and release posture
+- `Docs/workstreams/index.md` for canonical workstream records
+- `Docs/closeout_index.md` and `Docs/closeouts/nexus_prebeta_rebaseline_through_v1.2.7-prebeta.md` for historical and epoch summaries
+
+## Naming Boundary
+
+Use:
+
+- `Nexus Desktop AI` for the product, repo, and tooling shell
+- `ORIN` for the current assistant persona
+
+Older `Jarvis` references remain only where they are:
+
+- preserved historical context
+- still-real runtime artifact names
+- intentionally retained compatibility references
+
+## Repository Boundary
+
+This repository contains the engineering and canon surfaces for the product.
+
+It is not, by itself:
+
+- a release checklist
+- a public marketing page
+- a substitute for the source-of-truth stack in `Docs/`
+
+When repo orientation and source-of-truth docs disagree, validate live repo truth first and then route through `Docs/Main.md`.


### PR DESCRIPTION
## Summary

This PR lands the rebuilt docs-only source-of-truth foundation on top of `v1.2.7-prebeta`.

## What Changed

It establishes clear layer ownership across the canon:

- backlog as identity and registry
- roadmap as sequencing and release posture
- workstream docs as promoted planning, execution, validation, and closure truth
- rebaseline and closeouts as epoch summaries
- incident patterns as generalized reusable lessons
- User Test Summary as a workstream-owned validation layer
- `Docs/Main.md` as routing authority aligned to merged truth

It also aligns the supporting docs to current Nexus Desktop AI / ORIN truth, removes stale FB-035 active or unreleased posture, and updates the Codex-facing guidance layer so analysis remains full-scan by default while narrow execution discipline applies only after scope approval.

Validation used for this branch:

- confirmed the committed diff versus `origin/main` is docs-only
- confirmed `Docs/Main.md` routes only to existing docs on the branch
- confirmed no stale `v1.2.6-prebeta` latest-release claims remain
- confirmed no stale FB-035 active or branch-local unreleased claims remain in canonical surfaces
- confirmed `git diff --check origin/main...HEAD` is clean

Out of scope and intentionally left untouched:

- code, runtime, launcher, validator, or test changes
- release work
- next implementation-lane selection
- broad bug-system expansion
- historical closeout rewrites

- backlog as identity and registry
- roadmap as sequencing and release posture
- workstream docs as promoted planning, execution, validation, and closure truth
- rebaseline and closeouts as epoch summaries
- incident patterns as generalized reusable lessons
- User Test Summary as a workstream-owned validation layer
- `Docs/Main.md` as routing authority aligned to merged truth

- confirmed the committed diff versus `origin/main` is docs-only
- confirmed `Docs/Main.md` routes only to existing docs on the branch
- confirmed no stale `v1.2.6-prebeta` latest-release claims remain
- confirmed no stale FB-035 active or branch-local unreleased claims remain in canonical surfaces
- confirmed `git diff --check origin/main...HEAD` is clean

- code, runtime, launcher, validator, or test changes
- release work
- next implementation-lane selection
- broad bug-system expansion
- historical closeout rewrites
