### PR TITLE
feat(FB-027): add URL target support for saved actions

### DIFF
--- a/Docs/feature_backlog.md
+++ b/Docs/feature_backlog.md
@@ -18,6 +18,19 @@ Historical note:
 - older implemented entries may preserve older Jarvis-era titles as historical identity
 - those preserved titles are not current runtime-path claims
 
+## Promoted Canonical Workstreams
+
+### [ID: FB-027] Interaction system baseline and shared action model
+
+Status: Implemented on branch (baseline preserved; URL target support; unreleased)
+Record State: Promoted
+Priority: High
+Release Stage: pre-Beta
+Target Version: TBD
+Canonical Workstream Doc: Docs/workstreams/FB-027_interaction_system_baseline.md
+Summary: Lock the typed-first interaction baseline and deliver the first bounded capability milestone by adding first-class URL targets to saved actions.
+Why it matters: Future interaction work needs one authoritative baseline and one bounded first expansion so saved-action, resolution, and command-surface growth do not silently rewrite current guarantees.
+
 ## Registry Items
 
 ### [ID: FB-004] Future boot orchestrator layer
@@ -49,16 +62,6 @@ Release Stage: Slice-staged
 Target Version: v2.0
 Summary: Preserve the future boot and desktop phase-boundary model above the already-closed milestone taxonomy work.
 Why it matters: Keeps boot-versus-desktop ownership planning explicit without reopening the closed taxonomy milestone by inertia.
-
-### [ID: FB-027] Jarvis interaction surfaces and shared action model
-
-Status: Deferred (first pre-Beta slice released in v2.2.1 rev1)
-Record State: Registry-only
-Priority: High
-Release Stage: Slice-staged
-Target Version: TBD
-Summary: Continue the long-term interaction-system lane above the existing typed overlay, shared action model, and saved-action foundation.
-Why it matters: This remains the clearest future product-facing interaction lane, but it should resume only through an explicitly chosen next slice.
 
 ### [ID: FB-029] ORIN legal-safe rebrand, future ARIA persona option, and repo licensing hardening
 

--- a/Docs/prebeta_roadmap.md
+++ b/Docs/prebeta_roadmap.md
@@ -57,14 +57,27 @@ Use these release-state values when relevant:
 
 ## Current Release Posture
 
-Current merged truth indicates:
+Current branch truth indicates:
 
 - latest public prerelease: `v1.2.7-prebeta`
 - latest public release commit: `3168823`
 - no merged unreleased non-doc implementation debt currently exists on `main`
-- no active non-doc implementation lane is currently selected on merged truth
+- this branch now carries an unreleased FB-027 implementation delta for first-class URL saved-action targets
+- FB-027 remains the active promoted interaction workstream on this branch
 
-That means the repo is between implementation lanes, not automatically continuing the old FB-035 branch.
+That means merged `main` remains between released non-doc implementation lanes while this branch now carries the first bounded FB-027 capability milestone above the locked interaction baseline.
+
+## Current Promoted Workstream Context
+
+### FB-027 Interaction System Baseline
+
+- status: `implemented on branch`
+- lane type: `implementation`
+- release floor: `patch prerelease`
+- target version: `TBD`
+- release state: `active delta`
+- canonical workstream doc: `Docs/workstreams/FB-027_interaction_system_baseline.md`
+- sequencing note: now preserves the locked typed-first baseline while adding first-class URL saved-action targets without changing exact-match resolution, state-machine boundedness, or input-capture behavior
 
 ## Recently Closed Workstreams
 
@@ -117,12 +130,13 @@ That means the repo is between implementation lanes, not automatically continuin
 
 ## Current Sequencing Reading
 
-Current merged truth indicates:
+Current branch truth indicates:
 
 - the released FB-035 lane is closed
 - the recent released workstreams above remain part of the locked current baseline
-- the next implementation lane must be chosen from refreshed backlog, workstream, and product-boundary truth
-- docs-only canon reconstruction does not itself choose the next implementation lane automatically
+- FB-027 now carries the first bounded implementation delta above the validated interaction baseline
+- the next FB-027 capability milestone should be chosen only after the URL target milestone is accepted
+- this milestone does not authorize resolution changes, voice, Action Studio, routines, profiles, hotkey cleanup, or shutdown-confirmation work
 
 Use canonical workstream docs for execution detail.
 Use the backlog for item identity.

