### PR TITLE
Promote FB-041 deterministic callable-group execution lane

### DIFF
--- a/Docs/Main.md
+++ b/Docs/Main.md
@@ -122,6 +122,7 @@ Use these for promoted work that needs a stable feature-state, branch-local vali
 
 - `Docs/workstreams/index.md`
 - `Docs/workstreams/FB-036_saved_action_authoring.md`
+- `Docs/workstreams/FB-041_deterministic_callable_group_execution_layer.md`
 - `Docs/workstreams/FB-035_release_context_fallback_hardening.md`
 - `Docs/workstreams/FB-034_recoverable_diagnostics.md`
 - `Docs/workstreams/FB-025_boot_desktop_milestone_taxonomy_clarification.md`

--- a/Docs/codex_user_guide.md
+++ b/Docs/codex_user_guide.md
@@ -238,10 +238,11 @@ Best for:
 
 Use:
 
-- `docs-only pass: repair post-release canon drift on updated main`
+- `docs-only pass: emergency repair for post-release canon drift on updated main`
 
-This is a valid standalone workstream when live truth justifies it.
-It does not need to be forced onto a hypothetical next implementation branch.
+This is an emergency-only workflow.
+Use it only when merged canon is already stale and that drift could not be prevented before merge or release.
+If a plausible next implementation workstream can be selected safely from current truth, do not treat this as the default path.
 If that docs pass changes validation or harness behavior assumptions, canon must be updated before further execution is recommended.
 
 ### Continue An Approved Branch

--- a/Docs/feature_backlog.md
+++ b/Docs/feature_backlog.md
@@ -26,7 +26,16 @@ Historical note:
 
 ## Promoted Canonical Workstreams
 
-No currently promoted non-doc implementation workstream is active on `main`.
+### [ID: FB-041] Deterministic callable-group execution layer
+
+Status: Promoted for pre-implementation setup
+Record State: Promoted
+Priority: High
+Release Stage: pre-Beta
+Target Version: TBD
+Canonical Workstream Doc: Docs/workstreams/FB-041_deterministic_callable_group_execution_layer.md
+Summary: Promote the first bounded callable-group follow-through execution layer for deterministic linear member execution in stored order with stop-on-failure, terminal success or failure propagation, and runtime progression markers.
+Why it matters: Released FB-036 intentionally deferred callable-group execution follow-through. This lane isolates that first execution seam without reopening authoring or UI scope and without overlapping FB-037 through FB-040.
 
 ## Registry Items
 
@@ -139,16 +148,6 @@ Release Stage: pre-Beta
 Target Version: TBD
 Summary: Track future runtime monitoring and HUD surfaces for GPU / CPU thermals and performance, including possible plugin-fed telemetry inputs.
 Why it matters: Monitoring overlays are a separate runtime and status surface and should not be bolted onto the saved-action system without an explicit product boundary.
-
-### [ID: FB-041] Deterministic callable-group execution layer
-
-Status: Selected for successor-lane preparation
-Record State: Registry-only
-Priority: High
-Release Stage: pre-Beta
-Target Version: TBD
-Summary: Track the first bounded callable-group follow-through execution layer for deterministic linear member execution in stored order with stop-on-failure, terminal success or failure propagation, and runtime progression markers.
-Why it matters: Released FB-036 made callable groups a bounded authoring and exact-invocation surface, but it intentionally deferred scheduling, branching, nested groups, retries, parallelism, shell UX, and built-in catalog expansion. This lane isolates the first execution follow-through seam without reusing FB-037 through FB-040 or reopening the FB-036 foundation by inertia.
 
 ## Closed Canonical Workstreams
 

--- a/Docs/prebeta_roadmap.md
+++ b/Docs/prebeta_roadmap.md
@@ -65,9 +65,21 @@ Current merged truth indicates:
 - latest public release commit: `11eb8ad`
 - no merged unreleased non-doc implementation debt currently exists on `main`
 - the latest public released implementation milestone is FB-036 saved-action authoring and callable groups in `v1.3.0-prebeta`
