### PR TITLE
(FB-027): add saved-action inventory and guided access

### DIFF
--- a/Docs/feature_backlog.md
+++ b/Docs/feature_backlog.md
@@ -94,6 +94,56 @@ Target Version: TBD
 Summary: Track the broader Nexus-era vision and source-of-truth migration above the current phase-one canon foundation rebuild.
 Why it matters: The repo still needs deeper identity and wording normalization after the foundation layer is rebuilt.
 
+### [ID: FB-036] Limited saved-action authoring and type-first custom task UX
+
+Status: Deferred
+Record State: Registry-only
+Priority: High
+Release Stage: pre-Beta
+Target Version: TBD
+Summary: Track the first post-v1.2.8 FB-027 follow-through lane for bounded saved-action create/edit UX with explicit user-facing action-type selection and safe persistence.
+Why it matters: Saved-action inventory and guided access improve inspection, but users still need a deliberate non-Action-Studio path to create and edit custom tasks without hand-editing JSON. This lane should keep custom tasks focused on user-defined or non-standard actions such as personal URLs, paths, or host-specific app launches while preserving the locked interaction baseline.
+
+### [ID: FB-037] Curated built-in system actions and Nexus settings expansion
+
+Status: Deferred
+Record State: Registry-only
+Priority: High
+Release Stage: pre-Beta
+Target Version: TBD
+Summary: Track future curated built-in actions for standard Windows, system, vendor-utility, and Nexus-owned surfaces such as Sound settings, graphics settings, NVIDIA / AMD utilities, and Nexus settings.
+Why it matters: Standard product actions should feel native and inspectable under the shared action model instead of being pushed into user-defined saved actions as ad hoc customization. Common Windows and Nexus-owned actions should ship as first-class built-ins, while saved actions remain the seam for personal or non-standard tasks.
+
+### [ID: FB-038] Taskbar / tray quick-task UX and Create Custom Task surface
+
+Status: Deferred
+Record State: Registry-only
+Priority: Medium
+Release Stage: pre-Beta
+Target Version: TBD
+Summary: Track future taskbar or tray quick-access UX, including a Create Custom Task affordance, as a deliberate shell-facing entry surface into the shared action model.
+Why it matters: Taskbar and tray interaction affect entry, discoverability, and user trust, so they should be planned as an explicit UX lane instead of piggybacking on overlay or authoring work.
+
+### [ID: FB-039] External trigger and plugin integration architecture
+
+Status: Deferred
+Record State: Registry-only
+Priority: Medium
+Release Stage: pre-Beta
+Target Version: TBD
+Summary: Track future plugin and integration lifecycle design for external trigger surfaces such as Stream Deck and other installed integration points.
+Why it matters: Plugin-backed action triggering needs explicit lifecycle, safety, and ownership boundaries before it becomes part of the product.
+
+### [ID: FB-040] Monitoring, thermals, and performance HUD surface
+
+Status: Deferred
+Record State: Registry-only
+Priority: Medium
+Release Stage: pre-Beta
+Target Version: TBD
+Summary: Track future runtime monitoring and HUD surfaces for GPU / CPU thermals and performance, including possible plugin-fed telemetry inputs.
+Why it matters: Monitoring overlays are a separate runtime and status surface and should not be bolted onto the saved-action system without an explicit product boundary.
+
 ## Closed Canonical Workstreams
 
 ### [ID: FB-027] Interaction system baseline and shared action model

--- a/Docs/orin_interaction_architecture.md
+++ b/Docs/orin_interaction_architecture.md
@@ -100,6 +100,29 @@ A future authoring surface should let users define and inspect:
 
 This authoring surface should stay downstream of the same shared action model already used by typed interaction.
 
+The first bounded authoring follow-through should prefer:
+
+- explicit user-facing action-type selection
+- bounded target choices such as Windows app, Application (`.exe`), folder, file, and website URL
+- safe persistence and validation before write
+
+It should not assume full Action Studio scope just to make custom tasks usable.
+
+### Built-In Versus User-Defined Actions
+
+The architecture should distinguish between:
+
+- curated built-in actions for standard Windows, system, vendor-utility, and Nexus-owned surfaces
+- user-defined saved actions for personal, host-specific, or non-standard tasks such as custom URLs, folders, files, or app targets
+
+That distinction keeps common product capability feeling native while preserving saved actions as the bounded customization seam.
+
+### Taskbar Or Tray Quick-Access Surface
+
+A future shell-facing surface may later expose quick-task entry from the taskbar or tray, including a Create Custom Task affordance.
+
+That future surface should feed into the same shared action model and authoring boundaries rather than becoming a disconnected launcher path.
+
 ### Runtime And Status Surface
 
 The interaction system should expose what ORIN is doing, what it just resolved, and what the current command state is.
@@ -110,6 +133,8 @@ This supports:
 - confirmation clarity
 - recoverability after non-success outcomes
 - better debugging and validation evidence
+
+A later runtime-and-status follow-through may also expose monitoring or HUD surfaces for GPU / CPU thermals and performance, but that should remain a separate bounded lane rather than being treated as automatic saved-action follow-through.
 
 ## Shared Action Model
 
@@ -126,6 +151,7 @@ The architecture should not split into:
 - one system for typed commands
 - one system for voice commands
 - one separate system for saved presets
+- one hidden side system for shell quick tasks, plugins, or monitoring overlays
 
 The shared action model is the architectural seam that keeps those surfaces coherent.
 
@@ -197,6 +223,12 @@ It may later support bounded user preferences for supported web-facing or extern
 
 This document does not define the exact storage schema, editor UI, or execution engine for those features.
 
+Future customization should also preserve:
+
+- explicit user-facing type choice for custom tasks
+- safe distinction between standard built-in actions and user-defined saved actions
+- bounded plugin and external-trigger ownership instead of silent connector sprawl
+
 ## Release-Stage View
 
 At architecture level:
@@ -217,6 +249,8 @@ This architecture document does not define:
 - tray, shell, renderer, or notification implementation details
 - auth or trust backend mechanics
 - plugin lifecycle design
+- Stream Deck or similar external-trigger lifecycle specifics
+- monitoring or HUD implementation specifics
 - exact Action Studio screen layout
 - detailed routine-graph editing UX
 

--- a/Docs/prebeta_roadmap.md
+++ b/Docs/prebeta_roadmap.md
@@ -138,6 +138,13 @@ Current merged truth indicates:
 - no merged unreleased non-doc implementation debt currently exists on `main`
 - the next implementation workstream should be chosen only after fresh post-release analysis on updated `main`
 - the released FB-027 milestone does not authorize further saved-action, resolution, voice, Action Studio, routines, profiles, hotkey cleanup, or shutdown-confirmation work by inertia
