### PR TITLE
docs: post-v1.2.8-prebeta truth sync and rebaseline

### DIFF
--- a/Docs/Main.md
+++ b/Docs/Main.md
@@ -100,7 +100,7 @@ Use these for closeout policy, historical closeout lookup, and the modern Nexus-
 
 - `Docs/closeout_guidance.md`
 - `Docs/closeout_index.md`
-- `Docs/closeouts/nexus_prebeta_rebaseline_through_v1.2.7-prebeta.md`
+- `Docs/closeouts/nexus_prebeta_rebaseline_through_v1.2.8-prebeta.md`
 
 Historical closeout leaf docs are intentionally routed through `Docs/closeout_index.md`.
 

--- a/Docs/closeout_guidance.md
+++ b/Docs/closeout_guidance.md
@@ -34,7 +34,7 @@ The historical Jarvis line already has preserved closeouts through `v2.2.1`.
 
 The modern Nexus pre-Beta line now resumes epoch-summary coverage through:
 
-- `Docs/closeouts/nexus_prebeta_rebaseline_through_v1.2.7-prebeta.md`
+- `Docs/closeouts/nexus_prebeta_rebaseline_through_v1.2.8-prebeta.md`
 
 That rebaseline is the current modern carry-forward baseline.
 
@@ -78,5 +78,5 @@ When those facts change, the repo may legitimately need a docs-only canon repair
 - preserve historical closeouts
 - route historical lookup through `Docs/closeout_index.md`
 - use canonical workstream records for workstream-level detail
-- use the modern Nexus rebaseline for epoch truth through `v1.2.7-prebeta`
+- use the modern Nexus rebaseline for epoch truth through `v1.2.8-prebeta`
 - create new closeouts or rebaselines only when they materially improve future planning clarity

--- a/Docs/closeout_index.md
+++ b/Docs/closeout_index.md
@@ -11,12 +11,12 @@ Use `Docs/closeout_guidance.md` for policy and cadence questions.
 
 ## Current Nexus-Era Baseline
 
-### Nexus Pre-Beta Rebaseline Through v1.2.7-prebeta
+### Nexus Pre-Beta Rebaseline Through v1.2.8-prebeta
 
 - scope:
-  - current shared Nexus pre-Beta baseline through the released FB-035 milestone
+  - current shared Nexus pre-Beta baseline through the released FB-027 URL-target milestone
 - file:
-  - `Docs/closeouts/nexus_prebeta_rebaseline_through_v1.2.7-prebeta.md`
+  - `Docs/closeouts/nexus_prebeta_rebaseline_through_v1.2.8-prebeta.md`
 
 ## Historical Jarvis Closeouts
 

--- a/Docs/closeouts/nexus_prebeta_rebaseline_through_v1.2.8-prebeta.md
+++ b/Docs/closeouts/nexus_prebeta_rebaseline_through_v1.2.8-prebeta.md
@@ -1,13 +1,8 @@
-# Nexus Pre-Beta Rebaseline Through v1.2.7-prebeta
-
-Historical note:
-
-- the current carry-forward Nexus pre-Beta baseline has advanced to `Docs/closeouts/nexus_prebeta_rebaseline_through_v1.2.8-prebeta.md`
-- this document remains the historical epoch summary through `v1.2.7-prebeta`
+# Nexus Pre-Beta Rebaseline Through v1.2.8-prebeta
 
 ## Purpose
 
-This document is the modern Nexus-era rebaseline through `v1.2.7-prebeta`.
+This document is the modern Nexus-era rebaseline through `v1.2.8-prebeta`.
 
 Its job is to:
 
@@ -20,7 +15,7 @@ Its job is to:
 
 This rebaseline covers merged shared truth through the released public prerelease:
 
-- `v1.2.7-prebeta`
+- `v1.2.8-prebeta`
 
 It stands on top of the preserved historical closeout line indexed in:
 
