### PR TITLE
[codex] Harden PR-readiness gates and lock successor lane

### DIFF
--- a/Docs/Main.md
+++ b/Docs/Main.md
@@ -180,13 +180,15 @@ These are reference layers, not active workstream or roadmap owners.
 - do not treat workstream docs as the owner of repo-wide phase, timeout, stop-loss, proof-authority, validation-helper, or desktop UI audit rules; those belong to `Docs/phase_governance.md`
 - keep historical Jarvis material preserved, but mark it as historical rather than current reality
 - after a release, do not default to a standalone docs-only canon lane when a plausible next workstream can be selected from updated `main`
-- the normal post-release sequence is:
-  1. validate live repo truth on updated `main`
-  2. select the next workstream
-  3. create a fresh compliant branch for that workstream
-  4. perform required post-release canon sync at the start of that branch
-  5. then continue lane work
-- a standalone docs-only post-release repair is an explicit exception path only when no plausible next workstream can yet be selected safely
+- the normal pre-PR sequence for a branch that changes release-facing canon is:
+  1. validate current branch truth
+  2. complete the merge-target canon updates on that same branch
+  3. select the next workstream from current canon
+  4. confirm the next workstream has canon-valid record state
+  5. create the fresh successor branch
+  6. keep that successor branch reserved until it is revalidated after merge
+  7. only then allow the current branch to enter PR creation
+- a standalone post-release canon repair is an emergency-only exception path when merged canon is already stale or when external drift made pre-merge prevention impossible
 - when a slice changes user-visible behavior or another operator-facing path, do not treat `## User Test Summary` as a recap slot; route through `Docs/user_test_summary_guidance.md` and require a real manual checklist unless no meaningful manual test exists
 - when an active desktop workstream has a canonical repo-level `UTS` artifact, do not stop at response text; update that workstream-owned artifact as well unless an explicit exception from `Docs/user_test_summary_guidance.md` applies
 - for relevant desktop user-facing slices, also export or refresh `C:\Users\anden\OneDrive\Desktop\User Test Summary.txt` unless an explicit exception from `Docs/user_test_summary_guidance.md` applies

--- a/Docs/codex_modes.md
+++ b/Docs/codex_modes.md
@@ -156,6 +156,15 @@ Workflow mode should usually return:
 - remaining drift or known gaps
 - whether the approved phase is complete
 
+When the approved phase is `PR Readiness`, the output must also explicitly include:
+
+- confirmation that the merge-target canon completeness gate passed
+- the selected next workstream identity
+- the next workstream `Record State`
+- the successor branch name
+- confirmation that the successor branch was created
+- confirmation that the successor branch is reserved until revalidated after merge
+
 Do not report cleanup as complete unless the pass has explicitly checked for leftover apps, windows, dialogs, helper processes, probe files, or other temporary artifacts it created or opened.
 
 Do not report an interactive validation pass as complete or trustworthy if it exceeded its time budgets or sat stalled without a clean abort path.
@@ -203,7 +212,9 @@ not another unrelated implementation lane.
 
 ### Fresh Branch Start After A Closed Workstream
 
-After a workstream is merged and closed, the next workstream should start from updated `main` on a fresh branch.
+After a workstream is merged and closed, the next workstream should execute from updated `main` on a fresh branch.
+
+That successor branch may be created during `PR Readiness`, but it must stay reserved until the current branch merges and the successor branch is revalidated against updated `main`.
 
 If a branch is stale, merged, or identical to `main`, call it out explicitly and stop using it as the base for next-lane planning.
 
@@ -214,9 +225,9 @@ Release-dependent truth sometimes changes after the code lane is already closed.
 When that happens:
 
 - carry the canon sync on the active lane when that lane is still open
-- if the lane is already closed, normally validate updated `main`, select the next plausible workstream, create its fresh branch, and perform the post-release canon sync at the start of that branch before implementation begins
-- do not default to a standalone docs-only post-release canon pass when a plausible next implementation lane can already be selected safely
-- use a standalone docs-only canon pass only as an explicit exception when no plausible safe next implementation lane can yet be selected, or when current canon drift makes branch selection itself untrustworthy
+- if the lane is already closed, do not treat post-release canon repair as a normal next-branch step
+- require merge-target canon completeness before PR so merged `main` does not become stale in the first place
+- use a standalone post-release canon pass only as an emergency exception when canon drift already exists on updated `main` and could not be prevented before merge or release
 
 ## Shared Rules Across Both Modes
 