--- a/Docs/workstreams/FB-027_interaction_system_baseline.md
+++ b/Docs/workstreams/FB-027_interaction_system_baseline.md
@@ -1,0 +1,400 @@
+# FB-027 Interaction System Baseline
+
+## ID And Title
+
+- ID: `FB-027`
+- Title: `Interaction system baseline and shared action model`
+
+## Record State
+
+- `Promoted`
+
+## Status
+
+- `Implemented on branch (baseline preserved; URL target support; unreleased)`
+
+## Release Stage
+
+- `pre-Beta`
+
+## Target Version
+
+- `no release`
+
+## Purpose / Why It Matters
+
+Define the current typed-first interaction system as an explicit baseline contract and use that locked baseline to deliver the first bounded FB-027 capability milestone.
+
+This workstream exists so future interaction work can extend a defended baseline instead of silently rewriting one.
+
+## Current Truth And Boundaries
+
+- the current shipped interaction surface is the typed desktop command overlay
+- the current open hotkeys are `Ctrl+Alt+Home` and `Ctrl+Alt+1`
+- the current shutdown hotkeys are `Ctrl+Alt+End` and `Ctrl+Alt+2`
+- the current overlay flow is bounded to `entry` -> `choose` -> `confirm` -> `result`
+- built-in actions and saved actions resolve through one shared action catalog
+- the current saved-action seam lives at `%LOCALAPPDATA%/Nexus Desktop AI/saved_actions.json`
+- current saved-action target kinds are `app`, `folder`, `file`, and `url`
+- current repo truth does not yet include shipped voice invocation, Action Studio authoring UI, routines, profiles, or broader natural-language resolution
+- this workstream now protects the locked baseline while adding first-class URL saved-action targets through the existing shared action model
+
+## Milestone Value Statement
+
+If squashed to one milestone, this lane is still worthwhile because it turns the current interaction surface into an explicit contract and then proves that the first bounded capability expansion can land without changing resolution rules, state-machine boundaries, or input-capture behavior.
+
+## Scope
+
+- formalize the current typed-first interaction contract
+- define the explicit interaction invariants that future work must defend
+- identify which behaviors are baseline guarantees versus implementation details
+- define the validator surfaces that must exist before capability expansion proceeds
+- implement first-class URL target support for saved actions through the existing shared action model
+- extend validator coverage so URL targets are defended as part of the locked baseline
+- record directly related deferred follow-through that should remain out of scope for this pass
+
+## Non-Goals
+
+- capability expansion beyond bounded first-class URL target support
+- saved-action authoring UX
+- voice invocation
+- Action Studio
+- routines or profiles as shipped features
+- fuzzy or semantic intent resolution
+- runtime hotkey or shutdown-behavior changes in this pass
+- broader diagnostics-policy changes
+
+## Interaction Contract
+
+### Invocation Contract
+
+Guaranteed now:
+
+- the command overlay opens through `Ctrl+Alt+Home` and `Ctrl+Alt+1`
+- shutdown remains available through `Ctrl+Alt+End` and `Ctrl+Alt+2`
+- opening from the supported overlay hotkeys permits immediate typed interaction without requiring an initial click
+
+Not guaranteed now:
+
+- custom hotkeys
+- alternative invocation surfaces
+- voice invocation
+- shutdown confirmation prompts
+- permanent retention of the numeric overlay or shutdown hotkeys through Beta
+
+Must not regress:
+
+- supported overlay hotkeys must continue to open the command surface reliably until an explicitly approved future milestone changes them
+- supported shutdown hotkeys must remain predictable until an explicitly approved future milestone changes that path
+- initial typing must not leak into the previously focused underlay target
+
+### Overlay State Machine Contract
+
+Guaranteed now:
+
+- the visible interaction flow is bounded to `entry`, `choose`, `confirm`, and `result`
+- one exact resolved match moves from `entry` to `confirm`
+- ambiguous resolved matches move from `entry` to `choose`
+- confirmed execution transitions to `result`
+- `Esc` backs out from `choose` or `confirm` to `entry`
+
+Not guaranteed now:
+
+- extra intermediate review phases
+- richer multi-step workflows
+- alternate execution paths that bypass confirmation
+
+Must not regress:
+
+- the overlay must stay bounded and understandable
+- execution must not skip the visible confirmation step
+- cancel/back-out behavior must continue to return the user to a clean `entry` state
+
+### Resolution Contract
+
+Guaranteed now:
+
+- command resolution is exact normalized matching against action titles and aliases
+- one match yields a confirmable pending action
+- multiple matches yield a visible ambiguous-choice state
+- zero matches yield a bounded `not_found` state instead of hidden guessing
+
+Not guaranteed now:
+
+- fuzzy matching
+- semantic inference
+- routines, profiles, or other higher-order command abstractions
+- broader natural-language understanding beyond the current normalized title-and-alias model
+
+Must not regress:
+
+- the interaction surface must resolve through one inspectable catalog
+- ambiguous outcomes must remain explicit rather than silently choosing a guessed action
+- `not_found` must remain bounded and visible
+
+### Saved-Action Contract
+
+Guaranteed now:
+
+- saved actions are sourced from `%LOCALAPPDATA%/Nexus Desktop AI/saved_actions.json`
+- built-in actions and saved actions share one effective catalog shape
+- supported saved-action target kinds are currently `app`, `folder`, `file`, and `url`
+- valid saved-action URL targets open through the existing system-handler launch path
+- missing, unreadable, invalid, or colliding saved-action sources fall back to built-ins only
+
+Not guaranteed now:
+
+- a saved-action authoring UI
+- partial salvage of malformed saved-action files
+- richer target kinds beyond `url`
+- routine or profile schemas
+
+Must not regress:
+
+- a bad saved-action source must not break the command overlay
+- built-in actions must remain available even when the saved-action source is invalid
+- collision handling must stay bounded and predictable
+- URL targets must not bypass the shared catalog, confirmation path, or bounded result flow
+
+### Input Capture / Focus Ownership Contract
+
+Guaranteed now:
+
+- fallback global capture owns text, `Enter`, `Esc`, and backspace while the overlay is in no-click entry mode and true local ownership is not yet established
+- true manual local focus transfers ownership to the local input field
+- outside click suspends no-click fallback capture instead of mirroring typing into the underlay and overlay at the same time
+- choose and confirm paths preserve human-delay capture behavior when local focus has not yet been re-established
+
+Not guaranteed now:
+
+- the exact timer values used for launch grace or capture rearm
+- any specific renderer timing beyond the behavioral contract above
+
+Must not regress:
+
+- no-click open must remain reliable
+- local manual focus takeover must stand fallback capture down
+- outside click must keep the overlay from silently mirroring input
+- human-delay choose and confirm behavior must remain usable
+
+### Result / Cleanup Contract
+
+Guaranteed now:
+
+- result display clears stale input text, last request text, pending action, and pending ambiguous-match state immediately
+- close-and-reopen after success, failure, timeout close, or manual close returns to a clean baseline
+- the result state remains bounded and transient rather than becoming a second execution phase
+
+Not guaranteed now:
+
+- exact result copy
+- exact result timeout duration
+- exact visual layout
+
+Must not regress:
+
+- stale request or confirmation metadata must not survive into the next reopen cycle
+- result closure must not leave the command surface in a half-armed state
+
+### Failure / Non-Success Boundary
+
+Guaranteed now:
+
+- `not_found`, `ambiguous`, and launch-failed paths remain bounded inside the current interaction surface
+- launch-failed handling preserves the existing manual-reporting boundary
+- interaction work does not widen into new diagnostics policy automatically
+
+Not guaranteed now:
+
+- broader recoverable-diagnostics expansion
+- automatic reporting
+- a richer non-success UX beyond the current bounded result path
+
+Must not regress:
+
+- interaction work must not silently widen reporting, diagnostics, or escalation behavior
+- non-success states must remain explicit and bounded
+
+## Invariants
+
+### Behavioral Invariants
+
+- opening the overlay from a supported hotkey must permit immediate typed interaction without an initial click
+- `Enter` must never execute a command before the user reaches and accepts the confirm state
+- ambiguous requests must require explicit user choice
+- `Esc` in `choose` or `confirm` must back out to `entry`
+- missing or invalid saved-action sources must degrade to the built-in baseline rather than to a broken overlay
+
+### State Invariants
+
+- `hidden` means no visible overlay state and no pending interaction state
+- `entry` means editable request-building state
+- `choose` means an ambiguous bounded match set exists
+- `confirm` means exactly one pending action is active
+- `result` means transient execution state has already been cleared
+
+### Transition Invariants
+
+- `entry` -> `confirm` only on exactly one resolved action
+- `entry` -> `choose` only on more than one resolved action
+- `choose` -> `confirm` only through explicit user selection
+- `choose` -> `entry` and `confirm` -> `entry` must clear stale pending metadata
+- `result` -> reopen must restore a clean `entry` baseline
+
+### Fallback Invariants
+
+- fallback capture must not remain active after true local manual focus ownership is established
+- fallback capture must not keep mirroring typing after outside-click suspension
+- expired capture must stand down instead of intercepting unrelated input
+- saved-action fallback must never remove built-ins from the effective catalog
+- interaction follow-through must not widen the bounded non-success and reporting contract accidentally
+
+## Validation Coverage And Required Defenses
+
+### Existing Validation Coverage
+
+The current baseline is now defended by:
+
+- `dev/orin_overlay_input_capture_helper.py`
+- `dev/orin_shared_action_baseline_validation.py`
+- `dev/orin_saved_action_source_validation.py`
+- `dev/orin_interaction_baseline_validation.py`
+
+Together, these surfaces now exercise:
+
+- first-open immediate typing
+- no-click entry behavior
+- local-focus takeover
+- outside-click suspension
+- choose and confirm human-delay capture behavior
+- cancel/retry state cleanup
+- result cleanup and clean reopen after success, failure, timeout close, and manual close
+- one choose-confirm-execute path
+- hotkey launch-grace behavior
+- shutdown-hotkey continuity
+- underlay suppression for fallback text and submit behavior
+- exact-match shared-action resolution behavior
+- explicit ambiguous-match behavior
+- built-in catalog integrity
+- valid saved-action catalog extension behavior
+- valid URL saved-action catalog extension behavior
+- missing, empty, invalid, unsupported, duplicate, and colliding saved-action fallback behavior
+- invalid URL saved-action fallback behavior
+- URL launch-path behavior without Windows path normalization
+- compact end-to-end typed-first `entry` -> `choose` -> `confirm` -> `result` behavior
+- compact end-to-end typed-first URL confirm/result behavior
+
+### Missing Explicit Validator Surfaces
+
+No baseline-blocking validator gap is currently known for the locked typed-first interaction contract.
+
+Future capability-expansion milestones may require additional validators when they deliberately change invocation surfaces, resolution behavior, authoring behavior, or non-success handling.
+
+### Required Validator Surfaces Before Capability Expansion
+
+Before capability expansion proceeds, the baseline must continue to be defended by:
+
+- the existing overlay input-capture helper retained as a baseline regression surface
+- a dedicated shared-action baseline validator
+- a dedicated saved-action-source validator
+- a compact integration validator proving the shipped typed-first contract still holds end to end
+
+### What Expansion Must Defend
+
+Future expansion work must preserve or explicitly re-negotiate:
+
+- invocation reliability
+- state-machine boundedness
+- explicit confirmation before execution
+- explicit ambiguity handling
+- bounded saved-action fallback behavior
+- clean result and reopen behavior
+- the existing manual-reporting and non-success boundary
+
+## Expansion Boundaries
+
+### Baseline Guarantees
+
+The guarantees in this document define the current typed-first baseline that future work must treat as protected behavior unless a later approved milestone explicitly changes it.
+
+### Implementation Details
+
+Current implementation details include:
+
+- exact timer values for launch grace and capture rearm
+- exact starter built-in action list and alias wording
+- exact status or panel copy
+- exact presentation layout details
+
+Those details may change later without violating the baseline if the protected contract stays intact.
+
+### Future Capabilities
+
+Future capabilities explicitly deferred beyond this pass include:
+
+- saved-action authoring UX
+- routines
+- profiles
+- richer saved-action target kinds beyond `url`
+- broader natural-language resolution
+- voice invocation
+- Action Studio
+- broader shortcut customization
+
+### Deferred Follow-Through Recorded Now
+
+The following directly related FB-027 follow-through is recorded now but not implemented in this pass:
+
+- remove `Ctrl+Alt+1` and `Ctrl+Alt+2` before Beta
+- add an `Are you sure you want to exit?` prompt for shutdown hotkeys before Beta
+- select the next capability-expansion milestone only after the URL target milestone is accepted
+
+These are deferred forward items, not current-runtime guarantees.
+
+## Stages / Executed Stages
+
+1. promoted FB-027 into a canonical workstream
+2. formalized the current typed-first interaction contract
+3. defined enforceable invariants
+4. mapped current validation coverage and missing validator surfaces
+5. added dedicated shared-action, saved-action-source, and compact end-to-end interaction baseline validators
+6. re-validated the retained overlay input-capture helper against the current renderer contract
+7. recorded directly related deferred follow-through without widening into capability implementation
+8. added first-class URL target support to the saved-action seam and shared action model without changing exact-match resolution
+9. extended shared-action, saved-action-source, and integration validators to defend the new URL target capability
+
+## Same-Branch Follow-Through
+
+None for the URL-target capability milestone.
+
+Future runtime or capability work must return as an explicitly selected next FB-027 milestone rather than as silent same-branch continuation.
+
+## Blockers / Holds / Stop Conditions
+
+- do not widen the URL-target milestone into broader saved-action, resolution, or interaction-surface expansion
+- do not widen this workstream into runtime behavior changes without explicit approval
+- do not treat deferred hotkey cleanup or shutdown confirmation work as current guarantees
+
+## User Test Summary
+
+This milestone changes a user-facing saved-action capability, so a workstream-owned User Test Summary should be expected before closure or release promotion.
+
+Future user-facing interaction changes should assume a workstream-owned User Test Summary will likely be needed before closure.
+
+## Baseline Lock Summary
+
+The typed-first interaction baseline remains explicit and validator-defended, and the first bounded capability milestone now extends that baseline with first-class URL saved-action targets without redefining the state machine, exact-match resolution, or input-capture contract.
+
+## Deferred Forward
+
+- remove `Ctrl+Alt+1` and `Ctrl+Alt+2` before Beta
+- add an `Are you sure you want to exit?` prompt for shutdown hotkeys before Beta
+- choose the first capability-expansion milestone only after this baseline-definition pass is accepted
+
+## Related References
+
+- `Docs/feature_backlog.md`
+- `Docs/prebeta_roadmap.md`
+- `Docs/workstreams/index.md`
+- `Docs/orin_interaction_architecture.md`
+- `Docs/ncp_hardening_assessment.md`