+- future candidate spaces now explicitly recorded in the backlog include:
+  - FB-036 for limited saved-action authoring and type-first custom task UX
+  - FB-037 for curated built-in system actions and Nexus settings expansion
+  - FB-038 for taskbar or tray quick-task UX including Create Custom Task
+  - FB-039 for external trigger and plugin integration architecture
+  - FB-040 for monitoring, thermals, and performance HUD surfaces
+- those candidate lanes must be selected deliberately rather than bundled together as one implicit interaction continuation
 
 Use canonical workstream docs for execution detail.
 Use the backlog for item identity.

--- a/Docs/workstreams/FB-027_interaction_system_baseline.md
+++ b/Docs/workstreams/FB-027_interaction_system_baseline.md
@@ -333,13 +333,18 @@ Those details may change later without violating the baseline if the protected c
 Future capabilities explicitly deferred beyond this pass include:
 
 - saved-action authoring UX
+- explicit user-facing action-type selection for future saved-action authoring flows
 - routines
 - profiles
 - richer saved-action target kinds beyond `url`
+- curated built-in system-action expansion beyond the current starter built-in catalog
 - broader natural-language resolution
 - voice invocation
 - Action Studio
 - broader shortcut customization
+- taskbar or tray quick-task surfaces such as Create Custom Task
+- external trigger and plugin integration architecture
+- monitoring, thermals, and performance HUD surfaces
 
 ### Deferred Follow-Through Recorded Now
 
@@ -348,6 +353,9 @@ The following directly related FB-027 follow-through is recorded now but not imp
 - remove `Ctrl+Alt+1` and `Ctrl+Alt+2` before Beta
 - add an `Are you sure you want to exit?` prompt for shutdown hotkeys before Beta
 - select the next capability-expansion milestone only through fresh post-release analysis on updated `main`
+- future saved-action authoring should present an explicit user-facing type choice without silently redefining the current saved-action contract
+- future curated built-in system actions should be tracked separately from user-defined saved-action customization
+- future taskbar or tray Create Custom Task affordances, plugin-trigger surfaces, and monitoring HUD work should remain explicit adjacent lanes rather than implicit same-branch continuation
 
 These are deferred forward items, not current-runtime guarantees.
 
@@ -390,6 +398,9 @@ The typed-first interaction baseline remains explicit and validator-defended, an
 - remove `Ctrl+Alt+1` and `Ctrl+Alt+2` before Beta
 - add an `Are you sure you want to exit?` prompt for shutdown hotkeys before Beta
 - choose the next capability-expansion milestone only through fresh post-release analysis on updated `main`
+- if saved-action authoring is selected later, keep explicit user-facing type selection downstream of the bounded shared action model rather than turning it into Action Studio by inertia
+- keep standard Windows and Nexus-owned actions as future curated built-ins rather than forcing them into user-defined saved actions
+- keep taskbar or tray Create Custom Task work, plugin integration, and monitoring HUD surfaces as separate explicit lanes unless a future approved workstream intentionally merges them
 
 ## Related References
 

--- a/desktop/desktop_renderer.py
+++ b/desktop/desktop_renderer.py
@@ -73,7 +73,7 @@ class CommandInputLineEdit(QLineEdit):
         self._last_focus_was_manual = False
         self._local_typing_enabled = False
         self.setContextMenuPolicy(Qt.NoContextMenu)
-        self.setPlaceholderText("Type a saved action or alias")
+        self.setPlaceholderText("Type a built-in or saved action")
         self.setReadOnly(True)
 
     def is_input_armed(self) -> bool:
@@ -231,6 +231,41 @@ class CommandOverlayPanel(QWidget):
         self.status_label.setWordWrap(True)
         layout.addWidget(self.status_label)
 
+        self.saved_inventory_frame = QFrame(self.panel)
+        self.saved_inventory_frame.setObjectName("savedActionInventory")
+        saved_inventory_layout = QVBoxLayout(self.saved_inventory_frame)
+        saved_inventory_layout.setContentsMargins(18, 16, 18, 14)
+        saved_inventory_layout.setSpacing(8)
+
+        self.saved_inventory_title = QLabel("Saved action inventory", self.saved_inventory_frame)
+        self.saved_inventory_title.setObjectName("savedActionInventoryTitle")
+        saved_inventory_layout.addWidget(self.saved_inventory_title)
+
+        self.saved_inventory_status = QLabel("", self.saved_inventory_frame)
+        self.saved_inventory_status.setObjectName("savedActionInventoryStatus")
+        self.saved_inventory_status.setWordWrap(True)
+        saved_inventory_layout.addWidget(self.saved_inventory_status)
+
+        self.saved_inventory_source = QLabel("", self.saved_inventory_frame)
+        self.saved_inventory_source.setObjectName("savedActionInventorySource")
+        self.saved_inventory_source.setWordWrap(True)
+        saved_inventory_layout.addWidget(self.saved_inventory_source)
+
+        self.saved_inventory_guidance = QLabel("", self.saved_inventory_frame)
+        self.saved_inventory_guidance.setObjectName("savedActionInventoryGuidance")
+        self.saved_inventory_guidance.setWordWrap(True)
+        saved_inventory_layout.addWidget(self.saved_inventory_guidance)
+
+        self.saved_inventory_items_frame = QFrame(self.saved_inventory_frame)
+        self.saved_inventory_items_frame.setObjectName("savedActionInventoryItems")
+        self.saved_inventory_items_layout = QVBoxLayout(self.saved_inventory_items_frame)
+        self.saved_inventory_items_layout.setContentsMargins(0, 2, 0, 0)
+        self.saved_inventory_items_layout.setSpacing(8)
+        saved_inventory_layout.addWidget(self.saved_inventory_items_frame)
+
+        layout.addWidget(self.saved_inventory_frame)
+        self.saved_inventory_frame.hide()
+
         self.ambiguous_label = QLabel("", self.panel)
         self.ambiguous_label.setObjectName("commandAmbiguous")
         self.ambiguous_label.setWordWrap(True)
@@ -259,13 +294,17 @@ class CommandOverlayPanel(QWidget):
         self.confirm_title_value = self._make_confirm_value()
         confirm_layout.addWidget(self.confirm_title_value, 1, 1)
 
-        confirm_layout.addWidget(self._make_confirm_label("Target kind"), 2, 0)
-        self.confirm_kind_value = self._make_confirm_value()
-        confirm_layout.addWidget(self.confirm_kind_value, 2, 1)
+        confirm_layout.addWidget(self._make_confirm_label("Action origin"), 2, 0)
+        self.confirm_origin_value = self._make_confirm_value()
+        confirm_layout.addWidget(self.confirm_origin_value, 2, 1)
 
