### PR TITLE
docs(FB-027): sync release truth for merged inventory milestone

### DIFF
--- a/Docs/feature_backlog.md
+++ b/Docs/feature_backlog.md
@@ -148,14 +148,14 @@ Why it matters: Monitoring overlays are a separate runtime and status surface an
 
 ### [ID: FB-027] Interaction system baseline and shared action model
 
-Status: Released (v1.2.8-prebeta)
+Status: Released (v1.2.8-prebeta); merged unreleased follow-through on main
 Record State: Closed
 Priority: High
 Release Stage: pre-Beta
 Target Version: v1.2.8-prebeta
 Canonical Workstream Doc: Docs/workstreams/FB-027_interaction_system_baseline.md
-Summary: Lock the typed-first interaction baseline and deliver the first bounded capability milestone by adding first-class URL targets to saved actions.
-Why it matters: Future interaction work needs one authoritative baseline and one bounded first expansion so saved-action, resolution, and command-surface growth do not silently rewrite current guarantees.
+Summary: Lock the typed-first interaction baseline and deliver bounded shared-action follow-through through the released URL-target milestone plus the later merged unreleased saved-action inventory and guided-access milestone on `main`.
+Why it matters: Future interaction work needs one authoritative baseline and truthful release posture so the released URL-target milestone and the newer merged unreleased inventory-and-guided-access milestone do not get collapsed into one misleading state.
 
 ### [ID: FB-025] Boot and desktop milestone taxonomy clarification
 

--- a/Docs/prebeta_roadmap.md
+++ b/Docs/prebeta_roadmap.md
@@ -61,11 +61,25 @@ Current merged truth indicates:
 
 - latest public prerelease: `v1.2.8-prebeta`
 - latest public release commit: `4816aac`
-- no merged unreleased non-doc implementation debt currently exists on `main`
-- the most recent released implementation milestone is FB-027 for first-class URL saved-action targets
+- one merged unreleased non-doc implementation milestone currently exists on `main`
+- the latest public released FB-027 milestone remains the first-class URL saved-action target release in `v1.2.8-prebeta`
+- the current merged unreleased runtime delta on `main` is the later FB-027 saved-action inventory and guided-access follow-through
 - no active non-doc implementation workstream is currently selected on `main`
 
-That means `main` is again between released non-doc implementation lanes. The released FB-027 baseline-and-URL milestone now forms part of the current shared pre-Beta baseline, and the next workstream should be chosen from refreshed post-release truth rather than by continuing released work by inertia.
+That means `main` is not yet between released non-doc implementation lanes. The released FB-027 baseline-and-URL milestone still forms part of the current shared pre-Beta baseline, but `main` now also carries an additional unreleased FB-027 runtime milestone that should be handled through release prep or directly coupled truth repair before another unrelated implementation lane is selected.
+
+## Current Merged Unreleased Implementation Context
+
+### FB-027 Saved-Action Inventory And Guided Access
+
+- status: `merged unreleased`
+- lane type: `implementation`
+- release floor: `patch prerelease`
+- target version: `TBD`
+- release state: `merged unreleased`
+- canonical workstream doc: `Docs/workstreams/FB-027_interaction_system_baseline.md`
+- sequencing note: `main` now includes entry-state saved-action inventory, built-in-vs-saved distinction in choose and confirm, and source-health visibility plus guided access for missing, invalid, or colliding saved-action sources without changing exact-match resolution, state-machine boundedness, or baseline input-capture behavior
+- merged-path note: the branch that carried this runtime milestone also carried directly coupled future-lane planning material, but the release-driving runtime delta is the inventory and guided-access milestone itself
 
 ## Most Recent Released Workstream Context
 
@@ -132,12 +146,13 @@ That means `main` is again between released non-doc implementation lanes. The re
 
 Current merged truth indicates:
 
