### PR TITLE
[codex] sync v1.3.0-prebeta canon

### DIFF
--- a/Docs/Main.md
+++ b/Docs/Main.md
@@ -121,6 +121,7 @@ Rules:
 Use these for promoted work that needs a stable feature-state, branch-local validation/evidence record, active seam trail, durable artifact/reuse history, and closure history:
 
 - `Docs/workstreams/index.md`
+- `Docs/workstreams/FB-036_saved_action_authoring.md`
 - `Docs/workstreams/FB-035_release_context_fallback_hardening.md`
 - `Docs/workstreams/FB-034_recoverable_diagnostics.md`
 - `Docs/workstreams/FB-025_boot_desktop_milestone_taxonomy_clarification.md`
@@ -133,7 +134,7 @@ Use these for closeout policy, historical closeout lookup, and the modern Nexus-
 
 - `Docs/closeout_guidance.md`
 - `Docs/closeout_index.md`
-- `Docs/closeouts/nexus_prebeta_rebaseline_through_v1.2.9-prebeta.md`
+- `Docs/closeouts/nexus_prebeta_rebaseline_through_v1.3.0-prebeta.md`
 
 Historical closeout leaf docs are intentionally routed through `Docs/closeout_index.md`.
 

--- a/Docs/closeout_index.md
+++ b/Docs/closeout_index.md
@@ -11,12 +11,12 @@ Use `Docs/closeout_guidance.md` for policy and cadence questions.
 
 ## Current Nexus-Era Baseline
 
-### Nexus Pre-Beta Rebaseline Through v1.2.9-prebeta
+### Nexus Pre-Beta Rebaseline Through v1.3.0-prebeta
 
 - scope:
-  - current shared Nexus pre-Beta baseline through the released FB-027 inventory and guided-access milestone
+  - current shared Nexus pre-Beta baseline through the released FB-036 saved-action authoring and callable-group milestone
 - file:
-  - `Docs/closeouts/nexus_prebeta_rebaseline_through_v1.2.9-prebeta.md`
+  - `Docs/closeouts/nexus_prebeta_rebaseline_through_v1.3.0-prebeta.md`
 
 ## Historical Jarvis Closeouts
 