-        confirm_layout.addWidget(self._make_confirm_label("Target"), 3, 0)
+        confirm_layout.addWidget(self._make_confirm_label("Target kind"), 3, 0)
+        self.confirm_kind_value = self._make_confirm_value()
+        confirm_layout.addWidget(self.confirm_kind_value, 3, 1)
+
+        confirm_layout.addWidget(self._make_confirm_label("Target"), 4, 0)
         self.confirm_target_value = self._make_confirm_value()
-        confirm_layout.addWidget(self.confirm_target_value, 3, 1)
+        confirm_layout.addWidget(self.confirm_target_value, 4, 1)
 
         self.confirm_help_label = QLabel(
             "Press Enter to confirm or Esc to return.",
@@ -273,7 +312,7 @@ class CommandOverlayPanel(QWidget):
         )
         self.confirm_help_label.setObjectName("commandConfirmHelp")
         self.confirm_help_label.setWordWrap(True)
-        confirm_layout.addWidget(self.confirm_help_label, 4, 0, 1, 2)
+        confirm_layout.addWidget(self.confirm_help_label, 5, 0, 1, 2)
 
         layout.addWidget(self.confirmation_frame)
         self.confirmation_frame.hide()
@@ -356,6 +395,41 @@ class CommandOverlayPanel(QWidget):
             }
             #commandStatus[statusKind="launch_requested"], #commandStatus[statusKind="ready"] {
                 color: rgba(166, 247, 195, 0.94);
+            }
+            #savedActionInventory {
+                margin-top: 16px;
+                border-radius: 18px;
+                background: rgba(8, 20, 34, 214);
+                border: 1px solid rgba(118, 226, 255, 0.12);
+            }
+            #savedActionInventoryTitle {
+                color: rgba(118, 226, 255, 0.84);
+                font-size: 13px;
+                font-weight: 600;
+                letter-spacing: 0.10em;
+            }
+            #savedActionInventoryStatus {
+                color: rgba(236, 247, 255, 0.92);
+                font-size: 13px;
+            }
+            #savedActionInventoryStatus[statusKind="invalid_source"], #savedActionInventoryStatus[statusKind="invalid_saved_actions"], #savedActionInventoryStatus[statusKind="missing"] {
+                color: rgba(255, 189, 176, 0.96);
+            }
+            #savedActionInventorySource {
+                color: rgba(172, 215, 235, 0.80);
+                font-size: 12px;
+            }
+            #savedActionInventoryGuidance {
+                color: rgba(166, 247, 195, 0.88);
+                font-size: 12px;
+            }
+            QLabel[inventoryRole="item"] {
+                padding: 10px 12px;
+                border-radius: 14px;
+                border: 1px solid rgba(118, 226, 255, 0.16);
+                background: rgba(6, 18, 30, 196);
+                color: rgba(234, 246, 255, 0.94);
+                font-size: 12px;
             }
             #commandAmbiguous {
                 min-height: 20px;
@@ -502,19 +576,52 @@ class CommandOverlayPanel(QWidget):
         for match in matches:
             index = int(match.get("index", -1))
             title = match.get("title", "")
+            origin_label = match.get("origin_label", "Action")
             target_kind = match.get("target_kind", "")
             target_display = match.get("target_display") or match.get("target", "")
             button_text = f"{index + 1}. {title}"
+            metadata_bits = [origin_label]
+            if target_kind:
+                metadata_bits.append(target_kind)
+            if metadata_bits:
+                button_text += f"\n{' • '.join(metadata_bits)}"
             if target_display:
-                button_text += f"\n{target_kind}: {target_display}"
-            elif target_kind:
-                button_text += f"\n{target_kind}"
+                button_text += f"\n{target_display}"
             button = QPushButton(button_text, self.ambiguous_choices_frame)
             button.setProperty("choiceRole", "ambiguous")
             button.setToolTip(match.get("target", ""))
             button.clicked.connect(lambda _checked=False, idx=index: self.ambiguous_match_selected.emit(idx))
             self.ambiguous_choices_layout.addWidget(button)
         self.ambiguous_choices_frame.setVisible(bool(matches))
+
+    def _clear_saved_inventory_items(self):
+        while self.saved_inventory_items_layout.count():
+            item = self.saved_inventory_items_layout.takeAt(0)
+            widget = item.widget()
+            if widget is not None:
+                widget.deleteLater()
+
+    def _populate_saved_inventory_items(self, items: list[dict]):
+        self._clear_saved_inventory_items()
+        for item in items[:6]:
+            title = item.get("title", "")
+            origin_label = item.get("origin_label", "Saved")
+            target_kind = item.get("target_kind", "")
+            target_display = item.get("target_display") or item.get("target", "")
+            item_text = title
+            metadata_bits = [origin_label]
+            if target_kind:
+                metadata_bits.append(target_kind)
+            if metadata_bits:
+                item_text += f"\n{' • '.join(metadata_bits)}"
+            if target_display:
+                item_text += f"\n{target_display}"
+
+            label = QLabel(item_text, self.saved_inventory_items_frame)
+            label.setProperty("inventoryRole", "item")
+            label.setWordWrap(True)
+            label.setToolTip(item.get("target", ""))
+            self.saved_inventory_items_layout.addWidget(label)
 
     def render_payload(self, payload: dict):
         payload = payload or {}
@@ -541,17 +648,13 @@ class CommandOverlayPanel(QWidget):
             self.setFocus(Qt.ActiveWindowFocusReason)
 
         if phase == "confirm":
-            self.hint_label.setText("Review the resolved action before execution.")
+            self.hint_label.setText("Review the resolved action origin and destination before execution.")
         elif phase == "choose":
-            self.hint_label.setText("Press a number key or click the intended saved action, then confirm it before launch.")
+            self.hint_label.setText("Press a number key or click the intended action after reviewing its origin and destination.")
         elif phase == "result":
             self.hint_label.setText("Returning to passive desktop mode.")
         else:
-            self.hint_label.setText(
-                "Type a saved action or alias, then press Enter."
-                if not armed
-                else "Type a saved action or alias, then press Enter."
-            )
+            self.hint_label.setText("Type a built-in or saved action, then press Enter.")
 
         status_kind = payload.get("status_kind", "idle")
         self.status_label.setProperty("statusKind", status_kind)
@@ -561,14 +664,43 @@ class CommandOverlayPanel(QWidget):
         if payload.get("status_text"):
             self.status_label.setText(payload["status_text"])
         elif phase == "entry" and not armed:
-            self.status_label.setText("Type a saved action or alias to begin.")
+            self.status_label.setText("Type an action or alias to begin.")
         else:
             self.status_label.setText("")
+
+        saved_action_inventory = payload.get("saved_action_inventory") or {}
+        show_inventory = phase == "entry" and bool(saved_action_inventory.get("visible"))
+        self.saved_inventory_frame.setVisible(show_inventory)
+        if show_inventory:
+            item_count = int(saved_action_inventory.get("count", 0))
+            self.saved_inventory_title.setText(
+                f"Saved action inventory ({item_count})"
+                if item_count
+                else "Saved action inventory"
+            )
+            inventory_status_kind = saved_action_inventory.get("status_kind", "hidden")
+            self.saved_inventory_status.setProperty("statusKind", inventory_status_kind)
+            self.saved_inventory_status.style().unpolish(self.saved_inventory_status)
+            self.saved_inventory_status.style().polish(self.saved_inventory_status)
+            self.saved_inventory_status.setText(saved_action_inventory.get("status_text", ""))
+
+            source_path = saved_action_inventory.get("path", "")
+            source_display = saved_action_inventory.get("path_display") or source_path
+            self.saved_inventory_source.setText(f"Source: {source_display}" if source_display else "")
+            self.saved_inventory_source.setToolTip(source_path)
+            self.saved_inventory_guidance.setText(saved_action_inventory.get("guidance_text", ""))
+            self._populate_saved_inventory_items(saved_action_inventory.get("items") or [])
+        else:
+            self._clear_saved_inventory_items()
+            self.saved_inventory_status.setText("")
+            self.saved_inventory_source.setText("")
+            self.saved_inventory_source.setToolTip("")
+            self.saved_inventory_guidance.setText("")
 
         titles = payload.get("ambiguous_titles") or []
         if phase == "choose" and titles:
             self.ambiguous_label.setText(
-                "Multiple saved actions matched your request. Press a number key or click a choice after reviewing the destination detail below."
+                "Multiple actions matched your request. Press a number key or click a choice after reviewing the origin and destination detail below."
             )
         else:
             self.ambiguous_label.setText(f"Matches: {' | '.join(titles)}" if titles else "")
@@ -580,6 +712,7 @@ class CommandOverlayPanel(QWidget):
         if show_confirm:
             self.confirm_request_value.setText(payload.get("typed_request", ""))
             self.confirm_title_value.setText(action.get("title", ""))
+            self.confirm_origin_value.setText(action.get("origin_label", ""))
             self.confirm_kind_value.setText(action.get("target_kind", ""))
             self.confirm_target_value.setText(action.get("target_display") or action.get("target", ""))
             self.confirm_target_value.setToolTip(action.get("target", ""))

--- a/desktop/interaction_overlay_model.py
+++ b/desktop/interaction_overlay_model.py
@@ -1,6 +1,7 @@
 from .shared_action_model import (
     CommandActionCatalog,
     DEFAULT_COMMAND_ACTION_CATALOG,
+    format_action_origin_label,
 )
 
 
@@ -116,7 +117,7 @@ class CommandOverlayModel:
         if self.phase == "entry":
             if not self.input_armed:
                 self.status_kind = "idle"
-                self.status_text = "Type a saved action or alias to begin."
+                self.status_text = "Type an action or alias to begin."
                 return ("awaiting_click_arm", None)
 
             if not self.action_catalog.normalize_text(self.input_text):
@@ -139,7 +140,7 @@ class CommandOverlayModel:
             self.pending_action = None
             if not matches:
                 self.status_kind = "not_found"
-                self.status_text = "No saved action or alias matched that request."
+                self.status_text = "No action or alias matched that request."
                 return ("not_found", None)
 
             self.phase = "choose"
@@ -178,8 +179,29 @@ class CommandOverlayModel:
         self.pending_action = None
         self.pending_matches = ()
 
+    def _serialize_action(self, action, *, index: int | None = None):
+        if action is None:
+            return None
+
+        payload = {
+            "id": action.id,
+            "title": action.title,
+            "origin": action.origin,
+            "origin_label": format_action_origin_label(action.origin),
+            "target_kind": action.target_kind,
+            "target": action.target,
+            "target_display": self.action_catalog.format_target_display(
+                action.target_kind,
+                action.target,
+            ),
+        }
+        if index is not None:
+            payload["index"] = index
+        return payload
+
     def view_payload(self):
         action = self.pending_action
+        saved_action_inventory = self.action_catalog.saved_action_inventory
         return {
             "visible": self.visible,
             "phase": self.phase,
@@ -188,33 +210,30 @@ class CommandOverlayModel:
             "status_kind": self.status_kind,
             "status_text": self.status_text,
             "typed_request": self.last_request,
-            "pending_action": None
-            if action is None
-            else {
-                "id": action.id,
-                "title": action.title,
-                "target_kind": action.target_kind,
-                "target": action.target,
-                "target_display": self.action_catalog.format_target_display(
-                    action.target_kind,
-                    action.target,
-                ),
-            },
+            "pending_action": self._serialize_action(action),
             "ambiguous_titles": [match.title for match in self.pending_matches] if self.status_kind == "ambiguous" else [],
             "ambiguous_matches": [
-                {
-                    "index": index,
-                    "id": match.id,
-                    "title": match.title,
-                    "target_kind": match.target_kind,
-                    "target": match.target,
-                    "target_display": self.action_catalog.format_target_display(
-                        match.target_kind,
-                        match.target,
-                    ),
-                }
+                self._serialize_action(match, index=index)
                 for index, match in enumerate(self.pending_matches)
             ]
             if self.status_kind == "ambiguous"
             else [],
+            "saved_action_inventory": {
+                "visible": saved_action_inventory.visible,
+                "status_kind": saved_action_inventory.status_kind,
+                "status_text": saved_action_inventory.status_text,
+                "guidance_text": saved_action_inventory.guidance_text,
+                "path": saved_action_inventory.path,
+                "path_display": self.action_catalog.format_target_display(
+                    "file",
+                    saved_action_inventory.path,
+                )
+                if saved_action_inventory.path
+                else "",
+                "count": len(saved_action_inventory.actions),
+                "items": [
+                    self._serialize_action(saved_action)
+                    for saved_action in saved_action_inventory.actions
+                ],
+            },
         }

--- a/desktop/saved_action_source.py
+++ b/desktop/saved_action_source.py
@@ -41,6 +41,13 @@ class SavedActionSourcePayload:
     actions: tuple[dict[str, Any], ...]
 
 