--- a/Docs/workstreams/index.md
+++ b/Docs/workstreams/index.md
@@ -24,7 +24,7 @@ Use this layer when a backlog item has been promoted and now needs:
 
 ### Active
 
-- none currently
+- `Docs/workstreams/FB-027_interaction_system_baseline.md`
 
 ### Closed
 

--- a/desktop/saved_action_source.py
+++ b/desktop/saved_action_source.py
@@ -24,6 +24,13 @@ DEFAULT_SAVED_ACTION_TEMPLATE = {
             "target": r"C:\Users\YourName\Downloads",
             "aliases": ["open downloads", "show downloads"],
         },
+        {
+            "id": "open_nexus_docs_site",
+            "title": "Open Nexus Docs Site",
+            "target_kind": "url",
+            "target": "https://example.com/docs",
+            "aliases": ["open nexus docs site", "open docs site"],
+        },
     ],
 }
 

--- a/desktop/shared_action_model.py
+++ b/desktop/shared_action_model.py
@@ -85,7 +85,8 @@ DEFAULT_COMMAND_ACTIONS = (
     ),
 )
 
-SUPPORTED_ACTION_TARGET_KINDS = frozenset({"app", "folder", "file"})
+SUPPORTED_ACTION_TARGET_KINDS = frozenset({"app", "folder", "file", "url"})
+SUPPORTED_SAVED_ACTION_URL_SCHEMES = frozenset({"http", "https"})
 LEGACY_SAVED_ACTIONS_ACCESS_ACTION_IDS = frozenset(
     {"open_saved_actions_file", "open_saved_actions_folder"}
 )
@@ -165,6 +166,20 @@ def _coerce_saved_action_aliases(record: dict) -> tuple[str, ...]:
     return tuple(normalized_aliases)
 
 