--- a/Docs/closeouts/nexus_prebeta_rebaseline_through_v1.3.0-prebeta.md
+++ b/Docs/closeouts/nexus_prebeta_rebaseline_through_v1.3.0-prebeta.md
@@ -1,0 +1,100 @@
+# Nexus Pre-Beta Rebaseline Through v1.3.0-prebeta
+
+## Purpose
+
+This document is the modern Nexus-era rebaseline through `v1.3.0-prebeta`.
+
+Its job is to:
+
+- summarize the current shared pre-Beta baseline
+- capture what is locked versus deferred
+- reduce prompt bloat by replacing repeated lane recaps
+- point back to preserved historical closeouts without rewriting them
+
+## Baseline Scope
+
+This rebaseline covers merged shared truth through the released public prerelease:
+
+- `v1.3.0-prebeta`
+
+It stands on top of the preserved historical closeout line indexed in:
+
+- `Docs/closeout_index.md`
+
+## Material Closed Workstreams In This Baseline
+
+The closed workstreams that materially define the current baseline are:
+
+- `Docs/workstreams/FB-028_history_state_relocation.md`
+- `Docs/workstreams/FB-033_startup_snapshot_harness_follow_through.md`
+- `Docs/workstreams/FB-025_boot_desktop_milestone_taxonomy_clarification.md`
+- `Docs/workstreams/FB-034_recoverable_diagnostics.md`
+- `Docs/workstreams/FB-035_release_context_fallback_hardening.md`
+- `Docs/workstreams/FB-027_interaction_system_baseline.md`
+- `Docs/workstreams/FB-036_saved_action_authoring.md`
+
+## What Is Locked Now
+
+Through `v1.3.0-prebeta`, current shared truth includes:
+
+- launcher-owned historical state is not a live root-logs surface
+- the startup snapshot harness is a bounded dev-only and opt-in debugging surface
+- boot and desktop milestone taxonomy remains clarified without collapsing ownership boundaries
+- one recoverable-operational-incident class is closed and shipped:
+  - repeated identical `launch_failed` for the same action in a still-running session
+- support-report fallback now derives release context from released-canon truth instead of the highest planned prerelease target
+- the manual-reporting boundary remains local and manual only
+- the typed-first desktop interaction baseline is explicit and validator-defended
+- built-in actions and saved actions resolve through one shared action catalog
+- the first bounded interaction capability milestone is released:
+  - first-class URL target support for saved actions without changing exact-match resolution, state-machine boundedness, or input-capture behavior
+- the later bounded FB-027 follow-through is also released:
+  - saved-action inventory and guided access
+  - built-in-vs-saved distinction in choose and confirm
+  - saved-source health visibility for missing, invalid, template-only, and colliding states
+  - directly coupled validator expansion for inventory, origin, and source-state visibility
+- the released FB-036 milestone is now also part of the locked shared pre-Beta baseline:
+  - bounded custom-task create, edit, and delete flows
+  - explicit trigger modeling with alias-root invocation for newly created tasks
+  - bounded callable-group create, manage, and exact invocation
+  - bounded single-group assignment and inline group quick-create
+  - immediate catalog reload and fail-closed malformed-source blocking for authoring paths
+  - final exact-green interactive proof plus launched-process UI audit for the released authoring baseline
+
+## What Remains Deferred
+
+This rebaseline does not authorize automatic continuation into:
+
+- curated built-in system actions and Nexus settings expansion
+- taskbar or tray quick-task entry surfaces
+- external trigger and plugin integration architecture
+- monitoring, thermal, or performance HUD surfaces
+- scheduling, branching, or multi-step execution logic for callable groups
+- Action Studio behavior
+- voice invocation
+- shutdown exit-confirmation work
+- hotkey cleanup before Beta
+- broader reporting-policy or upload-behavior work
+- broader boot-layer implementation work
+- broader interaction, rebrand, voice, or UI follow-through by inertia
+
+## Forward-Planning Posture After This Baseline
+
+Current merged truth is again between released non-doc implementation lanes.
+
+The next implementation workstream must be chosen from refreshed backlog, workstream, product-boundary, and release truth on updated `main` rather than by continuing FB-027 or FB-036 by inertia.
+
+## Historical Relationship
+
+The preserved historical Jarvis closeout line remains valid historical context.
+
+Use:
+
+- `Docs/closeout_guidance.md` for closeout and rebaseline policy
+- `Docs/closeout_index.md` for historical closeout lookup
+
+This document does not rewrite those historical closeouts.
+
+## Carry-Forward Rule
+
+Future prompts should usually treat this rebaseline plus the retained workstream records as the modern carry-forward baseline through `v1.3.0-prebeta` instead of replaying each closed lane narrative in full.

--- a/Docs/feature_backlog.md
+++ b/Docs/feature_backlog.md
@@ -28,10 +28,6 @@ Historical note:
 
 No currently promoted non-doc implementation workstream is active on `main`.
 
-Branch-local promoted implementation workstream currently in progress:
-
-- `Docs/workstreams/FB-036_saved_action_authoring.md` on `feature/fb-036-idea5-integrated-hardening`
-
 ## Registry Items
 
 ### [ID: FB-004] Future boot orchestrator layer
@@ -104,17 +100,6 @@ Target Version: TBD
 Summary: Track the broader Nexus-era vision and source-of-truth migration above the current phase-one canon foundation rebuild.
 Why it matters: The repo still needs deeper identity and wording normalization after the foundation layer is rebuilt.
 