-- the released FB-027 lane is now part of the current locked interaction baseline
+- the released FB-027 baseline-and-URL milestone is now part of the current locked interaction baseline
+- `main` also contains a later merged unreleased FB-027 inventory-and-guided-access milestone above that released baseline
 - the released FB-035 lane is closed
 - the recent released workstreams above remain part of the locked current baseline
-- no merged unreleased non-doc implementation debt currently exists on `main`
-- the next implementation workstream should be chosen only after fresh post-release analysis on updated `main`
-- the released FB-027 milestone does not authorize further saved-action, resolution, voice, Action Studio, routines, profiles, hotkey cleanup, or shutdown-confirmation work by inertia
+- merged unreleased non-doc implementation debt currently exists on `main`
+- the correct next move is release prep or directly coupled truth repair, not another unrelated implementation lane
+- neither the released FB-027 milestone nor the merged unreleased inventory-and-guided-access follow-through authorizes further saved-action authoring, resolution, voice, Action Studio, routines, profiles, hotkey cleanup, or shutdown-confirmation work by inertia
 - future candidate spaces now explicitly recorded in the backlog include:
   - FB-036 for limited saved-action authoring and type-first custom task UX
   - FB-037 for curated built-in system actions and Nexus settings expansion

--- a/Docs/workstreams/FB-027_interaction_system_baseline.md
+++ b/Docs/workstreams/FB-027_interaction_system_baseline.md
@@ -13,6 +13,17 @@
 
 - `Released (v1.2.8-prebeta)`
 
+## Current Release-Truth Note
+
+- the baseline-and-URL milestone in this workstream remains the latest released FB-027 milestone through `v1.2.8-prebeta`
+- current merged `main` also includes a later unreleased FB-027 follow-through that adds:
+  - entry-state saved-action inventory
+  - built-in-vs-saved distinction in choose and confirm
+  - source-health visibility and guided access for missing, invalid, or colliding saved-action sources
+  - directly coupled validator expansion for inventory, origin, and source-state visibility
+- the branch that carried that later runtime milestone also carried future-lane planning material, but those planning notes are not themselves released runtime behavior
+- until the next prerelease is cut, release truth must distinguish between the released `v1.2.8-prebeta` milestone and the newer merged unreleased inventory-and-guided-access follow-through on `main`
+
 ## Release Stage
 
 - `pre-Beta`
@@ -38,6 +49,7 @@ This workstream exists so future interaction work can extend a defended baseline
 - current saved-action target kinds are `app`, `folder`, `file`, and `url`
 - current repo truth does not yet include shipped voice invocation, Action Studio authoring UI, routines, profiles, or broader natural-language resolution
 - this workstream locked the typed-first baseline and released the first-class URL saved-action target milestone through the existing shared action model
+- current merged `main` also includes a later unreleased saved-action inventory and guided-access follow-through above that released baseline
 
 ## Milestone Value Statement
 
@@ -51,6 +63,8 @@ If squashed to one milestone, this lane is still worthwhile because it turns the
 - define the validator surfaces that must exist before capability expansion proceeds
 - implement first-class URL target support for saved actions through the existing shared action model
 - extend validator coverage so URL targets are defended as part of the locked baseline
+- implement a later merged unreleased follow-through that adds saved-action inventory, built-in-vs-saved origin visibility, and guided access without changing exact-match resolution or the typed-first state machine
+- extend validator coverage so inventory, origin, and saved-source-state visibility are defended as part of the same bounded interaction lane
 - record directly related deferred follow-through that should remain out of scope for this pass
 
 ## Non-Goals
@@ -278,11 +292,15 @@ Together, these surfaces now exercise:
 - built-in catalog integrity
 - valid saved-action catalog extension behavior
 - valid URL saved-action catalog extension behavior
+- saved-action inventory visibility and correctness
+- built-in-vs-saved origin visibility in choose and confirm
+- source-health visibility for missing, invalid, and colliding saved-action sources
 - missing, empty, invalid, unsupported, duplicate, and colliding saved-action fallback behavior
 - invalid URL saved-action fallback behavior
 - URL launch-path behavior without Windows path normalization
 - compact end-to-end typed-first `entry` -> `choose` -> `confirm` -> `result` behavior
 - compact end-to-end typed-first URL confirm/result behavior