+@dataclass(frozen=True)
+class SavedActionSourceInspection:
+    path: Path
+    status: str
+    actions: tuple[dict[str, Any], ...] = ()
+
+
 def resolve_default_saved_action_source_path() -> Path:
     local_app_data = os.environ.get("LOCALAPPDATA", "").strip()
     if local_app_data:
@@ -80,6 +87,16 @@ def ensure_saved_action_source_bootstrap(
 def load_saved_action_source(
     source_path: str | os.PathLike[str] | None = None,
 ) -> SavedActionSourcePayload | None:
+    inspection = inspect_saved_action_source(source_path)
+    if inspection.status != "loaded":
+        return None
+
+    return SavedActionSourcePayload(path=inspection.path, actions=inspection.actions)
+
+
+def inspect_saved_action_source(
+    source_path: str | os.PathLike[str] | None = None,
+) -> SavedActionSourceInspection:
     path = (
         Path(source_path)
         if source_path is not None
@@ -95,28 +112,34 @@ def load_saved_action_source(
 
     try:
         if not path.exists() or not path.is_file():
-            return None
+            return SavedActionSourceInspection(path=path, status="missing")
     except OSError:
-        return None
+        return SavedActionSourceInspection(path=path, status="missing")
 
     try:
         raw_text = path.read_text(encoding="utf-8")
     except (OSError, UnicodeError):
-        return None
+        return SavedActionSourceInspection(path=path, status="invalid_source")
 
     if not raw_text.strip():
-        return None
+        return SavedActionSourceInspection(path=path, status="invalid_source")
 
     try:
         payload = json.loads(raw_text)
     except json.JSONDecodeError:
-        return None
+        return SavedActionSourceInspection(path=path, status="invalid_source")
 
     if not isinstance(payload, dict):
-        return None
+        return SavedActionSourceInspection(path=path, status="invalid_source")
 
     actions = payload.get("actions")
-    if not isinstance(actions, list) or not actions:
-        return None
+    if not isinstance(actions, list):
+        return SavedActionSourceInspection(path=path, status="invalid_source")
+    if not actions:
+        return SavedActionSourceInspection(path=path, status="template_only")
 
-    return SavedActionSourcePayload(path=path, actions=tuple(actions))
+    return SavedActionSourceInspection(
+        path=path,
+        status="loaded",
+        actions=tuple(actions),
+    )

--- a/desktop/shared_action_model.py
+++ b/desktop/shared_action_model.py
@@ -7,6 +7,7 @@ from typing import Iterable
 from urllib.parse import urlparse, unquote
 
 from .saved_action_source import (
+    inspect_saved_action_source,
     load_saved_action_source,
     resolve_default_saved_action_source_path,
 )
@@ -24,6 +25,7 @@ class CommandAction:
     target_kind: str
     target: str
     aliases: tuple[str, ...]
+    origin: str = "built_in"
 
 
 DEFAULT_COMMAND_ACTIONS = (
@@ -92,13 +94,39 @@ LEGACY_SAVED_ACTIONS_ACCESS_ACTION_IDS = frozenset(
 )
 
 
+@dataclass(frozen=True)
+class SavedActionInventoryState:
+    visible: bool = False
+    status_kind: str = "hidden"
+    status_text: str = ""
+    guidance_text: str = ""
+    path: str = ""
+    actions: tuple[CommandAction, ...] = ()
+
+
+def format_action_origin_label(origin: str) -> str:
+    if (origin or "").strip().casefold() == "saved":
+        return "Saved"
+    return "Built-in"
+
+
 class CommandActionCatalog:
-    def __init__(self, actions: Iterable[CommandAction] = DEFAULT_COMMAND_ACTIONS):
+    def __init__(
+        self,
+        actions: Iterable[CommandAction] = DEFAULT_COMMAND_ACTIONS,
+        *,
+        saved_action_inventory: SavedActionInventoryState | None = None,
+    ):
         self._actions = tuple(actions)
+        self._saved_action_inventory = saved_action_inventory or SavedActionInventoryState()
 
     @property
     def actions(self) -> tuple[CommandAction, ...]:
         return self._actions
+
+    @property
+    def saved_action_inventory(self) -> SavedActionInventoryState:
+        return self._saved_action_inventory
 
     def normalize_text(self, text: str) -> str:
         return normalize_command_text(text)
@@ -199,67 +227,149 @@ def _command_action_from_saved_record(record: object) -> CommandAction:
         target_kind=target_kind,
         target=target,
         aliases=_coerce_saved_action_aliases(record),
+        origin="saved",
+    )
+
+
+def _build_saved_action_access_guidance() -> str:
+    file_action = next(
+        (action.title for action in DEFAULT_COMMAND_ACTIONS if action.id == "open_saved_actions_file"),
+        "Open Saved Actions File",
+    )
+    folder_action = next(
+        (action.title for action in DEFAULT_COMMAND_ACTIONS if action.id == "open_saved_actions_folder"),
+        "Open Saved Actions Folder",
+    )
+    return f'Use "{file_action}" or "{folder_action}" to inspect the source.'
+
+
+def _load_saved_command_actions_from_records(records: Iterable[object]) -> tuple[CommandAction, ...]:
+    built_in_ids = {action.id.casefold() for action in DEFAULT_COMMAND_ACTIONS}
+    built_in_phrases: set[str] = set()
+    for action in DEFAULT_COMMAND_ACTIONS:
+        built_in_phrases.update(_normalized_action_phrases(action))
+
+    seen_saved_ids: set[str] = set()
+    seen_saved_phrases: set[str] = set()
+    saved_actions: list[CommandAction] = []
+    for record in records:
+        action = _command_action_from_saved_record(record)
+        normalized_id = action.id.casefold()
+        normalized_phrases = _normalized_action_phrases(action)
+        if normalized_id in seen_saved_ids:
+            raise ValueError("Saved action id collides with another saved action.")
+        if normalized_phrases & seen_saved_phrases:
+            raise ValueError("Saved action title or alias collides with another saved action.")
+
+        built_in_phrase_collisions = normalized_phrases & built_in_phrases
+        if normalized_id in built_in_ids or built_in_phrase_collisions:
+            # Preserve backward compatibility for users who already added these
+            # same file/folder helpers manually before they became built-ins.
+            incompatible_id_collision = (
+                normalized_id in built_in_ids
+                and normalized_id not in LEGACY_SAVED_ACTIONS_ACCESS_ACTION_IDS
+            )
+            incompatible_phrase_collision = bool(
+                built_in_phrase_collisions
+                - LEGACY_SAVED_ACTIONS_ACCESS_ACTION_PHRASES
+            )
+            if incompatible_id_collision or incompatible_phrase_collision:
+                raise ValueError("Saved action title or alias collides with an existing action.")
+            continue
+
+        seen_saved_ids.add(normalized_id)
+        seen_saved_phrases.update(normalized_phrases)
+        saved_actions.append(action)
+
+    return tuple(saved_actions)
+
+
+def inspect_saved_action_inventory(
+    source_path: str | os.PathLike[str] | None = None,
+) -> SavedActionInventoryState:
+    guidance_text = _build_saved_action_access_guidance()
+    inspection = inspect_saved_action_source(source_path)
+    source_path_text = str(inspection.path)
+
+    if inspection.status == "missing":
+        return SavedActionInventoryState(
+            visible=True,
+            status_kind="missing",
+            status_text="Saved actions source is missing. Built-in actions remain available.",
+            guidance_text=guidance_text,
+            path=source_path_text,
+        )
+
+    if inspection.status == "template_only":
+        return SavedActionInventoryState(
+            visible=True,
+            status_kind="template_only",
+            status_text="No saved actions are active yet. The starter source is ready when you want it.",
+            guidance_text=guidance_text,
+            path=source_path_text,
+        )
+
+    if inspection.status == "invalid_source":
+        return SavedActionInventoryState(
+            visible=True,
+            status_kind="invalid_source",
+            status_text="Saved actions are unavailable because the source file could not be read cleanly.",
+            guidance_text=guidance_text,
+            path=source_path_text,
+        )
+
+    try:
+        saved_actions = _load_saved_command_actions_from_records(inspection.actions)
+    except ValueError:
+        return SavedActionInventoryState(
+            visible=True,
+            status_kind="invalid_saved_actions",
+            status_text="Saved actions are unavailable because one or more source entries are invalid or colliding.",
+            guidance_text=guidance_text,
+            path=source_path_text,
+        )
+
+    if not saved_actions:
+        return SavedActionInventoryState(
+            visible=True,
+            status_kind="template_only",
+            status_text="No saved actions are active yet. The starter source is ready when you want it.",
+            guidance_text=guidance_text,
+            path=source_path_text,
+        )
+
+    count = len(saved_actions)
+    noun = "action" if count == 1 else "actions"
+    return SavedActionInventoryState(
+        visible=True,
+        status_kind="loaded",
+        status_text=f"{count} saved {noun} loaded from the current source.",
+        guidance_text=guidance_text,
+        path=source_path_text,
+        actions=saved_actions,
     )
 
 
 def load_saved_command_actions(
     source_path: str | os.PathLike[str] | None = None,
 ) -> tuple[CommandAction, ...]:
-    payload = load_saved_action_source(source_path)
-    if payload is None:
-        return ()
-
-    try:
-        built_in_ids = {action.id.casefold() for action in DEFAULT_COMMAND_ACTIONS}
-        built_in_phrases: set[str] = set()
-        for action in DEFAULT_COMMAND_ACTIONS:
-            built_in_phrases.update(_normalized_action_phrases(action))
-
-        seen_saved_ids: set[str] = set()
-        seen_saved_phrases: set[str] = set()
-        saved_actions: list[CommandAction] = []
-        for record in payload.actions:
-            action = _command_action_from_saved_record(record)
-            normalized_id = action.id.casefold()
-            normalized_phrases = _normalized_action_phrases(action)
-            if normalized_id in seen_saved_ids:
-                raise ValueError("Saved action id collides with another saved action.")
-            if normalized_phrases & seen_saved_phrases:
-                raise ValueError("Saved action title or alias collides with another saved action.")
-
-            built_in_phrase_collisions = normalized_phrases & built_in_phrases
-            if normalized_id in built_in_ids or built_in_phrase_collisions:
-                # Preserve backward compatibility for users who already added these
-                # same file/folder helpers manually before they became built-ins.
-                incompatible_id_collision = (
-                    normalized_id in built_in_ids
-                    and normalized_id not in LEGACY_SAVED_ACTIONS_ACCESS_ACTION_IDS
-                )
-                incompatible_phrase_collision = bool(
-                    built_in_phrase_collisions
-                    - LEGACY_SAVED_ACTIONS_ACCESS_ACTION_PHRASES
-                )
-                if incompatible_id_collision or incompatible_phrase_collision:
-                    raise ValueError("Saved action title or alias collides with an existing action.")
-                continue
-
-            seen_saved_ids.add(normalized_id)
-            seen_saved_phrases.update(normalized_phrases)
-            saved_actions.append(action)
-
-        return tuple(saved_actions)
-    except ValueError:
-        return ()
+    return inspect_saved_action_inventory(source_path).actions
 
 
 def build_default_command_action_catalog(
     source_path: str | os.PathLike[str] | None = None,
 ) -> CommandActionCatalog:
-    saved_actions = load_saved_command_actions(source_path)
-    if not saved_actions:
-        return CommandActionCatalog(DEFAULT_COMMAND_ACTIONS)
+    saved_action_inventory = inspect_saved_action_inventory(source_path)
+    if not saved_action_inventory.actions:
+        return CommandActionCatalog(
+            DEFAULT_COMMAND_ACTIONS,
+            saved_action_inventory=saved_action_inventory,
+        )
 
-    return CommandActionCatalog((*DEFAULT_COMMAND_ACTIONS, *saved_actions))
+    return CommandActionCatalog(
+        (*DEFAULT_COMMAND_ACTIONS, *saved_action_inventory.actions),
+        saved_action_inventory=saved_action_inventory,
+    )
 
 
 DEFAULT_COMMAND_ACTION_CATALOG = build_default_command_action_catalog()

--- a/dev/orin_interaction_baseline_validation.py
+++ b/dev/orin_interaction_baseline_validation.py
@@ -11,7 +11,11 @@ if ROOT_DIR not in sys.path:
 
 import desktop.desktop_renderer as renderer_mod
 from desktop.interaction_overlay_model import CommandOverlayModel
-from desktop.shared_action_model import CommandAction, CommandActionCatalog
+from desktop.shared_action_model import (
+    CommandAction,
+    CommandActionCatalog,
+    SavedActionInventoryState,
+)
 
 
 class _FakeRect:
@@ -200,12 +204,20 @@ def _test_typed_first_choose_confirm_result_flow():
         _assert(window._command_model.phase == "choose", "an ambiguous request should enter choose phase")
         ambiguous_matches = window._command_panel.last_payload.get("ambiguous_matches") or []
         _assert(len(ambiguous_matches) >= 2, "an ambiguous request should surface multiple visible choices")
+        _assert(
+            all(match.get("origin") == "built_in" for match in ambiguous_matches),
+            "an ambiguous request should surface explicit built-in vs saved origin detail",
+        )
 
         window.handle_overlay_text_requested("2")
         _assert(window._command_model.phase == "confirm", "choosing an ambiguous match should enter confirm phase")
 
         pending_action = window._command_panel.last_payload.get("pending_action") or {}
         _assert(pending_action.get("id"), "confirm phase should surface one pending action")
+        _assert(
+            pending_action.get("origin") == "built_in" and pending_action.get("origin_label") == "Built-in",
+            "confirm phase should surface built-in origin detail without changing the state machine",
+        )
         _assert(pending_action.get("target_kind"), "confirm phase should surface target kind detail")
         _assert(
             pending_action.get("target_display") or pending_action.get("target"),
@@ -252,6 +264,7 @@ def _test_url_saved_action_confirm_result_flow():
                 target_kind="url",
                 target="https://example.com/docs/start",
                 aliases=("open docs site",),
+                origin="saved",
             ),
         )
     )
@@ -271,6 +284,10 @@ def _test_url_saved_action_confirm_result_flow():
         _assert(
             pending_action.get("target_kind") == "url",
             "confirm phase should surface url target kinds without changing the state machine",
+        )
+        _assert(
+            pending_action.get("origin") == "saved" and pending_action.get("origin_label") == "Saved",
+            "confirm phase should surface saved-action origin detail for user-defined actions",
         )
         _assert(
             pending_action.get("target_display") == "example.com/docs/start",
@@ -296,6 +313,45 @@ def _test_url_saved_action_confirm_result_flow():
         renderer_mod.launch_command_action = original_launch
 
 
+def _test_entry_payload_surfaces_saved_action_inventory_guidance():
+    saved_action = CommandAction(
+        id="open_reports",
+        title="Open Reports",
+        target_kind="folder",
+        target=r"C:\Reports",
+        aliases=("open reports",),
+        origin="saved",
+    )
+    action_catalog = CommandActionCatalog(
+        (saved_action,),
+        saved_action_inventory=SavedActionInventoryState(
+            visible=True,
+            status_kind="loaded",
+            status_text="1 saved action loaded from the current source.",
+            guidance_text='Use "Open Saved Actions File" or "Open Saved Actions Folder" to inspect the source.',
+            path=r"C:\Users\Test\AppData\Local\Nexus Desktop AI\saved_actions.json",
+            actions=(saved_action,),
+        ),
+    )
+    window = _make_window(action_catalog=action_catalog)
+    window.open_command_overlay()
+
+    inventory = window._command_panel.last_payload.get("saved_action_inventory") or {}
+    _assert(inventory.get("visible"), "entry payload should surface saved-action inventory visibility")
+    _assert(inventory.get("status_kind") == "loaded", "entry payload should surface saved-action inventory status")
+    _assert(inventory.get("count") == 1, "entry payload should surface the saved-action inventory count")
+    inventory_items = inventory.get("items") or []
+    _assert(len(inventory_items) == 1, "entry payload should surface the effective saved-action inventory items")
+    _assert(
+        inventory_items[0].get("origin") == "saved" and inventory_items[0].get("origin_label") == "Saved",
+        "entry payload should surface saved-action origin detail inside the inventory view",
+    )
+    _assert(
+        inventory_items[0].get("target_display") == r"C:\Reports",
+        "entry payload should surface saved-action target detail for inspection",
+    )
+
+
 def main():
     tests = [
         ("typed-first open enters entry mode", _test_open_starts_in_typed_first_entry_mode),
@@ -303,6 +359,7 @@ def main():
         ("choose-confirm-result baseline flow", _test_typed_first_choose_confirm_result_flow),
         ("result close and reopen is clean", _test_result_close_and_reopen_is_clean),
         ("url saved action confirm-result flow", _test_url_saved_action_confirm_result_flow),
+        ("entry payload surfaces saved-action inventory guidance", _test_entry_payload_surfaces_saved_action_inventory_guidance),
     ]
 
     for name, fn in tests:

--- a/dev/orin_saved_action_source_validation.py
+++ b/dev/orin_saved_action_source_validation.py
@@ -11,7 +11,11 @@ ROOT_DIR = os.path.dirname(CURRENT_DIR)
 if ROOT_DIR not in sys.path:
     sys.path.insert(0, ROOT_DIR)
 
-from desktop.saved_action_source import load_saved_action_source, resolve_default_saved_action_source_path
+from desktop.saved_action_source import (
+    inspect_saved_action_source,
+    load_saved_action_source,
+    resolve_default_saved_action_source_path,
+)
 from desktop.shared_action_model import (
     DEFAULT_COMMAND_ACTIONS,
     build_default_command_action_catalog,
@@ -58,9 +62,17 @@ def _test_default_source_bootstraps_template_without_actions():
         with _with_local_app_data(temp_dir):
             path = resolve_default_saved_action_source_path()
             payload = load_saved_action_source()
+            inspection = inspect_saved_action_source()
+            catalog = build_default_command_action_catalog()
 
             _assert(payload is None, "the default starter template should not count as active saved actions")
             _assert(path.is_file(), "loading the default source should bootstrap the starter JSON file")
+            _assert(inspection.status == "template_only", "the bootstrapped starter source should stay visible even without active saved actions")
+            _assert(catalog.saved_action_inventory.visible, "the default catalog should surface saved-action guidance visibility")
+            _assert(
+                catalog.saved_action_inventory.status_kind == "template_only",
+                "the default catalog should describe the starter source as no active saved actions yet",
+            )
 
             raw = json.loads(path.read_text(encoding="utf-8"))
             _assert(raw.get("schema_version") == 1, "the bootstrapped template should preserve schema version 1")
@@ -70,14 +82,24 @@ def _test_default_source_bootstraps_template_without_actions():
 def _test_missing_custom_source_falls_back_to_built_ins_only():
     with tempfile.TemporaryDirectory() as temp_dir:
         custom_path = Path(temp_dir) / "missing" / "saved_actions.json"
+        inspection = inspect_saved_action_source(custom_path)
 
         _assert(load_saved_action_source(custom_path) is None, "a missing custom source should not produce a payload")
         _assert(load_saved_command_actions(custom_path) == (), "a missing custom source should resolve to no saved actions")
+        _assert(inspection.status == "missing", "a missing custom source should report explicit missing-source visibility")
 
         catalog = build_default_command_action_catalog(custom_path)
         _assert(
             tuple(action.id for action in catalog.actions) == _builtin_ids(),
             "a missing custom source should leave the effective catalog at built-ins only",
+        )
+        _assert(
+            catalog.saved_action_inventory.status_kind == "missing",
+            "the effective catalog should expose missing-source visibility while preserving built-ins",
+        )
+        _assert(
+            catalog.saved_action_inventory.path == str(custom_path),
+            "missing-source visibility should preserve the intended saved-action path",
         )
 
 
@@ -85,14 +107,32 @@ def _test_empty_or_invalid_custom_sources_fail_closed():
     with tempfile.TemporaryDirectory() as temp_dir:
         empty_path = Path(temp_dir) / "empty.json"
         invalid_path = Path(temp_dir) / "invalid.json"
+        template_only_path = Path(temp_dir) / "template_only.json"
 
         _write_text(empty_path, "   \n")
         _write_text(invalid_path, "{ not valid json")
+        _write_json(template_only_path, {"schema_version": 1, "actions": []})
 
         _assert(load_saved_action_source(empty_path) is None, "an empty custom source should not produce a payload")
         _assert(load_saved_command_actions(empty_path) == (), "an empty custom source should fail closed to no saved actions")
         _assert(load_saved_action_source(invalid_path) is None, "invalid JSON should not produce a payload")
         _assert(load_saved_command_actions(invalid_path) == (), "invalid JSON should fail closed to no saved actions")
+        _assert(
+            inspect_saved_action_source(empty_path).status == "invalid_source",
+            "an empty custom source should surface invalid-source visibility",
+        )
+        _assert(
+            inspect_saved_action_source(invalid_path).status == "invalid_source",
+            "invalid JSON should surface invalid-source visibility",
+        )
+        _assert(
+            inspect_saved_action_source(template_only_path).status == "template_only",
+            "an explicit empty actions list should remain visible as no active saved actions",
+        )
+        _assert(
+            build_default_command_action_catalog(template_only_path).saved_action_inventory.status_kind == "template_only",
+            "an explicit empty actions list should guide the user without activating saved actions",
+        )
 
 
 def _test_valid_saved_actions_extend_the_effective_catalog():
@@ -120,6 +160,7 @@ def _test_valid_saved_actions_extend_the_effective_catalog():
 
         _assert(payload is not None and len(payload.actions) == 1, "a valid custom source should load one payload action")
         _assert(len(saved_actions) == 1 and saved_actions[0].id == "open_reports", "a valid saved action should become one effective saved action")
+        _assert(saved_actions[0].origin == "saved", "effective saved actions should preserve saved origin metadata")
         _assert(
             len(catalog.actions) == len(DEFAULT_COMMAND_ACTIONS) + 1,
             "a valid saved action should extend the effective catalog above the built-ins",
@@ -127,6 +168,14 @@ def _test_valid_saved_actions_extend_the_effective_catalog():
         _assert(
             tuple(action.id for action in catalog.actions[:-1]) == _builtin_ids(),
             "extending the catalog should preserve built-in actions ahead of saved actions",
+        )
+        _assert(
+            catalog.saved_action_inventory.status_kind == "loaded",
+            "a valid custom source should surface a loaded saved-action inventory state",
+        )
+        _assert(
+            tuple(action.id for action in catalog.saved_action_inventory.actions) == ("open_reports",),
+            "the saved-action inventory should list the effective saved action set",
         )
 
 
@@ -189,6 +238,10 @@ def _test_unsupported_target_kind_fails_closed():
             load_saved_command_actions(source_path) == (),
             "unsupported saved-action target kinds should fail closed to no saved actions",
         )
+        _assert(
+            build_default_command_action_catalog(source_path).saved_action_inventory.status_kind == "invalid_saved_actions",
+            "unsupported saved-action kinds should remain visible to the user as invalid saved-action entries",
+        )
 
 
 def _test_invalid_url_targets_fail_closed():
@@ -213,6 +266,10 @@ def _test_invalid_url_targets_fail_closed():
         _assert(
             load_saved_command_actions(source_path) == (),
             "invalid url saved-action targets should fail closed to no saved actions",
+        )
+        _assert(
+            build_default_command_action_catalog(source_path).saved_action_inventory.status_kind == "invalid_saved_actions",
+            "invalid url saved-action targets should remain visible as invalid saved-action entries",
         )
 
 
@@ -302,6 +359,10 @@ def _test_builtin_collisions_fail_closed():
         _assert(
             load_saved_command_actions(source_path) == (),
             "collisions against built-in ids or phrases should fail closed to no saved actions",
+        )
+        _assert(
+            build_default_command_action_catalog(source_path).saved_action_inventory.status_kind == "invalid_saved_actions",
+            "built-in collisions should remain visible as invalid saved-action entries",
         )
 
 

--- a/dev/orin_shared_action_baseline_validation.py
+++ b/dev/orin_shared_action_baseline_validation.py
@@ -113,6 +113,7 @@ def _test_builtin_catalog_integrity():
             action.target_kind in SUPPORTED_ACTION_TARGET_KINDS,
             f"{action.id} should keep a supported target kind",
         )
+        _assert(action.origin == "built_in", f"{action.id} should preserve built-in origin metadata")
         _assert(action.target and str(action.target).strip(), f"{action.id} should keep a non-empty target")
 
         normalized_title = normalize_command_text(action.title)
@@ -132,6 +133,7 @@ def _test_url_target_support_is_first_class():
                 target_kind="url",
                 target="https://example.com/docs/start",
                 aliases=("open docs site",),
+                origin="saved",
             ),
         )
     )