@@ -35,10 +30,11 @@ The closed workstreams that materially define the current baseline are:
 - `Docs/workstreams/FB-025_boot_desktop_milestone_taxonomy_clarification.md`
 - `Docs/workstreams/FB-034_recoverable_diagnostics.md`
 - `Docs/workstreams/FB-035_release_context_fallback_hardening.md`
+- `Docs/workstreams/FB-027_interaction_system_baseline.md`
 
 ## What Is Locked Now
 
-Through `v1.2.7-prebeta`, current shared truth includes:
+Through `v1.2.8-prebeta`, current shared truth includes:
 
 - launcher-owned historical state is not a live root-logs surface
 - the startup snapshot harness is a bounded dev-only and opt-in debugging surface
@@ -47,21 +43,29 @@ Through `v1.2.7-prebeta`, current shared truth includes:
   - repeated identical `launch_failed` for the same action in a still-running session
 - support-report fallback now derives release context from released-canon truth instead of the highest planned prerelease target
 - the manual-reporting boundary remains local and manual only
+- the typed-first desktop interaction baseline is explicit and validator-defended
+- built-in actions and saved actions resolve through one shared action catalog
+- the first bounded interaction capability milestone is now released:
+  - first-class URL target support for saved actions without changing exact-match resolution, state-machine boundedness, or input-capture behavior
 
 ## What Remains Deferred
 
 This rebaseline does not authorize automatic continuation into:
 
-- broader recoverable diagnostics surface work
+- saved-action authoring UX
+- broader resolution-quality follow-through
+- interaction-clarity follow-through
+- shutdown exit-confirmation work
+- hotkey cleanup before Beta
 - broader reporting-policy or upload-behavior work
 - broader boot-layer implementation work
-- broader interaction, rebrand, or UI follow-through by inertia
+- broader interaction, rebrand, voice, or UI follow-through by inertia
 
 ## Forward-Planning Posture After This Baseline
 
-Current merged truth does not automatically activate a new non-doc implementation lane.
+Current merged truth is again between released non-doc implementation lanes.
 
-The next implementation workstream must be chosen from refreshed backlog, workstream, and product-boundary truth rather than by continuing the released FB-035 lane.
+The next implementation workstream must be chosen from refreshed backlog, workstream, interaction, and product-boundary truth rather than by continuing the released FB-027 lane by inertia.
 
 ## Historical Relationship
 
@@ -76,4 +80,4 @@ This document does not rewrite those historical closeouts.
 
 ## Carry-Forward Rule
 
-Future prompts should usually treat this rebaseline plus the retained workstream records as the modern carry-forward baseline through `v1.2.7-prebeta` instead of replaying each closed lane narrative in full.
+Future prompts should usually treat this rebaseline plus the retained workstream records as the modern carry-forward baseline through `v1.2.8-prebeta` instead of replaying each closed lane narrative in full.

--- a/Docs/feature_backlog.md
+++ b/Docs/feature_backlog.md
@@ -20,16 +20,7 @@ Historical note:
 
 ## Promoted Canonical Workstreams
 
-### [ID: FB-027] Interaction system baseline and shared action model
-
-Status: Merged unreleased on `main` (baseline preserved; URL target support implemented)
-Record State: Promoted
-Priority: High
-Release Stage: pre-Beta
-Target Version: TBD
-Canonical Workstream Doc: Docs/workstreams/FB-027_interaction_system_baseline.md
-Summary: Lock the typed-first interaction baseline and deliver the first bounded capability milestone by adding first-class URL targets to saved actions.
-Why it matters: Future interaction work needs one authoritative baseline and one bounded first expansion so saved-action, resolution, and command-surface growth do not silently rewrite current guarantees.
+No currently promoted non-doc implementation workstream is active on `main`.
 
 ## Registry Items
 
@@ -104,6 +95,17 @@ Summary: Track the broader Nexus-era vision and source-of-truth migration above 
 Why it matters: The repo still needs deeper identity and wording normalization after the foundation layer is rebuilt.
 
 ## Closed Canonical Workstreams