+- compact end-to-end entry-state inventory guidance behavior
 
 ### Missing Explicit Validator Surfaces
 
@@ -370,12 +388,17 @@ These are deferred forward items, not current-runtime guarantees.
 7. recorded directly related deferred follow-through without widening into capability implementation
 8. added first-class URL target support to the saved-action seam and shared action model without changing exact-match resolution
 9. extended shared-action, saved-action-source, and integration validators to defend the new URL target capability
+10. added entry-state saved-action inventory and guided access through the existing typed-first overlay
+11. surfaced built-in-vs-saved origin detail plus saved-source health visibility without changing exact-match resolution, state-machine boundedness, or input-capture behavior
+12. extended validator coverage to defend inventory, origin, and source-state visibility as part of the merged unreleased follow-through
 
 ## Same-Branch Follow-Through
 
-None for the URL-target capability milestone.
+The originally released URL-target milestone is no longer the only merged execution truth in this record.
 
-Future runtime or capability work must return as an explicitly selected next FB-027 milestone rather than as silent same-branch continuation.
+Current merged `main` also includes a later unreleased inventory-and-guided-access follow-through above the released `v1.2.8-prebeta` milestone.
+
+Future runtime or capability work beyond that merged unreleased follow-through must still return as an explicitly selected next FB-027 milestone rather than as silent continuation.
 
 ## Blockers / Holds / Stop Conditions
 
@@ -385,13 +408,13 @@ Future runtime or capability work must return as an explicitly selected next FB-
 
 ## User Test Summary
 
-This milestone changes a user-facing saved-action capability, so a workstream-owned User Test Summary should be expected before closure or release promotion.
+This workstream now includes user-facing saved-action capability changes beyond the released URL-target milestone, so a workstream-owned User Test Summary should still be considered before the next release promotion that includes the merged unreleased inventory-and-guided-access follow-through.
 
 Future user-facing interaction changes should assume a workstream-owned User Test Summary will likely be needed before closure.
 
 ## Baseline Lock Summary
 
-The typed-first interaction baseline remains explicit and validator-defended, and the first bounded capability milestone now extends that baseline with first-class URL saved-action targets without redefining the state machine, exact-match resolution, or input-capture contract.
+The typed-first interaction baseline remains explicit and validator-defended. The released URL-target milestone and the later merged unreleased inventory-and-guided-access follow-through both extend that baseline without redefining the state machine, exact-match resolution, or input-capture contract.
 
 ## Deferred Forward
 


### PR DESCRIPTION
## Summary

This PR repairs release-truth drift after the merge of the FB-027 saved-action inventory and guided-access milestone.

## What Changed

It updates canonical docs so they now clearly distinguish:

* the latest public prerelease: `v1.2.8-prebeta`
* the earlier released FB-027 URL-target milestone
* the newer merged but unreleased FB-027 inventory / guided-access follow-through now present on `main`

This is a docs-only truth-sync PR. It includes no runtime, validator, release, or branch-management changes.

* Base truth: `main` / `origin/main`
* Branch: `docs/fb-027-release-truth-sync`
* Commit: `59f6656` — `docs(FB-027): sync release truth for merged inventory milestone`

Changed files:

* `Docs/feature_backlog.md`
* `Docs/prebeta_roadmap.md`
* `Docs/workstreams/FB-027_interaction_system_baseline.md`

Post-sync validator confirmation:

* `python dev\orin_recoverable_launch_failed_validation.py`
* `python dev\orin_shared_action_baseline_validation.py`
* `python dev\orin_saved_action_source_validation.py`
* `python dev\orin_interaction_baseline_validation.py`
* `python dev\orin_overlay_input_capture_helper.py`

This branch is a clean docs-only milestone and is ready for review. It keeps scope tightly bounded to canon and release-truth repair for the already-merged unreleased FB-027 inventory and guided-access milestone.