@@ -139,6 +141,10 @@ def _test_url_target_support_is_first_class():
     _assert(
         _ids(catalog.resolve_actions("open docs site")) == ("open_nexus_docs_site",),
         "url actions should resolve through the same exact-match shared action catalog",
+    )
+    _assert(
+        catalog.resolve_actions("open docs site")[0].origin == "saved",
+        "url saved actions should preserve saved origin metadata inside the shared catalog",
     )
     _assert(
         catalog.format_target_display("url", "https://example.com/docs/start") == "example.com/docs/start",


### PR DESCRIPTION
## Summary

This PR makes saved actions visible and understandable within the typed-first overlay without changing the underlying interaction contract.

## What Changed

### PR Description

This PR makes saved actions visible and understandable within the typed-first overlay without changing the underlying interaction contract.

It adds a visible saved-action inventory in entry state, distinguishes built-in vs saved actions in choose/confirm, and improves guidance when the saved-actions source is missing, invalid, or colliding. Exact-match resolution, the bounded `entry -> choose -> confirm -> result` flow, and baseline input-capture behavior remain unchanged.

#### Merge Readiness

This branch is a clean, reviewable runtime milestone. It contains one implementation commit, directly coupled validator coverage, and no planning-branch content. It is ready for PR creation as a standalone FB-027 follow-through slice.

### PR Description

#### Merge Readiness