+
+### [ID: FB-027] Interaction system baseline and shared action model
+
+Status: Released (v1.2.8-prebeta)
+Record State: Closed
+Priority: High
+Release Stage: pre-Beta
+Target Version: v1.2.8-prebeta
+Canonical Workstream Doc: Docs/workstreams/FB-027_interaction_system_baseline.md
+Summary: Lock the typed-first interaction baseline and deliver the first bounded capability milestone by adding first-class URL targets to saved actions.
+Why it matters: Future interaction work needs one authoritative baseline and one bounded first expansion so saved-action, resolution, and command-surface growth do not silently rewrite current guarantees.
 
 ### [ID: FB-025] Boot and desktop milestone taxonomy clarification
 

--- a/Docs/prebeta_roadmap.md
+++ b/Docs/prebeta_roadmap.md
@@ -59,25 +59,25 @@ Use these release-state values when relevant:
 
 Current merged truth indicates:
 
-- latest public prerelease: `v1.2.7-prebeta`
-- latest public release commit: `3168823`
-- merged unreleased non-doc implementation debt now exists on `main`
-- that merged unreleased implementation debt is the first FB-027 capability milestone for first-class URL saved-action targets
-- FB-027 remains the active promoted interaction workstream on `main`
+- latest public prerelease: `v1.2.8-prebeta`
+- latest public release commit: `4816aac`
+- no merged unreleased non-doc implementation debt currently exists on `main`
+- the most recent released implementation milestone is FB-027 for first-class URL saved-action targets
+- no active non-doc implementation workstream is currently selected on `main`
 
-That means `main` is no longer between released non-doc implementation lanes. It now carries one merged unreleased FB-027 capability milestone above the locked interaction baseline, so the next posture should be release review/prep or directly coupled truth-repair and consistency work rather than another unrelated implementation lane.
+That means `main` is again between released non-doc implementation lanes. The released FB-027 baseline-and-URL milestone now forms part of the current shared pre-Beta baseline, and the next workstream should be chosen from refreshed post-release truth rather than by continuing released work by inertia.
 
-## Current Promoted Workstream Context
+## Most Recent Released Workstream Context
 
 ### FB-027 Interaction System Baseline
 
-- status: `merged unreleased on main`
+- status: `released`
 - lane type: `implementation`
 - release floor: `patch prerelease`
-- target version: `TBD`
-- release state: `merged unreleased`
+- target version: `v1.2.8-prebeta`
+- release state: `released`
 - canonical workstream doc: `Docs/workstreams/FB-027_interaction_system_baseline.md`
-- sequencing note: now preserves the locked typed-first baseline while adding first-class URL saved-action targets without changing exact-match resolution, state-machine boundedness, or input-capture behavior
+- sequencing note: released the locked typed-first baseline plus first-class URL saved-action targets without changing exact-match resolution, state-machine boundedness, or input-capture behavior
 
 ## Recently Closed Workstreams
 
@@ -132,12 +132,12 @@ That means `main` is no longer between released non-doc implementation lanes. It
 
 Current merged truth indicates:
 
+- the released FB-027 lane is now part of the current locked interaction baseline
 - the released FB-035 lane is closed
 - the recent released workstreams above remain part of the locked current baseline
-- FB-027 now contributes the first bounded merged unreleased implementation milestone above the validated interaction baseline
-- the immediate next posture is merged-truth sync and release-context consistency work, then release review/prep before another unrelated implementation lane
-- the next FB-027 capability milestone should be chosen only after merged truth and release posture are coherent on `main`
-- this milestone does not authorize resolution changes, voice, Action Studio, routines, profiles, hotkey cleanup, or shutdown-confirmation work
+- no merged unreleased non-doc implementation debt currently exists on `main`
+- the next implementation workstream should be chosen only after fresh post-release analysis on updated `main`
+- the released FB-027 milestone does not authorize further saved-action, resolution, voice, Action Studio, routines, profiles, hotkey cleanup, or shutdown-confirmation work by inertia
 
 Use canonical workstream docs for execution detail.
 Use the backlog for item identity.