+def _validate_saved_action_target(target_kind: str, target: str) -> str:
+    if target_kind != "url":
+        return target
+
+    if any(char.isspace() for char in target):
+        raise ValueError("Saved action URL targets must not contain whitespace.")
+
+    parsed = urlparse(target)
+    if parsed.scheme.casefold() not in SUPPORTED_SAVED_ACTION_URL_SCHEMES or not parsed.netloc:
+        raise ValueError("Saved action URL target must be an absolute http or https URL.")
+
+    return target
+
+
 def _command_action_from_saved_record(record: object) -> CommandAction:
     if not isinstance(record, dict):
         raise ValueError("Saved action records must be objects.")
@@ -173,11 +188,16 @@ def _command_action_from_saved_record(record: object) -> CommandAction:
     if target_kind not in SUPPORTED_ACTION_TARGET_KINDS:
         raise ValueError("Saved action target_kind is unsupported.")
 
+    target = _validate_saved_action_target(
+        target_kind,
+        _require_saved_action_string(record, "target"),
+    )
+
     return CommandAction(
         id=_require_saved_action_string(record, "id"),
         title=_require_saved_action_string(record, "title"),
         target_kind=target_kind,
-        target=_require_saved_action_string(record, "target"),
+        target=target,
         aliases=_coerce_saved_action_aliases(record),
     )
 
@@ -259,6 +279,10 @@ def resolve_command_actions(text: str, actions=DEFAULT_COMMAND_ACTIONS):
 
 
 def launch_command_action(action: CommandAction):
+    if action.target_kind == "url":
+        os.startfile(action.target)
+        return
+
     target = os.path.normpath(action.target)
 
     if action.target_kind == "app":