-### [ID: FB-036] Limited saved-action authoring and type-first custom task UX
-
-Status: Active on `feature/fb-036-idea5-integrated-hardening`
-Record State: Promoted
-Priority: High
-Release Stage: pre-Beta
-Target Version: TBD
-Canonical Workstream Doc: Docs/workstreams/FB-036_saved_action_authoring.md
-Summary: Track the first post-v1.2.8 FB-027 follow-through lane for bounded saved-action create/edit UX with explicit user-facing action-type selection and safe persistence.
-Why it matters: Saved-action inventory and guided access improve inspection, but users still need a deliberate non-Action-Studio path to create and edit custom tasks without hand-editing JSON. This lane should keep custom tasks focused on user-defined or non-standard actions such as personal URLs, paths, or host-specific app launches while preserving the locked interaction baseline.
-
 ### [ID: FB-037] Curated built-in system actions and Nexus settings expansion
 
 Status: Deferred
@@ -156,6 +141,17 @@ Summary: Track future runtime monitoring and HUD surfaces for GPU / CPU thermals
 Why it matters: Monitoring overlays are a separate runtime and status surface and should not be bolted onto the saved-action system without an explicit product boundary.
 
 ## Closed Canonical Workstreams
+
+### [ID: FB-036] Limited saved-action authoring and type-first custom task UX
+
+Status: Released (v1.3.0-prebeta)
+Record State: Closed
+Priority: High
+Release Stage: pre-Beta
+Target Version: v1.3.0-prebeta
+Canonical Workstream Doc: Docs/workstreams/FB-036_saved_action_authoring.md
+Summary: Released the bounded custom-task authoring, callable-group management, inline group quick-create, and exact-green validation hardening milestone above the locked FB-027 interaction baseline.
+Why it matters: Nexus now supports deliberate in-product custom-task and callable-group authoring without reopening the typed-first overlay contract, widening into Action Studio, or weakening exact-match resolution boundaries.
 
 ### [ID: FB-027] Interaction system baseline and shared action model
 

--- a/Docs/prebeta_roadmap.md
+++ b/Docs/prebeta_roadmap.md
@@ -61,27 +61,37 @@ Use these release-state values when relevant:
 
 Current merged truth indicates:
 
-- latest public prerelease: `v1.2.9-prebeta`
-- latest public release commit: `1bdf7a0`
+- latest public prerelease: `v1.3.0-prebeta`
+- latest public release commit: `11eb8ad`
 - no merged unreleased non-doc implementation debt currently exists on `main`
-- the latest public released FB-027 milestone is the saved-action inventory and guided-access release in `v1.2.9-prebeta`
+- the latest public released implementation milestone is FB-036 saved-action authoring and callable groups in `v1.3.0-prebeta`
 - no active non-doc implementation workstream is currently selected on `main`
 
-That means `main` is again between released non-doc implementation lanes. The released FB-027 baseline, URL-target milestone, and later inventory-and-guided-access follow-through now form part of the current shared pre-Beta baseline, and the next implementation workstream should be chosen only after fresh post-release analysis on updated `main`.
+That means `main` is again between released non-doc implementation lanes. The released FB-027 interaction baseline plus the later released FB-036 authoring-and-callable-group milestone now form part of the current shared pre-Beta baseline, and the next implementation workstream should be chosen only after fresh post-release analysis on updated `main`.
 
 ## Most Recent Released Workstream Context
 
-### FB-027 Interaction System Baseline
+### FB-036 Saved-Action Authoring And Callable Groups
 
 - status: `released`
+- lane type: `implementation`
+- release floor: `minor prerelease`
+- target version: `v1.3.0-prebeta`
+- release state: `released`
+- canonical workstream doc: `Docs/workstreams/FB-036_saved_action_authoring.md`
+- sequencing note: released bounded custom-task authoring, callable groups, inline group quick-create, explicit trigger modeling, and the final exact-green authoring hardening without changing the locked typed-first overlay contract or widening into Action Studio behavior
+
+## Recently Closed Workstreams
+
+### FB-027 Interaction System Baseline
+
+- status: `closed`
 - lane type: `implementation`
 - release floor: `patch prerelease`
 - target version: `v1.2.9-prebeta`
 - release state: `released`
 - canonical workstream doc: `Docs/workstreams/FB-027_interaction_system_baseline.md`