--- a/Docs/development_rules.md
+++ b/Docs/development_rules.md
@@ -124,7 +124,8 @@ Stay inside the active grouped lane until one of these is true:
 
 After a lane is closed:
 
-- the next workstream must start from updated `main` on a fresh branch
+- the next workstream must execute from updated `main` on a fresh branch
+- the successor branch may be created during `PR Readiness`, but it remains reserved and may not be used for execution until the current branch merges and the successor branch is revalidated against updated `main`
 
 If a branch becomes:
 
@@ -141,10 +142,17 @@ Supporting canon must stay aligned with live truth.
 That means:
 
 - directly supporting canon may be updated on the active implementation branch when that branch changes the truth
-- after a release, Codex should normally validate updated `main`, select the next plausible workstream, create a fresh compliant branch for that workstream, and perform any required post-release canon sync at the start of that branch before implementation begins
-- do not default to a standalone docs-only post-release branch when a plausible next workstream can already be selected safely from current truth
-- standalone docs-only canon reconstruction is exception-only when no plausible safe next implementation lane can be selected yet, or when current canon drift is misleading enough that branch selection itself would be untrustworthy
-- if a plausible next workstream exists, Codex must block standalone post-release docs execution and require fresh-branch selection first
+- no PR-ready without canon-ready:
+  - a branch is not PR-ready if merging it would leave `main` canon-stale
+- when a branch closes a workstream, changes released milestone posture, changes the current rebaseline, changes closeout-index routing, changes backlog or roadmap release posture, changes workstream-index release posture, or changes `Docs/Main.md` baseline routing, the required release-facing canon updates must already be on that branch before PR creation is allowed
+- no PR-ready without successor branch created:
+  - the next workstream must be selected from canon
+  - that workstream must have canon-valid `Record State`
+  - a fresh successor branch must already be created using an approved naming family such as `feature/<lane>`, `fix/<issue>`, or `docs/<lane>`
+  - that successor branch must remain reserved until the current branch merges and the successor branch is revalidated against updated `main`
+- post-release canon sync is emergency-only:
+  - use it only when canon drift already exists on updated `main` and could not be prevented before merge or release
+- do not default to a standalone docs-only post-release branch for routine canon completion
 - do not use canon sync as an excuse for broad unrelated documentation churn
 
 Local docs overlays are reference material only until revalidated against updated `origin/main`.

--- a/Docs/feature_backlog.md
+++ b/Docs/feature_backlog.md
@@ -140,6 +140,16 @@ Target Version: TBD
 Summary: Track future runtime monitoring and HUD surfaces for GPU / CPU thermals and performance, including possible plugin-fed telemetry inputs.
 Why it matters: Monitoring overlays are a separate runtime and status surface and should not be bolted onto the saved-action system without an explicit product boundary.
 
+### [ID: FB-041] Deterministic callable-group execution layer
+
+Status: Selected for successor-lane preparation
+Record State: Registry-only
+Priority: High
+Release Stage: pre-Beta
+Target Version: TBD
+Summary: Track the first bounded callable-group follow-through execution layer for deterministic linear member execution in stored order with stop-on-failure, terminal success or failure propagation, and runtime progression markers.
+Why it matters: Released FB-036 made callable groups a bounded authoring and exact-invocation surface, but it intentionally deferred scheduling, branching, nested groups, retries, parallelism, shell UX, and built-in catalog expansion. This lane isolates the first execution follow-through seam without reusing FB-037 through FB-040 or reopening the FB-036 foundation by inertia.
+
 ## Closed Canonical Workstreams
 
 ### [ID: FB-036] Limited saved-action authoring and type-first custom task UX

--- a/Docs/phase_governance.md
+++ b/Docs/phase_governance.md
@@ -58,6 +58,52 @@ Phase-sensitive work is blocked until the following are explicit and mutually co
 
 If the live harness behavior and documented timeout contract drift, execution is blocked until they are reconciled.
 