--- a/dev/orin_interaction_baseline_validation.py
+++ b/dev/orin_interaction_baseline_validation.py
@@ -1,0 +1,316 @@
+import os
+import sys
+from types import SimpleNamespace
+
+
+CURRENT_DIR = os.path.dirname(os.path.abspath(__file__))
+ROOT_DIR = os.path.dirname(CURRENT_DIR)
+
+if ROOT_DIR not in sys.path:
+    sys.path.insert(0, ROOT_DIR)
+
+import desktop.desktop_renderer as renderer_mod
+from desktop.interaction_overlay_model import CommandOverlayModel
+from desktop.shared_action_model import CommandAction, CommandActionCatalog
+
+
+class _FakeRect:
+    def __init__(self, x=0, y=0, width=1280, height=720):
+        self._x = x
+        self._y = y
+        self._width = width
+        self._height = height
+
+    def x(self):
+        return self._x
+
+    def y(self):
+        return self._y
+
+    def width(self):
+        return self._width
+
+    def height(self):
+        return self._height
+
+    def contains(self, x, y):
+        return self._x <= int(x) < (self._x + self._width) and self._y <= int(y) < (self._y + self._height)
+
+
+class _FakeTimer:
+    def __init__(self):
+        self.started_with = None
+
+    def stop(self):
+        self.started_with = None
+
+    def start(self, duration_ms):
+        self.started_with = duration_ms
+
+
+class _FakeInputLine:
+    def __init__(self):
+        self.focused = False
+        self._last_focus_was_manual = False
+        self.value = ""
+        self.local_typing_enabled = False
+
+    def hasFocus(self):
+        return self.focused
+
+    def last_focus_was_manual(self):
+        return self._last_focus_was_manual
+
+    def text(self):
+        return self.value
+
+    def set_local_typing_enabled(self, enabled: bool):
+        self.local_typing_enabled = bool(enabled)
+
+
+class _FakePanel:
+    def __init__(self):
+        self.input_line = _FakeInputLine()
+        self.active = False
+        self.visible = False
+        self.last_payload = None
+        self.focus_after_show_calls = 0
+        self.refresh_for_geometry_calls = 0
+        self._frame_rect = _FakeRect(100, 100, 400, 220)
+
+    def render_payload(self, payload):
+        self.last_payload = payload
+        self.input_line.value = payload.get("input_text", "")
+
+    def show_for_geometry(self, *_args, **_kwargs):
+        self.visible = True
+
+    def refresh_for_geometry(self, *_args, **_kwargs):
+        self.refresh_for_geometry_calls += 1
+
+    def isVisible(self):
+        return self.visible
+
+    def focus_input_after_show(self):
+        self.focus_after_show_calls += 1
+
+    def focus_input(self, *_args, **_kwargs):
+        self.active = True
+        self.input_line.focused = True
+
+    def isActiveWindow(self):
+        return self.active
+
+    def hide(self):
+        self.visible = False
+
+    def setFocus(self, *_args, **_kwargs):
+        self.active = True
+
+    def frameGeometry(self):
+        return self._frame_rect
+
+
+def _make_window(action_catalog: CommandActionCatalog | None = None):
+    window = renderer_mod.DesktopRuntimeWindow.__new__(renderer_mod.DesktopRuntimeWindow)
+    window.screen_ref = SimpleNamespace(availableGeometry=lambda: _FakeRect())
+    window.compute_compact_geometry = lambda: _FakeRect()
+    window._is_shutting_down = False
+    window._overlay_trace_enabled = False
+    window._command_model = CommandOverlayModel(action_catalog=action_catalog)
+    window._command_panel = _FakePanel()
+    window._result_close_timer = _FakeTimer()
+    window._overlay_input_capture_until = 0.0
+    window._overlay_local_input_engaged = False
+    window._overlay_global_capture_suspended = False
+    window._last_launch_failure_action_id = ""
+    window._last_launch_failure_count = 0
+    window._reported_recoverable_launch_failures = set()
+    window.runtime_log_path = ""
+    window._trace_overlay = lambda *_args, **_kwargs: None
+    window._foreground_window_snapshot = lambda: {"hwnd": 0, "class_name": "", "title": ""}
+    window._log_event = lambda *_args, **_kwargs: None
+    window._apply_command_overlay_state = lambda: renderer_mod.DesktopRuntimeWindow._apply_command_overlay_state(window)
+    window._show_command_result = lambda kind, text, close_delay_ms=1200: (
+        window._command_model.show_result(kind, text),
+        window._apply_command_overlay_state(),
+        window._result_close_timer.start(max(0, int(close_delay_ms))),
+    )
+    return window
+
+
+def _assert(condition, message):
+    if not condition:
+        raise AssertionError(message)
+
+
+def _type_request(window, text: str):
+    for char in text:
+        window.handle_overlay_text_requested(char)
+
+
+def _assert_clean_entry_baseline(window, message_prefix="overlay"):
+    _assert(window._command_model.phase == "entry", f"{message_prefix} should reopen in entry phase")
+    _assert(window._command_model.input_armed, f"{message_prefix} should reopen with input armed")
+    _assert(window._command_model.input_text == "", f"{message_prefix} should reopen with no stale input text")
+    _assert(window._command_model.last_request == "", f"{message_prefix} should reopen with no stale typed request")
+    _assert(window._command_model.pending_action is None, f"{message_prefix} should reopen with no stale pending action")
+    _assert(window._command_model.pending_matches == (), f"{message_prefix} should reopen with no stale pending matches")
+    _assert(window._command_panel.last_payload.get("phase") == "entry", f"{message_prefix} payload should reopen in entry phase")
+    _assert(window._command_panel.last_payload.get("input_text", "") == "", f"{message_prefix} payload should reopen with no stale input")
+    _assert(window._command_panel.last_payload.get("typed_request", "") == "", f"{message_prefix} payload should reopen with no stale typed request")
+    _assert(window._command_panel.last_payload.get("pending_action") is None, f"{message_prefix} payload should reopen with no pending action")
+    _assert(window._command_panel.last_payload.get("ambiguous_matches") == [], f"{message_prefix} payload should reopen with no stale ambiguous matches")
+
+
+def _test_open_starts_in_typed_first_entry_mode():
+    window = _make_window()
+    window.open_command_overlay()
+
+    _assert(window._command_model.visible, "opening the overlay should make the command surface visible")
+    _assert(window._command_model.phase == "entry", "opening the overlay should start in entry phase")
+    _assert(window._command_model.input_armed, "opening the overlay should arm entry input")
+    _assert(window.overlay_needs_global_input_capture(), "opening the overlay should allow immediate typed interaction")
+    _assert(window._command_panel.focus_after_show_calls == 1, "opening the overlay should request input focus after show")
+    _assert(window._command_panel.last_payload.get("typing_ready"), "opening the overlay should render typing-ready state")
+
+
+def _test_not_found_stays_bounded():
+    window = _make_window()
+    window.open_command_overlay()
+    _type_request(window, "zzzzzzz")
+    window.handle_overlay_submit_requested()
+
+    _assert(window._command_model.phase == "entry", "a no-match request should remain in entry phase")
+    _assert(window._command_model.status_kind == "not_found", "a no-match request should surface not_found status")
+    _assert(window._command_model.pending_action is None, "a no-match request should not leave a pending action")
+    _assert(window._command_panel.last_payload.get("ambiguous_matches") == [], "a no-match request should not leave ambiguous matches")
+
+
+def _test_typed_first_choose_confirm_result_flow():
+    window = _make_window()
+    launches = []
+    original_launch = renderer_mod.launch_command_action
+    renderer_mod.launch_command_action = lambda action: launches.append(action.id)
+    try:
+        window.open_command_overlay()
+        _type_request(window, "open nexus folder")
+        window.handle_overlay_submit_requested()
+
+        _assert(window._command_model.phase == "choose", "an ambiguous request should enter choose phase")
+        ambiguous_matches = window._command_panel.last_payload.get("ambiguous_matches") or []
+        _assert(len(ambiguous_matches) >= 2, "an ambiguous request should surface multiple visible choices")
+
+        window.handle_overlay_text_requested("2")
+        _assert(window._command_model.phase == "confirm", "choosing an ambiguous match should enter confirm phase")
+
+        pending_action = window._command_panel.last_payload.get("pending_action") or {}
+        _assert(pending_action.get("id"), "confirm phase should surface one pending action")
+        _assert(pending_action.get("target_kind"), "confirm phase should surface target kind detail")
+        _assert(
+            pending_action.get("target_display") or pending_action.get("target"),
+            "confirm phase should surface a visible target detail",
+        )
+
+        expected_launch_id = pending_action["id"]
+        window.handle_overlay_submit_requested()
+
+        _assert(launches == [expected_launch_id], "confirm submit should execute the chosen pending action exactly once")
+        _assert(window._command_model.phase == "result", "successful execution should enter result phase")
+        _assert(window._command_model.status_kind == "launch_requested", "successful execution should produce launch_requested result status")
+        _assert(window._command_model.input_text == "", "result phase should clear stale entry text")
+        _assert(window._command_model.pending_action is None, "result phase should clear stale pending action state")
+    finally:
+        renderer_mod.launch_command_action = original_launch
+
+
+def _test_result_close_and_reopen_is_clean():
+    window = _make_window()
+    original_launch = renderer_mod.launch_command_action
+    renderer_mod.launch_command_action = lambda _action: None
+    try:
+        window.open_command_overlay()
+        _type_request(window, "open file explorer")
+        window.handle_overlay_submit_requested()
+        _assert(window._command_model.phase == "confirm", "a single exact match should enter confirm phase")
+        window.handle_overlay_submit_requested()
+        _assert(window._command_model.phase == "result", "confirm submit should enter result phase before close")
+
+        window._close_command_overlay_after_result()
+        window.open_command_overlay()
+        _assert_clean_entry_baseline(window, "result reopen")
+    finally:
+        renderer_mod.launch_command_action = original_launch
+
+
+def _test_url_saved_action_confirm_result_flow():
+    action_catalog = CommandActionCatalog(
+        (
+            CommandAction(
+                id="open_nexus_docs_site",
+                title="Open Nexus Docs Site",
+                target_kind="url",
+                target="https://example.com/docs/start",
+                aliases=("open docs site",),
+            ),
+        )
+    )
+    window = _make_window(action_catalog=action_catalog)
+    launches = []
+    original_launch = renderer_mod.launch_command_action
+    renderer_mod.launch_command_action = lambda action: launches.append(
+        (action.id, action.target_kind, action.target)
+    )
+    try:
+        window.open_command_overlay()
+        _type_request(window, "open docs site")
+        window.handle_overlay_submit_requested()
+
+        _assert(window._command_model.phase == "confirm", "a single url exact match should enter confirm phase")
+        pending_action = window._command_panel.last_payload.get("pending_action") or {}
+        _assert(
+            pending_action.get("target_kind") == "url",
+            "confirm phase should surface url target kinds without changing the state machine",
+        )
+        _assert(
+            pending_action.get("target_display") == "example.com/docs/start",
+            "confirm phase should compact url targets for inspection before execution",
+        )
+
+        window.handle_overlay_submit_requested()
+
+        _assert(
+            launches == [("open_nexus_docs_site", "url", "https://example.com/docs/start")],
+            "confirm submit should execute the url saved action exactly once through the existing baseline flow",
+        )
+        _assert(window._command_model.phase == "result", "successful url execution should enter result phase")
+        _assert(
+            window._command_model.status_kind == "launch_requested",
+            "successful url execution should preserve the existing launch_requested result behavior",
+        )
+
+        window._close_command_overlay_after_result()
+        window.open_command_overlay()
+        _assert_clean_entry_baseline(window, "url result reopen")
+    finally:
+        renderer_mod.launch_command_action = original_launch
+
+
+def main():
+    tests = [
+        ("typed-first open enters entry mode", _test_open_starts_in_typed_first_entry_mode),
+        ("not-found stays bounded", _test_not_found_stays_bounded),
+        ("choose-confirm-result baseline flow", _test_typed_first_choose_confirm_result_flow),
+        ("result close and reopen is clean", _test_result_close_and_reopen_is_clean),
+        ("url saved action confirm-result flow", _test_url_saved_action_confirm_result_flow),
+    ]
+
+    for name, fn in tests:
+        fn()
+        print(f"PASS: {name}")
+
+    print("INTERACTION BASELINE VALIDATION: PASS")
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/dev/orin_overlay_input_capture_helper.py
+++ b/dev/orin_overlay_input_capture_helper.py
@@ -124,6 +124,10 @@ def _make_window():
     window._overlay_input_capture_until = 0.0
     window._overlay_local_input_engaged = False
     window._overlay_global_capture_suspended = False