-- sequencing note: released the locked typed-first baseline, first-class URL saved-action targets, and the later saved-action inventory and guided-access follow-through without changing exact-match resolution, state-machine boundedness, or input-capture behavior
-
-## Recently Closed Workstreams
+- sequencing note: remains the locked interaction baseline below the later released FB-036 authoring and callable-group milestone
 
 ### FB-035 Release-Context Fallback Hardening
 
@@ -134,7 +144,8 @@ That means `main` is again between released non-doc implementation lanes. The re
 
 Current merged truth indicates:
 
-- the released FB-027 baseline now includes both the earlier URL-target milestone and the later inventory-and-guided-access follow-through
+- the released FB-027 baseline remains part of the locked current interaction floor
+- the released FB-036 authoring-and-callable-group milestone is now part of the locked current pre-Beta baseline
 - the released FB-035 lane is closed
 - the recent released workstreams above remain part of the locked current baseline
 - no merged unreleased non-doc implementation debt currently exists on `main`
@@ -143,7 +154,6 @@ Current merged truth indicates:
 - standalone docs-only post-release repair is exception-only when no plausible next workstream can yet be selected safely from current truth
 - the released FB-027 baseline does not authorize further saved-action authoring, resolution, voice, Action Studio, routines, profiles, hotkey cleanup, or shutdown-confirmation work by inertia
 - future candidate spaces now explicitly recorded in the backlog include:
-  - FB-036 for limited saved-action authoring and type-first custom task UX
   - FB-037 for curated built-in system actions and Nexus settings expansion
   - FB-038 for taskbar or tray quick-task UX including Create Custom Task
   - FB-039 for external trigger and plugin integration architecture

--- a/Docs/workstreams/FB-036_saved_action_authoring.md
+++ b/Docs/workstreams/FB-036_saved_action_authoring.md
@@ -7,11 +7,21 @@
 
 ## Record State
 
-- `Promoted`
+- `Closed`
 
 ## Status
 
-- `Ready for PR on feature/fb-036-idea5-integrated-hardening`
+- `Released (v1.3.0-prebeta)`
+
+## Current Release-Truth Note
+
+- the final FB-036 integrated branch merged to `main`
+- the lane is released in `v1.3.0-prebeta`
+- the final exact-branch green proof remains:
+  - `dev/logs/fb_036_authoring_interactive_validation/reports/FB036SavedActionAuthoringInteractiveValidationReport_20260417_221901.txt`
+- the final launched-process UI audit remains:
+  - `dev/logs/launcher_live_window_audit/20260417_175140/manifest.json`
+- this workstream record is now historical lane truth, not an active execution lane
 
 ## Release Stage
 
@@ -19,7 +29,7 @@
 
 ## Target Version
 
-- `TBD`
+- `v1.3.0-prebeta`
 
 ## Purpose / Why It Matters
 
@@ -30,8 +40,8 @@ Repo-wide phase, timeout, proof-authority, and stop-loss rules for this workstre
 
 ## Current Phase
 
-- Phase: `PR Readiness`
-- Substate: `Validation / Hardening completed; docs synced to final green proof`
+- Phase: `Completed`
+- Substate: `Merged to main, released in v1.3.0-prebeta, and canon-synced`
 
 ## Phase Entry Basis
 
@@ -44,17 +54,17 @@ Repo-wide phase, timeout, proof-authority, and stop-loss rules for this workstre
 - the latest live launched-process UI audit is:
   - `dev/logs/launcher_live_window_audit/20260417_175140/manifest.json`
 - together those artifacts prove:
-  - the full interactive gate is green on the exact current branch truth
+  - the full interactive gate reached green on the exact final branch truth
   - all governed interactive scenarios now pass under the default harness profile rather than a manual override
-  - the latest UI conformity baseline and the launched-process audit remain aligned on the exact current branch truth
-  - the branch has no active validation seam and is ready to enter PR review
+  - the latest UI conformity baseline and the launched-process audit remain aligned on the final released branch truth
+  - the lane closed without any remaining active validation seam
 
 ## Phase Exit Criteria
 
 - the timeout contract in this workstream doc matches the live harness defaults
 - the seam ledger is current and no active seam remains
 - the latest exact-branch green interactive evidence and the latest live launched-process UI audit are both recorded here