-- no active non-doc implementation workstream is currently selected on `main`
+- the next active non-doc implementation workstream selected on `main` is FB-041 deterministic callable-group execution layer
 
-That means `main` is again between released non-doc implementation lanes. The released FB-027 interaction baseline plus the later released FB-036 authoring-and-callable-group milestone now form part of the current shared pre-Beta baseline, and the next implementation workstream should be chosen only after fresh post-release analysis on updated `main`.
+That means the released FB-027 interaction baseline plus the later released FB-036 authoring-and-callable-group milestone remain the current shared pre-Beta baseline, and FB-041 is now the promoted next bounded execution lane above that baseline.
+
+## Current Selected Workstream
+
+### FB-041 Deterministic Callable-Group Execution Layer
+
+- status: `promoted`
+- lane type: `implementation`
+- release floor: `patch prerelease`
+- target version: `TBD`
+- release state: `active delta`
+- canonical workstream doc: `Docs/workstreams/FB-041_deterministic_callable_group_execution_layer.md`
+- sequencing note: promote the first bounded callable-group execution follow-through lane for deterministic stored-order execution, stop-on-failure, terminal result propagation, and runtime progression markers without reopening authoring, UI, or broader automation scope
 
 ## Most Recent Released Workstream Context
 
@@ -149,7 +161,7 @@ Current merged truth indicates:
 - the released FB-035 lane is closed
 - the recent released workstreams above remain part of the locked current baseline
 - no merged unreleased non-doc implementation debt currently exists on `main`
-- the next implementation workstream should be chosen only after fresh post-release analysis on updated `main`
+- the next implementation workstream has now been selected and promoted as FB-041 deterministic callable-group execution layer
 - if a branch changes release-facing canon, those canon updates must land on that same branch before PR readiness is allowed
 - post-release canon repair is emergency-only when merged canon is already stale or external drift made pre-merge prevention impossible
 - the released FB-027 baseline does not authorize further saved-action authoring, resolution, voice, Action Studio, routines, profiles, hotkey cleanup, or shutdown-confirmation work by inertia
@@ -158,10 +170,9 @@ Current merged truth indicates:
   - FB-038 for taskbar or tray quick-task UX including Create Custom Task
   - FB-039 for external trigger and plugin integration architecture
   - FB-040 for monitoring, thermals, and performance HUD surfaces
-  - FB-041 for deterministic callable-group execution layer
 - those candidate lanes must be selected deliberately rather than bundled together as one implicit interaction continuation
-- the next selected successor lane from current canon is FB-041 deterministic callable-group execution layer
-- FB-041 remains `Registry-only` until a later promotion pass creates its canonical workstream record, and any successor branch for that lane must stay reserved until revalidated after the current branch merges
+- FB-041 is now `Promoted`, and its canonical workstream record owns the active execution truth for that lane
+- the reserved FB-041 branch must stay aligned to updated `main` before implementation begins and must not silently widen into other deferred candidate spaces
 
 Use canonical workstream docs for execution detail.
 Use the backlog for item identity.