+    window._last_launch_failure_action_id = ""
+    window._last_launch_failure_count = 0
+    window._reported_recoverable_launch_failures = set()
+    window.runtime_log_path = ""
     window._log_event = lambda *_args, **_kwargs: None
     window._apply_command_overlay_state = lambda: renderer_mod.DesktopRuntimeWindow._apply_command_overlay_state(window)
     window._show_command_result = lambda kind, text: (

--- a/dev/orin_saved_action_source_validation.py
+++ b/dev/orin_saved_action_source_validation.py
@@ -1,0 +1,330 @@
+import json
+import os
+import sys
+import tempfile
+from pathlib import Path
+
+
+CURRENT_DIR = os.path.dirname(os.path.abspath(__file__))
+ROOT_DIR = os.path.dirname(CURRENT_DIR)
+
+if ROOT_DIR not in sys.path:
+    sys.path.insert(0, ROOT_DIR)
+
+from desktop.saved_action_source import load_saved_action_source, resolve_default_saved_action_source_path
+from desktop.shared_action_model import (
+    DEFAULT_COMMAND_ACTIONS,
+    build_default_command_action_catalog,
+    load_saved_command_actions,
+)
+
+
+def _assert(condition, message):
+    if not condition:
+        raise AssertionError(message)
+
+
+def _write_text(path: Path, text: str):
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(text, encoding="utf-8")
+
+
+def _write_json(path: Path, payload: dict):
+    _write_text(path, json.dumps(payload, indent=2) + "\n")
+
+
+def _with_local_app_data(temp_path: str):
+    class _LocalAppDataContext:
+        def __enter__(self_inner):
+            self_inner._original = os.environ.get("LOCALAPPDATA")
+            os.environ["LOCALAPPDATA"] = temp_path
+            return self_inner
+
+        def __exit__(self_inner, exc_type, exc, tb):
+            if self_inner._original is None:
+                os.environ.pop("LOCALAPPDATA", None)
+            else:
+                os.environ["LOCALAPPDATA"] = self_inner._original
+
+    return _LocalAppDataContext()
+
+
+def _builtin_ids():
+    return tuple(action.id for action in DEFAULT_COMMAND_ACTIONS)
+
+
+def _test_default_source_bootstraps_template_without_actions():
+    with tempfile.TemporaryDirectory() as temp_dir:
+        with _with_local_app_data(temp_dir):
+            path = resolve_default_saved_action_source_path()
+            payload = load_saved_action_source()
+
+            _assert(payload is None, "the default starter template should not count as active saved actions")
+            _assert(path.is_file(), "loading the default source should bootstrap the starter JSON file")
+
+            raw = json.loads(path.read_text(encoding="utf-8"))
+            _assert(raw.get("schema_version") == 1, "the bootstrapped template should preserve schema version 1")
+            _assert(isinstance(raw.get("examples"), list), "the bootstrapped template should preserve starter examples")
+
+
+def _test_missing_custom_source_falls_back_to_built_ins_only():
+    with tempfile.TemporaryDirectory() as temp_dir:
+        custom_path = Path(temp_dir) / "missing" / "saved_actions.json"
+
+        _assert(load_saved_action_source(custom_path) is None, "a missing custom source should not produce a payload")
+        _assert(load_saved_command_actions(custom_path) == (), "a missing custom source should resolve to no saved actions")
+
+        catalog = build_default_command_action_catalog(custom_path)
+        _assert(
+            tuple(action.id for action in catalog.actions) == _builtin_ids(),
+            "a missing custom source should leave the effective catalog at built-ins only",
+        )
+
+
+def _test_empty_or_invalid_custom_sources_fail_closed():
+    with tempfile.TemporaryDirectory() as temp_dir:
+        empty_path = Path(temp_dir) / "empty.json"
+        invalid_path = Path(temp_dir) / "invalid.json"
+
+        _write_text(empty_path, "   \n")
+        _write_text(invalid_path, "{ not valid json")
+
+        _assert(load_saved_action_source(empty_path) is None, "an empty custom source should not produce a payload")
+        _assert(load_saved_command_actions(empty_path) == (), "an empty custom source should fail closed to no saved actions")
+        _assert(load_saved_action_source(invalid_path) is None, "invalid JSON should not produce a payload")
+        _assert(load_saved_command_actions(invalid_path) == (), "invalid JSON should fail closed to no saved actions")
+
+
+def _test_valid_saved_actions_extend_the_effective_catalog():
+    with tempfile.TemporaryDirectory() as temp_dir:
+        source_path = Path(temp_dir) / "valid_saved_actions.json"
+        _write_json(
+            source_path,
+            {
+                "schema_version": 1,
+                "actions": [
+                    {
+                        "id": "open_reports",
+                        "title": "Open Reports",
+                        "target_kind": "folder",
+                        "target": r"C:\Reports",
+                        "aliases": ["open reports", "show reports"],
+                    }
+                ],
+            },
+        )
+
+        payload = load_saved_action_source(source_path)
+        saved_actions = load_saved_command_actions(source_path)
+        catalog = build_default_command_action_catalog(source_path)
+
+        _assert(payload is not None and len(payload.actions) == 1, "a valid custom source should load one payload action")
+        _assert(len(saved_actions) == 1 and saved_actions[0].id == "open_reports", "a valid saved action should become one effective saved action")
+        _assert(
+            len(catalog.actions) == len(DEFAULT_COMMAND_ACTIONS) + 1,
+            "a valid saved action should extend the effective catalog above the built-ins",
+        )
+        _assert(
+            tuple(action.id for action in catalog.actions[:-1]) == _builtin_ids(),
+            "extending the catalog should preserve built-in actions ahead of saved actions",
+        )
+
+
+def _test_valid_url_saved_actions_extend_the_effective_catalog():
+    with tempfile.TemporaryDirectory() as temp_dir:
+        source_path = Path(temp_dir) / "valid_url_saved_actions.json"
+        _write_json(
+            source_path,
+            {
+                "schema_version": 1,
+                "actions": [
+                    {
+                        "id": "open_nexus_docs_site",
+                        "title": "Open Nexus Docs Site",
+                        "target_kind": "url",
+                        "target": "https://example.com/docs/start",
+                        "aliases": ["open docs site"],
+                    }
+                ],
+            },
+        )
+
+        saved_actions = load_saved_command_actions(source_path)
+        catalog = build_default_command_action_catalog(source_path)
+
+        _assert(
+            len(saved_actions) == 1 and saved_actions[0].target_kind == "url",
+            "a valid url saved action should be accepted into the effective saved-action catalog",
+        )
+        _assert(
+            saved_actions[0].target == "https://example.com/docs/start",
+            "accepted url saved actions should preserve their original target string",
+        )
+        _assert(
+            catalog.actions[-1].id == "open_nexus_docs_site" and catalog.actions[-1].target_kind == "url",
+            "valid url saved actions should extend the effective catalog as first-class actions",
+        )
+
+
+def _test_unsupported_target_kind_fails_closed():
+    with tempfile.TemporaryDirectory() as temp_dir:
+        source_path = Path(temp_dir) / "unsupported_target_kind.json"
+        _write_json(
+            source_path,
+            {
+                "schema_version": 1,
+                "actions": [
+                    {
+                        "id": "open_docs_url",
+                        "title": "Open Docs URL",
+                        "target_kind": "routine",
+                        "target": "https://example.com/docs",
+                        "aliases": ["open docs url"],
+                    }
+                ],
+            },
+        )
+
+        _assert(
+            load_saved_command_actions(source_path) == (),
+            "unsupported saved-action target kinds should fail closed to no saved actions",
+        )
+
+
+def _test_invalid_url_targets_fail_closed():
+    with tempfile.TemporaryDirectory() as temp_dir:
+        source_path = Path(temp_dir) / "invalid_url_target.json"
+        _write_json(
+            source_path,
+            {
+                "schema_version": 1,
+                "actions": [
+                    {
+                        "id": "open_docs_url",
+                        "title": "Open Docs URL",
+                        "target_kind": "url",
+                        "target": "example.com/docs",
+                        "aliases": ["open docs url"],
+                    }
+                ],
+            },
+        )
+
+        _assert(
+            load_saved_command_actions(source_path) == (),
+            "invalid url saved-action targets should fail closed to no saved actions",
+        )
+
+
+def _test_duplicate_saved_ids_fail_closed():
+    with tempfile.TemporaryDirectory() as temp_dir:
+        source_path = Path(temp_dir) / "duplicate_ids.json"
+        _write_json(
+            source_path,
+            {
+                "schema_version": 1,
+                "actions": [
+                    {
+                        "id": "open_reports",
+                        "title": "Open Reports",
+                        "target_kind": "folder",
+                        "target": r"C:\Reports",
+                        "aliases": ["open reports"],
+                    },
+                    {
+                        "id": "open_reports",
+                        "title": "Open Reports Backup",
+                        "target_kind": "folder",
+                        "target": r"C:\Reports\Backup",
+                        "aliases": ["open reports backup"],
+                    },
+                ],
+            },
+        )
+
+        _assert(
+            load_saved_command_actions(source_path) == (),
+            "duplicate saved-action ids should fail closed to no saved actions",
+        )
+
+
+def _test_duplicate_saved_phrases_fail_closed():
+    with tempfile.TemporaryDirectory() as temp_dir:
+        source_path = Path(temp_dir) / "duplicate_phrases.json"
+        _write_json(
+            source_path,
+            {
+                "schema_version": 1,
+                "actions": [
+                    {
+                        "id": "open_reports",
+                        "title": "Open Reports",
+                        "target_kind": "folder",
+                        "target": r"C:\Reports",
+                        "aliases": ["show reports"],
+                    },
+                    {
+                        "id": "open_reports_archive",
+                        "title": "Open Reports Archive",
+                        "target_kind": "folder",
+                        "target": r"C:\Reports\Archive",
+                        "aliases": ["show reports"],
+                    },
+                ],
+            },
+        )
+
+        _assert(
+            load_saved_command_actions(source_path) == (),
+            "duplicate saved-action titles or aliases should fail closed to no saved actions",
+        )
+
+
+def _test_builtin_collisions_fail_closed():
+    with tempfile.TemporaryDirectory() as temp_dir:
+        source_path = Path(temp_dir) / "builtin_collision.json"
+        _write_json(
+            source_path,
+            {
+                "schema_version": 1,
+                "actions": [
+                    {
+                        "id": "open_windows_explorer",
+                        "title": "Open Explorer Again",
+                        "target_kind": "app",
+                        "target": "explorer.exe",
+                        "aliases": ["open explorer again"],
+                    }
+                ],
+            },
+        )
+
+        _assert(
+            load_saved_command_actions(source_path) == (),
+            "collisions against built-in ids or phrases should fail closed to no saved actions",
+        )
+
+
+def main():
+    tests = [
+        ("default source bootstrap", _test_default_source_bootstraps_template_without_actions),
+        ("missing custom source fallback", _test_missing_custom_source_falls_back_to_built_ins_only),
+        ("empty and invalid source fallback", _test_empty_or_invalid_custom_sources_fail_closed),
+        ("valid saved actions extend catalog", _test_valid_saved_actions_extend_the_effective_catalog),
+        ("valid url saved actions extend catalog", _test_valid_url_saved_actions_extend_the_effective_catalog),
+        ("unsupported target kind fails closed", _test_unsupported_target_kind_fails_closed),
+        ("invalid url targets fail closed", _test_invalid_url_targets_fail_closed),
+        ("duplicate saved ids fail closed", _test_duplicate_saved_ids_fail_closed),
+        ("duplicate saved phrases fail closed", _test_duplicate_saved_phrases_fail_closed),
+        ("built-in collisions fail closed", _test_builtin_collisions_fail_closed),
+    ]
+
+    for name, fn in tests:
+        fn()
+        print(f"PASS: {name}")
+
+    print("SAVED ACTION SOURCE VALIDATION: PASS")
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/dev/orin_shared_action_baseline_validation.py
+++ b/dev/orin_shared_action_baseline_validation.py
@@ -1,0 +1,210 @@
+import os
+import sys
+
+
+CURRENT_DIR = os.path.dirname(os.path.abspath(__file__))
+ROOT_DIR = os.path.dirname(CURRENT_DIR)
+
+if ROOT_DIR not in sys.path:
+    sys.path.insert(0, ROOT_DIR)
+
+import desktop.shared_action_model as shared_action_mod
+from desktop.shared_action_model import (
+    CommandAction,
+    CommandActionCatalog,
+    DEFAULT_COMMAND_ACTIONS,
+    SUPPORTED_ACTION_TARGET_KINDS,
+    normalize_command_text,
+)
+
+
+def _assert(condition, message):
+    if not condition:
+        raise AssertionError(message)
+
+
+def _ids(actions):
+    return tuple(action.id for action in actions)
+
+
+def _build_resolution_catalog():
+    return CommandActionCatalog(
+        (
+            CommandAction(
+                id="open_reports_primary",
+                title="Open Reports",
+                target_kind="folder",
+                target=r"C:\Reports\Primary",
+                aliases=("show reports", "open reporting workspace"),
+            ),
+            CommandAction(
+                id="open_reports_archive",
+                title="Open Reports Archive",
+                target_kind="folder",
+                target=r"C:\Reports\Archive",
+                aliases=("show reports", "open archived reports"),
+            ),
+            CommandAction(
+                id="open_tools",
+                title="Open Tools",
+                target_kind="folder",
+                target=r"C:\Tools",
+                aliases=("show tools",),
+            ),
+        )
+    )
+
+
+def _test_normalization_contract():
+    _assert(
+        normalize_command_text("  Open   File Explorer!!! ") == "open file explorer",
+        "normalization should casefold, collapse whitespace, and trim trailing punctuation",
+    )
+    _assert(
+        normalize_command_text("Open Saved Actions File??") == "open saved actions file",
+        "normalization should trim question-mark punctuation as part of the exact-match contract",
+    )
+    _assert(normalize_command_text("") == "", "empty text should normalize to empty text")
+
+
+def _test_exact_match_contract_on_custom_catalog():
+    catalog = _build_resolution_catalog()
+
+    _assert(
+        _ids(catalog.resolve_actions("open reports")) == ("open_reports_primary",),
+        "exact title matches should return one exact resolved action",
+    )
+    _assert(
+        _ids(catalog.resolve_actions("SHOW TOOLS!!!")) == ("open_tools",),
+        "exact alias matches should work after normalization",
+    )
+    _assert(
+        catalog.resolve_actions("open report") == (),
+        "near-miss phrasing should not resolve under the exact-match baseline",
+    )
+    _assert(
+        catalog.resolve_actions("launch report center") == (),
+        "semantic intent should not be inferred under the current baseline",
+    )
+
+
+def _test_ambiguous_match_contract_on_custom_catalog():
+    catalog = _build_resolution_catalog()
+    matches = catalog.resolve_actions("show reports")
+
+    _assert(len(matches) == 2, "shared-action resolution should preserve explicit ambiguity when two actions match")
+    _assert(
+        _ids(matches) == ("open_reports_primary", "open_reports_archive"),
+        "ambiguous resolution should preserve the matched action set in catalog order",
+    )
+
+
+def _test_builtin_catalog_integrity():
+    built_in_ids = set()
+
+    _assert(DEFAULT_COMMAND_ACTIONS, "the built-in shared action catalog should not be empty")
+    for action in DEFAULT_COMMAND_ACTIONS:
+        _assert(action.id and action.id.strip(), "built-in action ids must be non-empty")
+        _assert(action.id not in built_in_ids, "built-in action ids must stay unique")
+        built_in_ids.add(action.id)
+
+        _assert(action.title and action.title.strip(), f"{action.id} should keep a non-empty title")
+        _assert(
+            action.target_kind in SUPPORTED_ACTION_TARGET_KINDS,
+            f"{action.id} should keep a supported target kind",
+        )
+        _assert(action.target and str(action.target).strip(), f"{action.id} should keep a non-empty target")
+
+        normalized_title = normalize_command_text(action.title)
+        _assert(normalized_title, f"{action.id} title should normalize to a non-empty phrase")
+        for alias in action.aliases:
+            _assert(normalize_command_text(alias), f"{action.id} aliases should normalize to non-empty phrases")
+
+
+def _test_url_target_support_is_first_class():
+    _assert("url" in SUPPORTED_ACTION_TARGET_KINDS, "url targets should be a supported action target kind")
+
+    catalog = CommandActionCatalog(
+        (
+            CommandAction(
+                id="open_nexus_docs_site",
+                title="Open Nexus Docs Site",
+                target_kind="url",
+                target="https://example.com/docs/start",
+                aliases=("open docs site",),
+            ),
+        )
+    )
+
+    _assert(
+        _ids(catalog.resolve_actions("open docs site")) == ("open_nexus_docs_site",),
+        "url actions should resolve through the same exact-match shared action catalog",
+    )
+    _assert(
+        catalog.format_target_display("url", "https://example.com/docs/start") == "example.com/docs/start",
+        "url actions should surface a compact confirm-target display",
+    )
+
+
+def _test_url_launch_uses_system_handler_without_path_normalization():
+    launches = []
+    original_startfile = shared_action_mod.os.startfile
+    original_popen = shared_action_mod.subprocess.Popen
+    shared_action_mod.os.startfile = lambda target: launches.append(target)
+    shared_action_mod.subprocess.Popen = lambda *_args, **_kwargs: (_ for _ in ()).throw(
+        AssertionError("url launches should not go through subprocess Popen")
+    )
+
+    try:
+        shared_action_mod.launch_command_action(
+            CommandAction(
+                id="open_nexus_docs_site",
+                title="Open Nexus Docs Site",
+                target_kind="url",
+                target="https://example.com/docs/start",
+                aliases=(),
+            )
+        )
+    finally:
+        shared_action_mod.os.startfile = original_startfile
+        shared_action_mod.subprocess.Popen = original_popen
+
+    _assert(
+        launches == ["https://example.com/docs/start"],
+        "url launches should use the original URL string through the system handler",
+    )
+
+
+def _test_default_catalog_wrapper_preserves_builtin_catalog():
+    catalog = CommandActionCatalog()
+
+    _assert(
+        len(catalog.actions) == len(DEFAULT_COMMAND_ACTIONS),
+        "the default catalog wrapper should expose the current built-in catalog without dropping actions",
+    )
+    _assert(
+        tuple(action.id for action in catalog.actions) == tuple(action.id for action in DEFAULT_COMMAND_ACTIONS),
+        "the default catalog wrapper should preserve built-in catalog ordering",
+    )
+
+
+def main():
+    tests = [
+        ("normalization contract", _test_normalization_contract),
+        ("exact match contract", _test_exact_match_contract_on_custom_catalog),
+        ("ambiguous match contract", _test_ambiguous_match_contract_on_custom_catalog),
+        ("built-in catalog integrity", _test_builtin_catalog_integrity),
+        ("url target support", _test_url_target_support_is_first_class),
+        ("url launch path", _test_url_launch_uses_system_handler_without_path_normalization),
+        ("default catalog wrapper", _test_default_catalog_wrapper_preserves_builtin_catalog),
+    ]
+
+    for name, fn in tests:
+        fn()
+        print(f"PASS: {name}")
+
+    print("SHARED ACTION BASELINE VALIDATION: PASS")
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

This PR is the first bounded FB-027 capability milestone above the locked interaction baseline. It adds URL targets as a first-class saved-action capability without redefining the baseline contract or widening into broader interaction-system expansion.

## What Changed

### Changes

- adds first-class `url` target support to saved actions
- preserves the typed-first interaction baseline, exact-match resolution, and existing state machine
- keeps confirm/result flow and input-capture behavior unchanged
- extends validator coverage for:
  - shared action baseline
  - saved action source behavior
  - typed-first interaction baseline
- updates FB-027 workstream/backlog/roadmap truth for this milestone
- explicitly leaves the existing recoverable launch-failed release-context validator failure out of scope

### Review Notes

This PR is the first bounded FB-027 capability milestone above the locked interaction baseline. It adds URL targets as a first-class saved-action capability without redefining the baseline contract or widening into broader interaction-system expansion.

### Changes

- adds first-class `url` target support to saved actions
- preserves the typed-first interaction baseline, exact-match resolution, and existing state machine
- keeps confirm/result flow and input-capture behavior unchanged
- extends validator coverage for:
  - shared action baseline
  - saved action source behavior
  - typed-first interaction baseline
- updates FB-027 workstream/backlog/roadmap truth for this milestone
- explicitly leaves the existing recoverable launch-failed release-context validator failure out of scope

### Review Notes