+### Merge-Target Canon Completeness Gate
+
+Rule:
+
+- a branch is not `PR Readiness`-complete if merging it would leave `main` canon-stale
+
+This gate is mandatory when a branch would:
+
+- close a workstream
+- become the latest released implementation milestone
+- change the current rebaseline or closeout baseline
+- change the current closeout-index pointer
+- change backlog, roadmap, or workstream-index release posture
+- change `Docs/Main.md` routing for the current baseline
+
+When this gate applies, the branch must already contain the required release-facing canon updates before PR creation is allowed:
+
+- canonical workstream record closure or equivalent release-state update
+- `Docs/feature_backlog.md`
+- `Docs/prebeta_roadmap.md`
+- `Docs/workstreams/index.md`
+- `Docs/closeout_index.md`
+- the new or updated closeout or rebaseline file
+- `Docs/Main.md` routing updates when the current baseline pointer changed
+
+If any required merge-target canon update is missing, the branch remains blocked in `Docs / Canon Sync` or `PR Readiness`.
+
+### Successor Lane Lock Gate
+
+Rule:
+
+- a branch is not `PR Readiness`-complete unless the next workstream is selected, canon-valid, and a fresh successor branch is created
+
+This gate requires all of the following before PR creation is allowed:
+
+- the next workstream identity is selected from current canon
+- that workstream has canon-valid `Record State`
+- a fresh successor branch is created using an approved naming family such as:
+  - `feature/<lane>`
+  - `fix/<issue>`
+  - `docs/<lane>`
+- the successor branch is explicitly treated as reserved
+- execution on the successor branch must not begin until the current branch merges and the successor branch is revalidated against updated `main`
+
+If the next workstream is not selected, its record state is not canon-valid, or the successor branch has not been created, the current branch is not PR-ready.
+
 ### Proof Authority Matrix
 
 When multiple evidence layers exist, use this authority order unless a workstream explicitly documents a tighter requirement:
@@ -224,9 +270,9 @@ The canonical rule is narrower:
 - `Workstream Analysis` -> `Approved Execution` only after the execution boundary is explicit
 - `Approved Execution` -> `Validation / Hardening` when branch truth must be proven or hardened
 - `Validation / Hardening` -> `Docs / Canon Sync` only after branch-local proof is sufficient for closeout
-- `Docs / Canon Sync` -> `PR Readiness` only after the docs reflect the proven branch truth and no active seam remains
+- `Docs / Canon Sync` -> `PR Readiness` only after the docs reflect the proven branch truth, the merge-target canon completeness gate passes, the successor lane lock gate passes, and no active seam remains
 - `PR Readiness` -> `Release Readiness` only when the branch is a legitimate merge or release candidate
-- `Release Readiness` -> `Post-Release Canon Sync` only after merged or released truth exists that canon must absorb
+- `Release Readiness` -> `Post-Release Canon Sync` only as an emergency repair path after merged or released truth already exists and canon drift escaped the earlier gates
 
 ## Phase Definitions
 
@@ -347,23 +393,31 @@ Exit:
 
 Purpose:
 
-- determine whether the branch is ready to become a merge candidate
+- determine whether the branch is ready to become a merge candidate without leaving merged canon stale and with the next lane already locked
 
 Allowed:
 
 - readiness review
 - PR material preparation
 - final drift checks
+- next-workstream confirmation
+- successor-branch creation
 
 Forbidden:
 
 - assuming readiness because the worktree is clean
 - skipping active validation blockers
+- allowing a branch to enter PR creation while merge-target canon updates are still missing
+- allowing a branch to enter PR creation while the next workstream identity or successor branch is still unresolved
 
 Required evidence:
 
 - branch-local proof complete
 - closeout truth current
+- merge-target canon completeness gate passed
+- next workstream identity selected from canon
+- next workstream record state is canon-valid
+- successor branch created and marked reserved until post-merge revalidation
 - no active seam
 
 Exit:
@@ -401,7 +455,7 @@ Exit:
 
 Purpose:
 
-- repair or align canon after a release when live merged truth requires it
+- perform emergency canon repair after a release only when merged truth is already live and canon drift escaped the earlier gates
 
 Allowed:
 
@@ -409,6 +463,8 @@ Allowed:
 
 Forbidden:
 
+- treating post-release canon sync as a normal part of the standard merge lifecycle
+- using post-release canon sync instead of the merge-target canon completeness gate
 - turning post-release sync into a new implementation lane by accident
 
 Required evidence:
@@ -416,6 +472,7 @@ Required evidence:
 - updated `main`
 - latest release truth
 - explicit canon drift
+- explicit reason the drift could not be prevented before merge or release
 
 Exit:
 