--- a/Docs/workstreams/FB-025_boot_desktop_milestone_taxonomy_clarification.md
+++ b/Docs/workstreams/FB-025_boot_desktop_milestone_taxonomy_clarification.md
@@ -82,4 +82,4 @@ Released in `v1.2.5-prebeta` as a bounded taxonomy clarification milestone.
 
 - `Docs/feature_backlog.md`
 - `Docs/prebeta_roadmap.md`
-- `Docs/closeouts/nexus_prebeta_rebaseline_through_v1.2.7-prebeta.md`
+- `Docs/closeouts/nexus_prebeta_rebaseline_through_v1.2.8-prebeta.md`

--- a/Docs/workstreams/FB-027_interaction_system_baseline.md
+++ b/Docs/workstreams/FB-027_interaction_system_baseline.md
@@ -7,11 +7,11 @@
 
 ## Record State
 
-- `Promoted`
+- `Closed`
 
 ## Status
 
-- `Merged unreleased on main (baseline preserved; URL target support implemented)`
+- `Released (v1.2.8-prebeta)`
 
 ## Release Stage
 
@@ -19,7 +19,7 @@
 
 ## Target Version
 
-- `TBD`
+- `v1.2.8-prebeta`
 
 ## Purpose / Why It Matters
 
@@ -37,7 +37,7 @@ This workstream exists so future interaction work can extend a defended baseline
 - the current saved-action seam lives at `%LOCALAPPDATA%/Nexus Desktop AI/saved_actions.json`
 - current saved-action target kinds are `app`, `folder`, `file`, and `url`
 - current repo truth does not yet include shipped voice invocation, Action Studio authoring UI, routines, profiles, or broader natural-language resolution
-- this workstream now protects the locked baseline while preserving the merged first-class URL saved-action target milestone through the existing shared action model
+- this workstream locked the typed-first baseline and released the first-class URL saved-action target milestone through the existing shared action model
 
 ## Milestone Value Statement
 
@@ -347,7 +347,7 @@ The following directly related FB-027 follow-through is recorded now but not imp
 
 - remove `Ctrl+Alt+1` and `Ctrl+Alt+2` before Beta
 - add an `Are you sure you want to exit?` prompt for shutdown hotkeys before Beta
-- select the next capability-expansion milestone only after merged truth and release posture for the URL target milestone are coherent on `main`
+- select the next capability-expansion milestone only through fresh post-release analysis on updated `main`
 
 These are deferred forward items, not current-runtime guarantees.
 
@@ -389,7 +389,7 @@ The typed-first interaction baseline remains explicit and validator-defended, an
 
 - remove `Ctrl+Alt+1` and `Ctrl+Alt+2` before Beta
 - add an `Are you sure you want to exit?` prompt for shutdown hotkeys before Beta
-- choose the next capability-expansion milestone only after merged truth and release posture for the URL target milestone are coherent on `main`
+- choose the next capability-expansion milestone only through fresh post-release analysis on updated `main`
 
 ## Related References
 

--- a/Docs/workstreams/FB-028_history_state_relocation.md
+++ b/Docs/workstreams/FB-028_history_state_relocation.md
@@ -85,4 +85,4 @@ Released in `v1.2.3-prebeta` as a bounded runtime-state relocation milestone.
 - `Docs/feature_backlog.md`
 - `Docs/prebeta_roadmap.md`
 - `Docs/development_rules.md`
-- `Docs/closeouts/nexus_prebeta_rebaseline_through_v1.2.7-prebeta.md`
+- `Docs/closeouts/nexus_prebeta_rebaseline_through_v1.2.8-prebeta.md`

--- a/Docs/workstreams/FB-033_startup_snapshot_harness_follow_through.md
+++ b/Docs/workstreams/FB-033_startup_snapshot_harness_follow_through.md
@@ -86,4 +86,4 @@ Released in `v1.2.4-prebeta` as intentional dev-only startup debugging infrastru
 - `Docs/feature_backlog.md`
 - `Docs/prebeta_roadmap.md`
 - `Docs/development_rules.md`