-- all of those conditions are now satisfied, and the branch is ready for `PR Readiness`
+- all of those conditions were satisfied before merge, and the lane is now closed as released historical truth
 
 ## Validation Contract
 
@@ -157,9 +167,9 @@ Undocumented slower profiles are not allowed during normal continuation. If a fu
 - latest proving report:
   - `dev/logs/fb_036_authoring_interactive_validation/reports/FB036SavedActionAuthoringInteractiveValidationReport_20260417_221901.txt`
 - current branch status note:
-  - the full interactive gate is green on the exact current branch truth using the harness defaults `1800s / 3s / 60s / 3s`
-  - all governed interactive scenarios passed on the exact current branch truth
-  - branch posture is now `Ready for PR`
+  - the full interactive gate reached green on the exact final branch truth using the harness defaults `1800s / 3s / 60s / 3s`
+  - all governed interactive scenarios passed on the final branch truth before merge
+  - lane posture is now `Closed` and `Released (v1.3.0-prebeta)`
 
 ## Stop-Loss Threshold
 

--- a/Docs/workstreams/index.md
+++ b/Docs/workstreams/index.md
@@ -67,10 +67,11 @@ For an active or recently closed canonical workstream, keep these durable tracea
 
 ### Active
 
-- `Docs/workstreams/FB-036_saved_action_authoring.md` on `feature/fb-036-idea5-integrated-hardening` (branch-local active workstream; not merged on `main`)
+No active canonical implementation workstream is currently selected on `main`.
 
 ### Closed
 
+- `Docs/workstreams/FB-036_saved_action_authoring.md`
 - `Docs/workstreams/FB-027_interaction_system_baseline.md`
 - `Docs/workstreams/FB-035_release_context_fallback_hardening.md`
 - `Docs/workstreams/FB-034_recoverable_diagnostics.md`


### PR DESCRIPTION
## Summary

`main` was already tagged `v1.3.0-prebeta` and contained the merged FB-036 release, but the canon still described the repo as if `v1.2.9-prebeta` and branch-local FB-036 truth were current. This PR reconciles the release layer, registry layer, and canonical workstream layer to the actual merged release state.

## What Changed

### What changed
- aligns merged canon to the released `v1.3.0-prebeta` truth on `main`
- advances the Nexus-era rebaseline and closeout routing from `v1.2.9-prebeta` to `v1.3.0-prebeta`
- marks FB-036 as closed and released across the backlog, roadmap, workstream index, and canonical workstream record
- adds the new `Docs/closeouts/nexus_prebeta_rebaseline_through_v1.3.0-prebeta.md` baseline summary

### Why it changed
`main` was already tagged `v1.3.0-prebeta` and contained the merged FB-036 release, but the canon still described the repo as if `v1.2.9-prebeta` and branch-local FB-036 truth were current. This PR reconciles the release layer, registry layer, and canonical workstream layer to the actual merged release state.

### Impact
- prompts and analysis now route through the correct released baseline
- FB-036 is no longer treated as an active branch-local workstream on `main`
- roadmap, backlog, workstream index, and closeout index now agree on the current released truth

### What changed
- aligns merged canon to the released `v1.3.0-prebeta` truth on `main`
- advances the Nexus-era rebaseline and closeout routing from `v1.2.9-prebeta` to `v1.3.0-prebeta`
- marks FB-036 as closed and released across the backlog, roadmap, workstream index, and canonical workstream record
- adds the new `Docs/closeouts/nexus_prebeta_rebaseline_through_v1.3.0-prebeta.md` baseline summary

### Why it changed
`main` was already tagged `v1.3.0-prebeta` and contained the merged FB-036 release, but the canon still described the repo as if `v1.2.9-prebeta` and branch-local FB-036 truth were current. This PR reconciles the release layer, registry layer, and canonical workstream layer to the actual merged release state.

### Impact
- prompts and analysis now route through the correct released baseline
- FB-036 is no longer treated as an active branch-local workstream on `main`
- roadmap, backlog, workstream index, and closeout index now agree on the current released truth