--- a/Docs/prebeta_roadmap.md
+++ b/Docs/prebeta_roadmap.md
@@ -150,15 +150,18 @@ Current merged truth indicates:
 - the recent released workstreams above remain part of the locked current baseline
 - no merged unreleased non-doc implementation debt currently exists on `main`
 - the next implementation workstream should be chosen only after fresh post-release analysis on updated `main`
-- if post-release canon drift is found and a plausible next workstream can already be selected safely, the repair should normally happen at the start of that next workstream branch rather than as a standalone docs-only lane
-- standalone docs-only post-release repair is exception-only when no plausible next workstream can yet be selected safely from current truth
+- if a branch changes release-facing canon, those canon updates must land on that same branch before PR readiness is allowed
+- post-release canon repair is emergency-only when merged canon is already stale or external drift made pre-merge prevention impossible
 - the released FB-027 baseline does not authorize further saved-action authoring, resolution, voice, Action Studio, routines, profiles, hotkey cleanup, or shutdown-confirmation work by inertia
 - future candidate spaces now explicitly recorded in the backlog include:
   - FB-037 for curated built-in system actions and Nexus settings expansion
   - FB-038 for taskbar or tray quick-task UX including Create Custom Task
   - FB-039 for external trigger and plugin integration architecture
   - FB-040 for monitoring, thermals, and performance HUD surfaces
+  - FB-041 for deterministic callable-group execution layer
 - those candidate lanes must be selected deliberately rather than bundled together as one implicit interaction continuation
+- the next selected successor lane from current canon is FB-041 deterministic callable-group execution layer
+- FB-041 remains `Registry-only` until a later promotion pass creates its canonical workstream record, and any successor branch for that lane must stay reserved until revalidated after the current branch merges
 
 Use canonical workstream docs for execution detail.
 Use the backlog for item identity.


### PR DESCRIPTION
## Summary

This docs-only PR hardens the repo-wide PR-readiness model so merged canon cannot go stale after a branch merges, and so the next lane must already be selected and branch-prepared before PR readiness can pass.

## What Changed

### What changed
- adds explicit `Merge-Target Canon Completeness Gate` governance
- adds explicit `Successor Lane Lock Gate` governance
- updates the normal lifecycle so release-facing canon must land on the same branch before PR creation
- redefines post-release canon sync as emergency-only instead of normal workflow
- updates PR-readiness output expectations in `Docs/codex_modes.md`
- adds `FB-041 — Deterministic callable-group execution layer` to the backlog as `Registry-only`
- records FB-041 as the selected successor lane in the roadmap

### Why this changed
The previous governance flow still allowed an invalid sequence:
implementation complete -> PR ready -> merge -> release -> post-release canon sync on the next branch.

That left `main` temporarily canon-stale after merge and blocked later execution lanes because backlog, roadmap, workstream index, and baseline truth lagged behind merged reality. This PR closes that governance gap directly.

### Impact
- PR readiness is now blocked unless merging the branch would leave `main` canon-correct.
- PR readiness is also blocked unless the next workstream is selected, canon-valid, and a fresh successor branch already exists.
- successor branches may be created during PR readiness, but they remain reserved until revalidated after merge.

### Files changed
- `Docs/Main.md`
- `Docs/codex_modes.md`
- `Docs/development_rules.md`
- `Docs/feature_backlog.md`
- `Docs/phase_governance.md`
- `Docs/prebeta_roadmap.md`

### What changed
- adds explicit `Merge-Target Canon Completeness Gate` governance
- adds explicit `Successor Lane Lock Gate` governance
- updates the normal lifecycle so release-facing canon must land on the same branch before PR creation
- redefines post-release canon sync as emergency-only instead of normal workflow
- updates PR-readiness output expectations in `Docs/codex_modes.md`
- adds `FB-041 — Deterministic callable-group execution layer` to the backlog as `Registry-only`
- records FB-041 as the selected successor lane in the roadmap

### Why this changed
The previous governance flow still allowed an invalid sequence:
implementation complete -> PR ready -> merge -> release -> post-release canon sync on the next branch.

### Impact
- PR readiness is now blocked unless merging the branch would leave `main` canon-correct.
- PR readiness is also blocked unless the next workstream is selected, canon-valid, and a fresh successor branch already exists.
- successor branches may be created during PR readiness, but they remain reserved until revalidated after merge.

### Files changed
- `Docs/Main.md`
- `Docs/codex_modes.md`
- `Docs/development_rules.md`
- `Docs/feature_backlog.md`
- `Docs/phase_governance.md`
- `Docs/prebeta_roadmap.md`