-- `Docs/closeouts/nexus_prebeta_rebaseline_through_v1.2.7-prebeta.md`
+- `Docs/closeouts/nexus_prebeta_rebaseline_through_v1.2.8-prebeta.md`

--- a/Docs/workstreams/FB-034_recoverable_diagnostics.md
+++ b/Docs/workstreams/FB-034_recoverable_diagnostics.md
@@ -93,4 +93,4 @@ Released in `v1.2.6-prebeta`. The lane stands as the first closed recoverable-op
 - `Docs/feature_backlog.md`
 - `Docs/prebeta_roadmap.md`
 - `Docs/incident_patterns.md`
-- `Docs/closeouts/nexus_prebeta_rebaseline_through_v1.2.7-prebeta.md`
+- `Docs/closeouts/nexus_prebeta_rebaseline_through_v1.2.8-prebeta.md`

--- a/Docs/workstreams/FB-035_release_context_fallback_hardening.md
+++ b/Docs/workstreams/FB-035_release_context_fallback_hardening.md
@@ -96,4 +96,4 @@ Released in `v1.2.7-prebeta`. The lane now prevents support-report fallback logi
 - `Docs/feature_backlog.md`
 - `Docs/prebeta_roadmap.md`
 - `Docs/incident_patterns.md`
-- `Docs/closeouts/nexus_prebeta_rebaseline_through_v1.2.7-prebeta.md`
+- `Docs/closeouts/nexus_prebeta_rebaseline_through_v1.2.8-prebeta.md`

--- a/Docs/workstreams/index.md
+++ b/Docs/workstreams/index.md
@@ -24,10 +24,11 @@ Use this layer when a backlog item has been promoted and now needs:
 
 ### Active
 
-- `Docs/workstreams/FB-027_interaction_system_baseline.md`
+- no currently active non-doc implementation workstream record is selected on `main`
 
 ### Closed
 
+- `Docs/workstreams/FB-027_interaction_system_baseline.md`
 - `Docs/workstreams/FB-035_release_context_fallback_hardening.md`
 - `Docs/workstreams/FB-034_recoverable_diagnostics.md`
 - `Docs/workstreams/FB-025_boot_desktop_milestone_taxonomy_clarification.md`

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Current repo truth includes:
 
 Latest public prerelease:
 
-- `v1.2.7-prebeta`
+- `v1.2.8-prebeta`
 
 ## Current Entry Paths
 
@@ -71,7 +71,7 @@ From there, route into the layer that owns the truth you need:
 - `Docs/feature_backlog.md` for tracked identity and registry state
 - `Docs/prebeta_roadmap.md` for sequencing and release posture
 - `Docs/workstreams/index.md` for canonical workstream records
-- `Docs/closeout_index.md` and `Docs/closeouts/nexus_prebeta_rebaseline_through_v1.2.7-prebeta.md` for historical and epoch summaries
+- `Docs/closeout_index.md` and `Docs/closeouts/nexus_prebeta_rebaseline_through_v1.2.8-prebeta.md` for historical and epoch summaries
 
 ## Naming Boundary
 


### PR DESCRIPTION
## Summary

synchronizes canonical release truth to v1.2.8-prebeta
marks the FB-027 URL milestone as released
advances rebaseline to v1.2.8-prebeta
restores release-context validator alignment
no runtime or feature changes included

## What Changed

No detailed branch evidence was preserved in the original PR body.

Historical metadata preserved for traceability:
- Base: `main`
- Head: `feature/post-v1.2.8-truth-sync`
- Head commit: `740742a884b2b339a17b3a0016695460595094dc`

Historical metadata preserved for traceability:
- Base: `main`
- Head: `feature/post-v1.2.8-truth-sync`
- Head commit: `740742a884b2b339a17b3a0016695460595094dc`
