### PR TITLE
Sync release truth after FB-027 URL milestone

### DIFF
--- a/Docs/feature_backlog.md
+++ b/Docs/feature_backlog.md
@@ -22,7 +22,7 @@ Historical note:
 
 ### [ID: FB-027] Interaction system baseline and shared action model
 
-Status: Implemented on branch (baseline preserved; URL target support; unreleased)
+Status: Merged unreleased on `main` (baseline preserved; URL target support implemented)
 Record State: Promoted
 Priority: High
 Release Stage: pre-Beta

--- a/Docs/prebeta_roadmap.md
+++ b/Docs/prebeta_roadmap.md
@@ -57,25 +57,25 @@ Use these release-state values when relevant:
 
 ## Current Release Posture
 
-Current branch truth indicates:
+Current merged truth indicates:
 
 - latest public prerelease: `v1.2.7-prebeta`
 - latest public release commit: `3168823`
-- no merged unreleased non-doc implementation debt currently exists on `main`
-- this branch now carries an unreleased FB-027 implementation delta for first-class URL saved-action targets
-- FB-027 remains the active promoted interaction workstream on this branch
+- merged unreleased non-doc implementation debt now exists on `main`
+- that merged unreleased implementation debt is the first FB-027 capability milestone for first-class URL saved-action targets
+- FB-027 remains the active promoted interaction workstream on `main`
 
-That means merged `main` remains between released non-doc implementation lanes while this branch now carries the first bounded FB-027 capability milestone above the locked interaction baseline.
+That means `main` is no longer between released non-doc implementation lanes. It now carries one merged unreleased FB-027 capability milestone above the locked interaction baseline, so the next posture should be release review/prep or directly coupled truth-repair and consistency work rather than another unrelated implementation lane.
 
 ## Current Promoted Workstream Context
 
 ### FB-027 Interaction System Baseline
 
-- status: `implemented on branch`
+- status: `merged unreleased on main`
 - lane type: `implementation`
 - release floor: `patch prerelease`
 - target version: `TBD`
-- release state: `active delta`
+- release state: `merged unreleased`
 - canonical workstream doc: `Docs/workstreams/FB-027_interaction_system_baseline.md`
 - sequencing note: now preserves the locked typed-first baseline while adding first-class URL saved-action targets without changing exact-match resolution, state-machine boundedness, or input-capture behavior
 
@@ -130,12 +130,13 @@ That means merged `main` remains between released non-doc implementation lanes w
 
 ## Current Sequencing Reading
 
-Current branch truth indicates:
+Current merged truth indicates:
 
 - the released FB-035 lane is closed
 - the recent released workstreams above remain part of the locked current baseline
-- FB-027 now carries the first bounded implementation delta above the validated interaction baseline
-- the next FB-027 capability milestone should be chosen only after the URL target milestone is accepted
+- FB-027 now contributes the first bounded merged unreleased implementation milestone above the validated interaction baseline
+- the immediate next posture is merged-truth sync and release-context consistency work, then release review/prep before another unrelated implementation lane
+- the next FB-027 capability milestone should be chosen only after merged truth and release posture are coherent on `main`
 - this milestone does not authorize resolution changes, voice, Action Studio, routines, profiles, hotkey cleanup, or shutdown-confirmation work
 
 Use canonical workstream docs for execution detail.

--- a/Docs/workstreams/FB-027_interaction_system_baseline.md
+++ b/Docs/workstreams/FB-027_interaction_system_baseline.md
@@ -11,7 +11,7 @@
 
 ## Status
 
-- `Implemented on branch (baseline preserved; URL target support; unreleased)`
+- `Merged unreleased on main (baseline preserved; URL target support implemented)`
 
 ## Release Stage
 
@@ -19,7 +19,7 @@
 
 ## Target Version
 
-- `no release`
+- `TBD`
 
 ## Purpose / Why It Matters
 
@@ -37,7 +37,7 @@ This workstream exists so future interaction work can extend a defended baseline
 - the current saved-action seam lives at `%LOCALAPPDATA%/Nexus Desktop AI/saved_actions.json`
 - current saved-action target kinds are `app`, `folder`, `file`, and `url`
 - current repo truth does not yet include shipped voice invocation, Action Studio authoring UI, routines, profiles, or broader natural-language resolution
-- this workstream now protects the locked baseline while adding first-class URL saved-action targets through the existing shared action model
+- this workstream now protects the locked baseline while preserving the merged first-class URL saved-action target milestone through the existing shared action model
 
 ## Milestone Value Statement
 
@@ -347,7 +347,7 @@ The following directly related FB-027 follow-through is recorded now but not imp
 
 - remove `Ctrl+Alt+1` and `Ctrl+Alt+2` before Beta
 - add an `Are you sure you want to exit?` prompt for shutdown hotkeys before Beta
-- select the next capability-expansion milestone only after the URL target milestone is accepted
+- select the next capability-expansion milestone only after merged truth and release posture for the URL target milestone are coherent on `main`
 
 These are deferred forward items, not current-runtime guarantees.
 
@@ -389,7 +389,7 @@ The typed-first interaction baseline remains explicit and validator-defended, an
 
 - remove `Ctrl+Alt+1` and `Ctrl+Alt+2` before Beta
 - add an `Are you sure you want to exit?` prompt for shutdown hotkeys before Beta
-- choose the first capability-expansion milestone only after this baseline-definition pass is accepted
+- choose the next capability-expansion milestone only after merged truth and release posture for the URL target milestone are coherent on `main`
 
 ## Related References
 

--- a/desktop/orin_support_reporting.py
+++ b/desktop/orin_support_reporting.py
@@ -15,7 +15,7 @@ SUPPORT_BUNDLE_FOLDER = "support_bundles"
 MANIFEST_FILENAME = "manifest.json"
 VERSION_CLOSEOUT_PATTERN = re.compile(r"^v(\d+)\.(\d+)\.(\d+)_closeout\.md$")
 LATEST_PUBLIC_PRERELEASE_LINE_PATTERN = re.compile(
-    r"latest public prerelease(?: is now)?\s*`(v\d+\.\d+\.\d+-prebeta)`",
+    r"latest public prerelease(?: is now)?\s*:?\s*`(v\d+\.\d+\.\d+-prebeta)`",
     re.IGNORECASE,
 )
 RELEASED_CLOSED_PRERELEASE_LINE_PATTERN = re.compile(


### PR DESCRIPTION
## Summary

Updates Sync release truth after FB-027 URL milestone.

## What Changed

### Changes

- sync FB-027 backlog, roadmap, and workstream truth to reflect the merged URL-target milestone on `main`
- restore roadmap-fallback release-context detection so support-report artifacts use the correct latest public prerelease when Git tag lookup is unavailable
- keep the change tightly scoped to release-truth repair for the pending `v1.2.8-prebeta` release

### Changes

- sync FB-027 backlog, roadmap, and workstream truth to reflect the merged URL-target milestone on `main`
- restore roadmap-fallback release-context detection so support-report artifacts use the correct latest public prerelease when Git tag lookup is unavailable
- keep the change tightly scoped to release-truth repair for the pending `v1.2.8-prebeta` release