--- a/Docs/workstreams/FB-041_deterministic_callable_group_execution_layer.md
+++ b/Docs/workstreams/FB-041_deterministic_callable_group_execution_layer.md
@@ -1,0 +1,118 @@
+# FB-041 Deterministic Callable-Group Execution Layer
+
+## ID And Title
+
+- ID: `FB-041`
+- Title: `Deterministic callable-group execution layer`
+
+## Record State
+
+- `Promoted`
+
+## Status
+
+- `Promoted for pre-implementation setup`
+
+## Release Stage
+
+- `pre-Beta`
+
+## Target Version
+
+- `TBD`
+
+## Canonical Branch
+
+- `feature/fb-041-deterministic-callable-group-execution`
+
+## Purpose / Why It Matters
+
+Promote the first bounded callable-group follow-through execution layer above the released FB-036 authoring baseline.
+
+This workstream exists so callable groups can move from exact invocation only into deterministic runtime follow-through without reopening FB-036 authoring foundations, widening into automation design, or overlapping the separate future lanes already tracked in FB-037 through FB-040.
+
+## Current Phase
+
+- Phase: `Approved Execution`
+- Substate: `Execution boundary approved, reserved branch revalidated against updated main, first product slice not started`
+
+## Phase Entry Basis
+
+- merged `main` now includes the governance-hardening merge from PR `#56`
+- merged `main` now includes `FB-041` in backlog as the selected successor lane
+- the reserved branch `feature/fb-041-deterministic-callable-group-execution` has been realigned to updated `main`
+- no implementation commits exist on the reserved branch beyond updated `main`
+- the lane is ready for a bounded implementation startup pass, but product code has not been changed yet
+
+## Phase Exit Criteria
+
+- the execution-dispatch seam after chooser or confirm resolution is located precisely in code before patching
+- the smallest safe first slice is approved against this workstream scope
+- the first bounded execution slice is completed and verified without widening into deferred non-goals
+
+## Current Branch Truth
+
+- the current shared baseline remains the released FB-027 interaction floor plus the released FB-036 authoring-and-callable-group milestone
+- exact group invocation already exists, but callable-group follow-through execution remains deferred on the released baseline
+- the reserved branch now matches updated merged `main` after the governance-hardening merge and remains the correct future execution base for this lane
+
+## Scope
+
+- deterministic linear execution only
+- stored-order stepping only
+- stop on first failure
+- terminal success or failure propagation
+- runtime markers for group start, per-step progression, and terminal completion or failure
+
+## Explicit Non-Goals
+
+- no UI changes
+- no scheduling
+- no branching
+- no nested groups
+- no parallel execution
+- no retries
+- no plugin or external trigger work
+- no built-in catalog expansion
+
+## Reuse Baseline
+
+- `Docs/workstreams/FB-036_saved_action_authoring.md`
+- `Docs/workstreams/FB-027_interaction_system_baseline.md`
+- `Docs/closeouts/nexus_prebeta_rebaseline_through_v1.3.0-prebeta.md`
+- `desktop/interaction_overlay_model.py`
+- `desktop/shared_action_model.py`
+
+## First Execution Boundary
+
+- the active implementation seam starts at the execution dispatch layer after chooser or confirm resolution
+- this lane does not start in UI, authoring, or group-definition storage
+- the exact dispatch function must be located before any product-code patching begins
+
+## Validation Contract
+
+- prefer repo-side deterministic proof first
+- required assertions:
+  - member execution order matches persisted stored order exactly
+  - step indices are monotonic and gap-free
+  - execution halts on first failure
+  - later members do not execute after failure
+  - aggregate success or failure matches the executed steps
+- required runtime markers:
+  - group execution start
+  - per-step start
+  - per-step success or failure
+  - group completion or failure
+- no timeout inflation
+- no validation-rule drift
+
+## Executed Slices
+
+- promoted the backlog identity into an active canonical workstream
+- created the stable canonical workstream record
+- revalidated the reserved branch against updated `main`
+- confirmed the lane remains pre-implementation only
+
+## User Test Summary
+
+No meaningful manual test exists yet because implementation has not started in this workstream.

--- a/Docs/workstreams/index.md
+++ b/Docs/workstreams/index.md
@@ -67,7 +67,7 @@ For an active or recently closed canonical workstream, keep these durable tracea
 
 ### Active
 
-No active canonical implementation workstream is currently selected on `main`.
+- `Docs/workstreams/FB-041_deterministic_callable_group_execution_layer.md`
 
 ### Closed
 


### PR DESCRIPTION
## Summary

Promotes FB-041 from Registry-only to Promoted and adds the canonical workstream record for deterministic callable-group execution.

## What Changed

This PR is docs-only and does not start implementation.

It updates:
- Main routing
- backlog/workstream index state
- roadmap sequencing
- FB-041 canonical workstream doc
- operator guidance for emergency-only canon repair alignment

Implementation remains blocked until this promotion merges.

It updates:
- Main routing
- backlog/workstream index state
- roadmap sequencing
- FB-041 canonical workstream doc
- operator guidance for emergency-only canon repair alignment
