### PR TITLE
Complete FB-041 deterministic callable-group execution lane

### DIFF
--- a/Docs/workstreams/FB-041_deterministic_callable_group_execution_layer.md
+++ b/Docs/workstreams/FB-041_deterministic_callable_group_execution_layer.md
@@ -11,7 +11,7 @@
 
 ## Status
 
-- `Promoted for pre-implementation setup`
+- `Execution in progress`
 
 ## Release Stage
 
@@ -34,7 +34,7 @@ This workstream exists so callable groups can move from exact invocation only in
 ## Current Phase
 
 - Phase: `Approved Execution`
-- Substate: `Execution boundary approved, reserved branch revalidated against updated main, first product slice not started`
+- Substate: `Dispatch integration landed, first bounded execution slice complete, deeper follow-through refinement pending`
 
 ## Phase Entry Basis
 
@@ -111,7 +111,9 @@ This workstream exists so callable groups can move from exact invocation only in
 - promoted the backlog identity into an active canonical workstream
 - created the stable canonical workstream record
 - revalidated the reserved branch against updated `main`
-- confirmed the lane remains pre-implementation only
+- added the first deterministic callable-group execution helper at the dispatch layer
+- routed the dispatch handoff through the deterministic group-execution helper when a callable-group confirm context is active
+- added repo-side validation for stored-order execution, stop-on-failure, and runtime-marker progression
 
 ## User Test Summary
 

--- a/Docs/workstreams/FB-041_deterministic_callable_group_execution_layer.md
+++ b/Docs/workstreams/FB-041_deterministic_callable_group_execution_layer.md
@@ -11,7 +11,7 @@
 
 ## Status
 
-- `Execution in progress`
+- `Completed on branch (pending merge)`
 
 ## Release Stage
 
@@ -33,28 +33,38 @@ This workstream exists so callable groups can move from exact invocation only in
 
 ## Current Phase
 
-- Phase: `Approved Execution`
-- Substate: `Dispatch integration landed, first bounded execution slice complete, deeper follow-through refinement pending`
+- Phase: `Completed`
+- Substate: `Exact-branch closeout evidence captured; ready for merge-facing closeout flow`
 
 ## Phase Entry Basis
 
-- merged `main` now includes the governance-hardening merge from PR `#56`
-- merged `main` now includes `FB-041` in backlog as the selected successor lane
-- the reserved branch `feature/fb-041-deterministic-callable-group-execution` has been realigned to updated `main`
-- no implementation commits exist on the reserved branch beyond updated `main`
-- the lane is ready for a bounded implementation startup pass, but product code has not been changed yet
+- merged `main` included the governance-hardening merge from PR `#56`
+- merged `main` included `FB-041` in backlog as the selected successor lane
+- merged `main` included the promoted canonical workstream record before implementation started
+- the implementation branch was recreated from updated `main` so no stale pre-promotion execution state was reused
+- product work in this lane then stayed bounded to deterministic callable-group execution plus the two explicitly documented UI clarification exceptions
 
 ## Phase Exit Criteria
 
-- the execution-dispatch seam after chooser or confirm resolution is located precisely in code before patching
-- the smallest safe first slice is approved against this workstream scope
-- the first bounded execution slice is completed and verified without widening into deferred non-goals
+- deterministic callable-group execution is implemented and bounded to stored-order, stop-on-failure follow-through
+- dispatch routing, execution intent binding, failure-path parity, and failure payload normalization are complete
+- the confirm-surface clarification exception and the result status-text clarification exception are both complete without widening into broader UI redesign
+- repo-side validation is green on the exact branch truth
+- interactive launched-process success and failure validation is green on the exact branch truth
+- live confirm and result surface audit evidence is captured on the exact branch truth
 
 ## Current Branch Truth
 
 - the current shared baseline remains the released FB-027 interaction floor plus the released FB-036 authoring-and-callable-group milestone
-- exact group invocation already exists, but callable-group follow-through execution remains deferred on the released baseline
-- the reserved branch now matches updated merged `main` after the governance-hardening merge and remains the correct future execution base for this lane
+- exact group invocation still enters through the released chooser and confirm flow, but group follow-through now executes the full stored-order callable group after confirm
+- deterministic callable-group execution now emits bounded runtime markers for:
+  - group start
+  - per-step start
+  - per-step success or failure
+  - terminal completion or failure
+- dispatch now consumes immutable execution intent captured at confirm time rather than ambient overlay group state
+- group failures now reuse the existing recoverable launch-failure classification pipeline with structured group-aware payloads
+- single-action dispatch, confirm text, result text, and failure behavior remain unchanged except where the documented confirm/result group-only clarification exceptions apply
 
 ## Scope
 
@@ -74,6 +84,13 @@ This workstream exists so callable groups can move from exact invocation only in
 - no retries
 - no plugin or external trigger work
 - no built-in catalog expansion
+
+Exception:
+
+- a single confirm-surface clarification seam is allowed to accurately reflect deterministic callable-group execution behavior
+- this confirm-surface exception does not include result-surface changes or UI restructuring
+- a single result status-text clarification seam is allowed to accurately reflect deterministic callable-group execution outcomes
+- this result-surface exception is limited to status-text only and does not include result hint changes, timing changes, payload or model changes, or UI restructuring
 
 ## Reuse Baseline
 
@@ -111,10 +128,87 @@ This workstream exists so callable groups can move from exact invocation only in
 - promoted the backlog identity into an active canonical workstream
 - created the stable canonical workstream record
 - revalidated the reserved branch against updated `main`
-- added the first deterministic callable-group execution helper at the dispatch layer
-- routed the dispatch handoff through the deterministic group-execution helper when a callable-group confirm context is active
-- added repo-side validation for stored-order execution, stop-on-failure, and runtime-marker progression
+- added deterministic callable-group execution with stored-order stepping, stop-on-failure, and terminal propagation
+- routed the post-confirm dispatch handoff through the deterministic group-execution helper when a callable-group confirm context is active
+- replaced ambient group-state dispatch decisions with immutable execution intent captured at confirm time and consumed exactly once
+- aligned group failure handling with the existing single-action recoverable failure classification and reporting path
+- completed structured failure payload normalization so single and group paths are schema-compatible downstream
+- added the confirm-surface clarification seam so group confirm copy accurately states that Enter runs the full stored-order group while the selected member remains inspection context
+- added the result status-text clarification seam so group success and fallback failure text accurately reflect callable-group outcomes
+- added result-name sanity checks proving result text uses execution intent group truth rather than mutable overlay state
+- added branch-local interactive launched-process validation and screenshot audit coverage for:
+  - real group success
+  - real group failure
+  - unchanged single-action confirm and result surfaces
+
+## Validation Evidence
+
+- repo-side deterministic validator:
+  - `python dev/orin_callable_group_execution_validation.py`
+  - latest pass confirms:
+    - stored-order execution
+    - gap-free step indices
+    - stop-on-failure
+    - no-later-member execution after failure
+    - execution intent single-use behavior
+    - confirm/result copy assertions
+    - overlay mutation protection for group result naming
+- FB-036 regression guard:
+  - `python dev/orin_saved_action_authoring_validation.py`
+- recoverable-failure regression guard:
+  - `python dev/orin_recoverable_launch_failed_validation.py`
+  - latest report:
+    - `dev/logs/recoverable_launch_failed_validation/reports/RecoverableLaunchFailedValidationReport_20260418_094518.txt`
+- exact-branch interactive launched-process closeout proof:
+  - `dev/orin_callable_group_execution_interactive_validation.ps1`
+  - latest report:
+    - `dev/logs/fb_041_callable_group_interactive_validation/20260418_094333/FB041CallableGroupInteractiveValidationReport_20260418_094333.txt`
+  - latest manifest:
+    - `dev/logs/fb_041_callable_group_interactive_validation/20260418_094333/manifest.json`
+  - latest launched-process UI captures:
+    - `dev/logs/fb_041_callable_group_interactive_validation/20260418_094333/group_success_confirm.png`
+    - `dev/logs/fb_041_callable_group_interactive_validation/20260418_094333/group_success_result.png`
+    - `dev/logs/fb_041_callable_group_interactive_validation/20260418_094333/group_failure_result.png`
+    - `dev/logs/fb_041_callable_group_interactive_validation/20260418_094333/single_action_confirm.png`
+    - `dev/logs/fb_041_callable_group_interactive_validation/20260418_094333/single_action_result.png`
+- closeout-grade interactive proof now explicitly covers:
+  - one real callable-group success pass
+  - one real callable-group failure pass
+  - live confirm copy audit
+  - live result status-text audit
+  - unchanged result hint audit
+  - unchanged single-action confirm and result audit
 
 ## User Test Summary
 
-No meaningful manual test exists yet because implementation has not started in this workstream.
+- setup:
+  - start the desktop runtime on the exact FB-041 branch truth
+  - ensure the saved-actions source includes:
+    - group `Workspace Tools`
+    - group `Broken Workspace Tools`
+    - single saved action `Open Notes Task`
+- exact success invocation:
+  - invoke `workspace tools`
+  - when the chooser appears, select `Open Notes Task`
+  - expected confirm text:
+    - hint: `Review the selected member details below. Press Enter to run "Workspace Tools" group in stored order.`
+    - footer: `Press Enter to run "Workspace Tools" group in stored order, or Esc to return.`
+  - expected success result text:
+    - `Group "Workspace Tools" executed in stored order.`
+- exact failure invocation:
+  - invoke `broken workspace tools`
+  - when the chooser appears, select `Open Notes Task`
+  - expected failure result text prefix:
+    - `Group "Broken Workspace Tools" failed at step 1:`
+- unchanged single-action control check:
+  - invoke `notes task`
+  - expected confirm text:
+    - hint: `Review the resolved action origin and destination before execution.`
+    - footer: `Press Enter to confirm or Esc to return.`
+  - expected success result text:
+    - `Launch request sent.`
+- what must remain unchanged:
+  - result hint text stays `Returning to passive desktop mode.`
+  - no new panels, rows, or workflow steps appear
+  - single-action behavior stays on the original non-group path
+  - the selected group member remains inspection context only; execution still follows the full stored-order group

--- a/desktop/desktop_renderer.py
+++ b/desktop/desktop_renderer.py
@@ -4488,7 +4488,8 @@ class CommandOverlayPanel(QWidget):
         self.confirm_request_value = self._make_confirm_value()
         confirm_layout.addWidget(self.confirm_request_value, 0, 1)
 
-        confirm_layout.addWidget(self._make_confirm_label("Resolved action"), 1, 0)
+        self.confirm_title_label = self._make_confirm_label("Resolved action")
+        confirm_layout.addWidget(self.confirm_title_label, 1, 0)
         self.confirm_title_value = self._make_confirm_value()
         confirm_layout.addWidget(self.confirm_title_value, 1, 1)
 
@@ -4712,6 +4713,23 @@ class CommandOverlayPanel(QWidget):
         label.setWordWrap(True)
         return label
 
+    def _build_confirm_surface_copy(self, selection_context: str, pending_group: dict | None = None) -> dict[str, str]:
+        normalized_selection_context = (selection_context or "").strip().casefold()
+        pending_group = pending_group or {}
+        group_title = (pending_group.get("title") or "").strip()
+        if normalized_selection_context == "group":
+            group_subject = f'"{group_title}" group' if group_title else "the full matched group"
+            return {
+                "title_label": "Selected member",
+                "hint_text": f"Review the selected member details below. Press Enter to run {group_subject} in stored order.",
+                "help_text": f"Press Enter to run {group_subject} in stored order, or Esc to return.",
+            }
+        return {
+            "title_label": "Resolved action",
+            "hint_text": "Review the resolved action origin and destination before execution.",
+            "help_text": "Press Enter to confirm or Esc to return.",
+        }
+
     def keyPressEvent(self, event):
         if event.key() in (Qt.Key_Return, Qt.Key_Enter):
             self.submit_requested.emit()
@@ -4846,9 +4864,10 @@ class CommandOverlayPanel(QWidget):
 
         selection_context = payload.get("selection_context", "")
         pending_group = payload.get("pending_group") or {}
+        confirm_surface_copy = self._build_confirm_surface_copy(selection_context, pending_group)
 
         if phase == "confirm":
-            self.hint_label.setText("Review the resolved action origin and destination before execution.")
+            self.hint_label.setText(confirm_surface_copy["hint_text"])
         elif phase == "choose":
             if selection_context == "group" and pending_group.get("title"):
                 self.hint_label.setText(
@@ -4910,12 +4929,14 @@ class CommandOverlayPanel(QWidget):
         show_confirm = phase == "confirm" and bool(action)
         self.confirmation_frame.setVisible(show_confirm)
         if show_confirm:
+            self.confirm_title_label.setText(confirm_surface_copy["title_label"])
             self.confirm_request_value.setText(payload.get("typed_request", ""))
             self.confirm_title_value.setText(action.get("title", ""))
             self.confirm_origin_value.setText(action.get("origin_label", ""))
             self.confirm_kind_value.setText(action.get("target_kind", ""))
             self.confirm_target_value.setText(action.get("target_display") or action.get("target", ""))
             self.confirm_target_value.setToolTip(action.get("target", ""))
+            self.confirm_help_label.setText(confirm_surface_copy["help_text"])
 
 
 class DesktopRuntimeWindow(QWidget):
@@ -6352,51 +6373,132 @@ class DesktopRuntimeWindow(QWidget):
             self._last_launch_failure_count = 0
         self._reported_recoverable_launch_failures.discard(action_id)
 
-    def _classify_recoverable_launch_failed_incident(self, action_id: str, failure_count: int) -> str:
+    def _classify_recoverable_launch_failed_incident(
+        self,
+        action_id: str,
+        failure_count: int,
+        *,
+        failure_context: dict[str, str] | None = None,
+    ) -> str:
+        normalized_failure_context = self._normalize_launch_failure_context(
+            action_id,
+            failure_context,
+        )
+        context_suffix = self._format_failure_context_suffix(normalized_failure_context)
         if failure_count < 2:
             self._log_event(
-                f"RENDERER_MAIN|COMMAND_LAUNCH_FAILED_CLASS2_INLINE|action_id={action_id}|count={failure_count}"
+                f"RENDERER_MAIN|COMMAND_LAUNCH_FAILED_CLASS2_INLINE|action_id={action_id}|count={failure_count}{context_suffix}"
             )
             return "class2_inline"
 
         if action_id in self._reported_recoverable_launch_failures:
             self._log_event(
-                f"RENDERER_MAIN|COMMAND_LAUNCH_FAILED_CLASS3_ALREADY_REPORTED|action_id={action_id}|count={failure_count}"
+                f"RENDERER_MAIN|COMMAND_LAUNCH_FAILED_CLASS3_ALREADY_REPORTED|action_id={action_id}|count={failure_count}{context_suffix}"
             )
             return "class3_already_reported"
 
         self._log_event(
-            f"RENDERER_MAIN|COMMAND_LAUNCH_FAILED_CLASS3_REPORT_SELECTED|action_id={action_id}|count={failure_count}"
+            f"RENDERER_MAIN|COMMAND_LAUNCH_FAILED_CLASS3_REPORT_SELECTED|action_id={action_id}|count={failure_count}{context_suffix}"
         )
         return "class3_report_selected"
 
-    def _prepare_recoverable_launch_failure_report(self, action) -> str | None:
+    def _format_failure_context_suffix(self, failure_context: dict[str, str] | None) -> str:
+        if not failure_context:
+            return ""
+        suffix_parts = []
+        for key, value in failure_context.items():
+            normalized = (value or "").strip()
+            if not normalized:
+                continue
+            suffix_parts.append(f"{key}={normalized.replace('|', '/')}")
+        if not suffix_parts:
+            return ""
+        return "|" + "|".join(suffix_parts)
+
+    def _bound_execution_trace(self, execution_trace: str, *, fallback_action_id: str = "") -> str:
+        segments = [
+            segment.strip()
+            for segment in (execution_trace or "").split(">")
+            if segment and segment.strip()
+        ]
+        if not segments and fallback_action_id.strip():
+            segments = [fallback_action_id.strip()]
+        if len(segments) > 8:
+            segments = segments[-8:]
+        return ">".join(segment.replace("|", "/") for segment in segments)
+
+    def _normalize_launch_failure_context(
+        self,
+        action_id: str,
+        failure_context: dict[str, str] | None = None,
+    ) -> dict[str, str]:
+        raw_context = dict(failure_context or {})
+        execution_type = (raw_context.get("execution_type") or "single").strip().casefold()
+        normalized_error_type = (raw_context.get("error_type") or "launch_exception").strip() or "launch_exception"
+
+        if execution_type == "group":
+            failed_action_id = (raw_context.get("failed_action_id") or action_id or "").strip()
+            return {
+                "execution_type": "group",
+                "failed_action_id": failed_action_id,
+                "group_id": (raw_context.get("group_id") or "").strip(),
+                "step_index": (raw_context.get("step_index") or raw_context.get("failed_step_index") or "").strip(),
+                "error_type": normalized_error_type,
+                "execution_trace": self._bound_execution_trace(
+                    raw_context.get("execution_trace", ""),
+                    fallback_action_id=failed_action_id,
+                ),
+            }
+
+        normalized_action_id = (action_id or "").strip()
+        return {
+            "execution_type": "single",
+            "action_id": normalized_action_id,
+            "group_id": "",
+            "step_index": "",
+            "error_type": normalized_error_type,
+            "execution_trace": self._bound_execution_trace(
+                raw_context.get("execution_trace", ""),
+                fallback_action_id=normalized_action_id,
+            ),
+        }
+
+    def _prepare_recoverable_launch_failure_report(self, action, *, failure_context: dict[str, str] | None = None) -> str | None:
+        normalized_failure_context = self._normalize_launch_failure_context(
+            action.id,
+            failure_context,
+        )
         failure_count = self._record_launch_failure(action.id)
-        incident_class = self._classify_recoverable_launch_failed_incident(action.id, failure_count)
+        context_suffix = self._format_failure_context_suffix(normalized_failure_context)
+        incident_class = self._classify_recoverable_launch_failed_incident(
+            action.id,
+            failure_count,
+            failure_context=normalized_failure_context,
+        )
         if incident_class == "class2_inline":
             return None
         if incident_class == "class3_already_reported":
             return None
         if not self.runtime_log_path or not os.path.isfile(self.runtime_log_path):
             self._log_event(
-                f"RENDERER_MAIN|COMMAND_LAUNCH_FAILED_RECOVERABLE_REPORT_SKIPPED|action_id={action.id}|reason=runtime_log_unavailable"
+                f"RENDERER_MAIN|COMMAND_LAUNCH_FAILED_RECOVERABLE_REPORT_SKIPPED|action_id={action.id}|reason=runtime_log_unavailable{context_suffix}"
             )
             return None
 
         crash_dir = os.path.join(os.path.dirname(self.runtime_log_path), "crash")
         self._log_event(
-            f"RENDERER_MAIN|COMMAND_LAUNCH_FAILED_RECOVERABLE_REPORT_BEGIN|action_id={action.id}|count={failure_count}"
+            f"RENDERER_MAIN|COMMAND_LAUNCH_FAILED_RECOVERABLE_REPORT_BEGIN|action_id={action.id}|count={failure_count}{context_suffix}"
         )
         try:
             report_prep = prepare_manual_issue_report(ROOT_DIR, self.runtime_log_path, crash_dir)
         except SupportBundleError as exc:
             self._log_event(
-                f"RENDERER_MAIN|COMMAND_LAUNCH_FAILED_RECOVERABLE_REPORT_FAILED|action_id={action.id}|reason={exc}"
+                f"RENDERER_MAIN|COMMAND_LAUNCH_FAILED_RECOVERABLE_REPORT_FAILED|action_id={action.id}|reason={exc}{context_suffix}"
             )
             return None
         except Exception as exc:
             self._log_event(
-                f"RENDERER_MAIN|COMMAND_LAUNCH_FAILED_RECOVERABLE_REPORT_FAILED|action_id={action.id}|reason={exc}"
+                f"RENDERER_MAIN|COMMAND_LAUNCH_FAILED_RECOVERABLE_REPORT_FAILED|action_id={action.id}|reason={exc}{context_suffix}"
             )
             return None
 
@@ -6407,11 +6509,11 @@ class DesktopRuntimeWindow(QWidget):
         try:
             os.startfile(os.path.dirname(bundle_info["bundle_path"]))
             self._log_event(
-                f"RENDERER_MAIN|COMMAND_LAUNCH_FAILED_RECOVERABLE_REPORT_FOLDER_OPENED|action_id={action.id}|bundle={bundle_info['bundle_name']}"
+                f"RENDERER_MAIN|COMMAND_LAUNCH_FAILED_RECOVERABLE_REPORT_FOLDER_OPENED|action_id={action.id}|bundle={bundle_info['bundle_name']}{context_suffix}"
             )
         except Exception as exc:
             self._log_event(
-                f"RENDERER_MAIN|COMMAND_LAUNCH_FAILED_RECOVERABLE_REPORT_FOLDER_FAILED|action_id={action.id}|reason={exc}"
+                f"RENDERER_MAIN|COMMAND_LAUNCH_FAILED_RECOVERABLE_REPORT_FOLDER_FAILED|action_id={action.id}|reason={exc}{context_suffix}"
             )
 
         if issue_url:
@@ -6419,12 +6521,12 @@ class DesktopRuntimeWindow(QWidget):
                 browser_opened = webbrowser.open(issue_url, new=2)
             except Exception as exc:
                 self._log_event(
-                    f"RENDERER_MAIN|COMMAND_LAUNCH_FAILED_RECOVERABLE_REPORT_ISSUE_FAILED|action_id={action.id}|reason={exc}"
+                    f"RENDERER_MAIN|COMMAND_LAUNCH_FAILED_RECOVERABLE_REPORT_ISSUE_FAILED|action_id={action.id}|reason={exc}{context_suffix}"
                 )
 
         self._reported_recoverable_launch_failures.add(action.id)
         self._log_event(
-            f"RENDERER_MAIN|COMMAND_LAUNCH_FAILED_RECOVERABLE_REPORT_READY|action_id={action.id}|bundle={bundle_info['bundle_name']}"
+            f"RENDERER_MAIN|COMMAND_LAUNCH_FAILED_RECOVERABLE_REPORT_READY|action_id={action.id}|bundle={bundle_info['bundle_name']}{context_suffix}"
         )
 
         if browser_opened:
@@ -6432,6 +6534,31 @@ class DesktopRuntimeWindow(QWidget):
         if issue_url:
             return "Launch failed again. Support bundle prepared; open the issue page manually and attach the bundle."
         return "Launch failed again. Support bundle prepared; review it locally before filing the report."
+
+    def _resolve_group_failure_action(self, group, failed_action_id: str):
+        normalized_failed_action_id = (failed_action_id or "").strip().casefold()
+        if not normalized_failed_action_id:
+            return None
+        for action in tuple(group.member_actions):
+            if action.id.strip().casefold() == normalized_failed_action_id:
+                return action
+        return None
+
+    def _build_group_failure_context(self, group, result) -> dict[str, str]:
+        execution_trace = tuple(result.completed_action_ids) + (
+            (result.failed_action_id,) if result.failed_action_id else ()
+        )
+        return {
+            "execution_type": "group",
+            "group_id": group.id,
+            "failed_action_id": result.failed_action_id,
+            "step_index": str(result.failed_step_index),
+            "error_type": "launch_exception",
+            "execution_trace": self._bound_execution_trace(
+                ">".join(action_id for action_id in execution_trace if action_id),
+                fallback_action_id=result.failed_action_id or "",
+            ),
+        }
 
     def handle_ambiguous_match_selected(self, index: int):
         result, payload = self._command_model.choose_match(index)
@@ -6491,21 +6618,41 @@ class DesktopRuntimeWindow(QWidget):
         if result != "execute_confirmed":
             return
 
-        action = payload
-        group = self._command_model.pending_group
-        execution_request_fields = [f"action_id={action.id}"]
-        if group is not None:
-            execution_request_fields.append(f"group_id={group.id}")
+        intent = payload
+        action = intent.action
+        execution_request_fields = [f"action_id={intent.action_id}"]
+        if intent.execution_type == "group":
+            execution_request_fields.append(f"group_id={intent.group_id}")
         self._log_event("RENDERER_MAIN|COMMAND_EXECUTION_REQUESTED|" + "|".join(execution_request_fields))
 
-        if group is not None:
+        if intent.execution_type == "group":
+            group = intent.group
+            if group is None:
+                return
+            group_label = (group.title or "").strip() or group.id
             result = self._execute_callable_group(group)
             if not result.succeeded:
+                failure_context = self._build_group_failure_context(group, result)
                 self._log_event(
                     "RENDERER_MAIN|COMMAND_GROUP_EXECUTION_FAILED|"
-                    f"group_id={group.id}|failed_action_id={result.failed_action_id}|failed_step_index={result.failed_step_index}"
+                    f"group_id={group.id}|failed_action_id={result.failed_action_id}|failed_step_index={result.failed_step_index}|"
+                    f"execution_trace={failure_context.get('execution_trace', '')}"
                 )
-                self._show_command_result("launch_failed", f"Launch failed: {result.error}")
+                failed_action = self._resolve_group_failure_action(group, result.failed_action_id)
+                recoverable_status = None
+                if failed_action is not None:
+                    recoverable_status = self._prepare_recoverable_launch_failure_report(
+                        failed_action,
+                        failure_context=failure_context,
+                    )
+                if recoverable_status:
+                    self._show_command_result("launch_failed", recoverable_status, close_delay_ms=2600)
+                else:
+                    failed_step_index = result.failed_step_index if result.failed_step_index is not None else "?"
+                    self._show_command_result(
+                        "launch_failed",
+                        f'Group "{group_label}" failed at step {failed_step_index}: {result.error}',
+                    )
                 return
 
             for completed_action_id in result.completed_action_ids:
@@ -6514,7 +6661,7 @@ class DesktopRuntimeWindow(QWidget):
                 "RENDERER_MAIN|COMMAND_GROUP_EXECUTION_COMPLETED|"
                 f"group_id={group.id}|step_count={result.step_count}"
             )
-            self._show_command_result("launch_requested", "Launch request sent.")
+            self._show_command_result("launch_requested", f'Group "{group_label}" executed in stored order.')
             return
 
         try:

--- a/desktop/desktop_renderer.py
+++ b/desktop/desktop_renderer.py
@@ -51,6 +51,7 @@ from .shared_action_model import (
     build_callable_group_phrases,
     build_saved_action_callable_phrases,
     default_saved_action_trigger_mode,
+    execute_command_group,
     launch_command_action,
 )
 from .orin_support_reporting import SupportBundleError, prepare_manual_issue_report
@@ -6318,6 +6319,22 @@ class DesktopRuntimeWindow(QWidget):
         self._apply_command_overlay_state()
         self._result_close_timer.start(max(0, int(close_delay_ms)))
 
+    def _emit_group_execution_marker(self, marker_name: str, fields: dict[str, str]):
+        parts = ["RENDERER_MAIN", marker_name]
+        for key, value in fields.items():
+            normalized = (value or "").strip()
+            if not normalized:
+                continue
+            parts.append(f"{key}={normalized}")
+        self._log_event("|".join(parts))
+
+    def _execute_callable_group(self, group):
+        return execute_command_group(
+            group,
+            action_launcher=launch_command_action,
+            marker_emitter=self._emit_group_execution_marker,
+        )
+
     def _close_command_overlay_after_result(self):
         self.close_command_overlay()
 
@@ -6475,7 +6492,31 @@ class DesktopRuntimeWindow(QWidget):
             return
 
         action = payload
-        self._log_event(f"RENDERER_MAIN|COMMAND_EXECUTION_REQUESTED|action_id={action.id}")
+        group = self._command_model.pending_group
+        execution_request_fields = [f"action_id={action.id}"]
+        if group is not None:
+            execution_request_fields.append(f"group_id={group.id}")
+        self._log_event("RENDERER_MAIN|COMMAND_EXECUTION_REQUESTED|" + "|".join(execution_request_fields))
+
+        if group is not None:
+            result = self._execute_callable_group(group)
+            if not result.succeeded:
+                self._log_event(
+                    "RENDERER_MAIN|COMMAND_GROUP_EXECUTION_FAILED|"
+                    f"group_id={group.id}|failed_action_id={result.failed_action_id}|failed_step_index={result.failed_step_index}"
+                )
+                self._show_command_result("launch_failed", f"Launch failed: {result.error}")
+                return
+
+            for completed_action_id in result.completed_action_ids:
+                self._clear_launch_failure_tracking(completed_action_id)
+            self._log_event(
+                "RENDERER_MAIN|COMMAND_GROUP_EXECUTION_COMPLETED|"
+                f"group_id={group.id}|step_count={result.step_count}"
+            )
+            self._show_command_result("launch_requested", "Launch request sent.")
+            return
+
         try:
             launch_command_action(action)
         except Exception as exc:

--- a/desktop/interaction_overlay_model.py
+++ b/desktop/interaction_overlay_model.py
@@ -1,12 +1,38 @@
 import os
+from dataclasses import dataclass
 
 from .shared_action_model import (
+    CommandAction,
     CommandActionCatalog,
+    CommandGroup,
     DEFAULT_COMMAND_ACTION_CATALOG,
     build_default_command_action_catalog,
     format_action_origin_label,
     reload_default_command_action_catalog,
 )
+
+
+@dataclass(frozen=True)
+class CommandExecutionIntent:
+    execution_type: str
+    action: CommandAction
+    group: CommandGroup | None = None
+
+    @property
+    def action_id(self) -> str:
+        return self.action.id
+
+    @property
+    def group_id(self) -> str:
+        return "" if self.group is None else self.group.id
+
+    @property
+    def resolved_member_action_ids(self) -> tuple[str, ...]:
+        return () if self.group is None else self.group.member_action_ids
+
+    @property
+    def resolved_member_actions(self) -> tuple[CommandAction, ...]:
+        return () if self.group is None else self.group.member_actions
 
 
 class CommandOverlayModel:
@@ -30,6 +56,28 @@ class CommandOverlayModel:
         self.pending_action = None
         self.pending_matches = ()
         self.pending_group = None
+        self.pending_execution_intent = None
+
+    def _clear_execution_intent(self):
+        self.pending_execution_intent = None
+
+    def _consume_execution_intent(self):
+        intent = self.pending_execution_intent
+        self.pending_execution_intent = None
+        return intent
+
+    def _bind_execution_intent(self, action: CommandAction):
+        if self.pending_group is not None:
+            self.pending_execution_intent = CommandExecutionIntent(
+                execution_type="group",
+                action=action,
+                group=self.pending_group,
+            )
+            return
+        self.pending_execution_intent = CommandExecutionIntent(
+            execution_type="single",
+            action=action,
+        )
 
     def open(self, *, arm_input: bool = False):
         self.visible = True
@@ -42,6 +90,7 @@ class CommandOverlayModel:
         self.pending_action = None
         self.pending_matches = ()
         self.pending_group = None
+        self._clear_execution_intent()
 
     def close(self):
         self.visible = False
@@ -54,6 +103,7 @@ class CommandOverlayModel:
         self.pending_action = None
         self.pending_matches = ()
         self.pending_group = None
+        self._clear_execution_intent()
 
     def toggle(self):
         if self.visible:
@@ -70,6 +120,7 @@ class CommandOverlayModel:
         self.status_kind = "idle"
         self.status_text = ""
         self.pending_group = None
+        self._clear_execution_intent()
 
     def set_input_text(self, text: str):
         if not self.visible or self.phase != "entry":
@@ -82,6 +133,7 @@ class CommandOverlayModel:
         self.pending_action = None
         self.pending_matches = ()
         self.pending_group = None
+        self._clear_execution_intent()
 
     def set_entry_feedback(self, status_kind: str, status_text: str):
         if not self.visible or self.phase != "entry":
@@ -93,6 +145,7 @@ class CommandOverlayModel:
         self.pending_action = None
         self.pending_matches = ()
         self.pending_group = None
+        self._clear_execution_intent()
 
     def set_action_catalog(self, action_catalog: CommandActionCatalog):
         self.action_catalog = action_catalog
@@ -116,6 +169,7 @@ class CommandOverlayModel:
         self.status_kind = "idle"
         self.status_text = ""
         self.pending_group = None
+        self._clear_execution_intent()
 
     def escape(self):
         if not self.visible:
@@ -130,6 +184,7 @@ class CommandOverlayModel:
             self.pending_action = None
             self.pending_matches = ()
             self.pending_group = None
+            self._clear_execution_intent()
             return "choice_cancelled"
 
         if self.phase == "confirm":
@@ -141,6 +196,7 @@ class CommandOverlayModel:
             self.pending_action = None
             self.pending_matches = ()
             self.pending_group = None
+            self._clear_execution_intent()
             return "confirm_cancelled"
 
         self.close()
@@ -169,6 +225,7 @@ class CommandOverlayModel:
                 self.pending_group = matched_group
                 self.pending_matches = matched_group.member_actions
                 self.pending_action = None
+                self._clear_execution_intent()
                 self.status_kind = "ambiguous"
                 self.status_text = "Choose a member from the matched group."
                 return ("ambiguous", matched_group.member_actions)
@@ -181,11 +238,13 @@ class CommandOverlayModel:
                 self.phase = "confirm"
                 self.input_armed = False
                 self.pending_action = matches[0]
+                self._bind_execution_intent(matches[0])
                 self.status_kind = "ready"
                 self.status_text = ""
                 return ("confirm_ready", matches[0])
 
             self.pending_action = None
+            self._clear_execution_intent()
             if not matches:
                 self.status_kind = "not_found"
                 self.status_text = "No action or alias matched that request."
@@ -197,8 +256,11 @@ class CommandOverlayModel:
             self.status_text = "Press a number key or click the intended action below."
             return ("ambiguous", matches)
 
-        if self.phase == "confirm" and self.pending_action is not None:
-            return ("execute_confirmed", self.pending_action)
+        if self.phase == "confirm":
+            intent = self._consume_execution_intent()
+            if intent is not None:
+                return ("execute_confirmed", intent)
+            return ("ignored", None)
 
         return ("ignored", None)
 
@@ -213,6 +275,7 @@ class CommandOverlayModel:
         self.phase = "confirm"
         self.input_armed = False
         self.pending_action = action
+        self._bind_execution_intent(action)
         self.status_kind = "ready"
         self.status_text = ""
         return ("confirm_ready", action)
@@ -227,6 +290,7 @@ class CommandOverlayModel:
         self.pending_action = None
         self.pending_matches = ()
         self.pending_group = None
+        self._clear_execution_intent()
 
     def _serialize_action(self, action, *, index: int | None = None):
         if action is None:

--- a/desktop/shared_action_model.py
+++ b/desktop/shared_action_model.py
@@ -3,7 +3,7 @@ import re
 import subprocess
 from dataclasses import dataclass
 from pathlib import Path, PureWindowsPath
-from typing import Iterable
+from typing import Callable, Iterable
 from urllib.parse import urlparse, unquote
 
 from .saved_action_source import (
@@ -149,6 +149,17 @@ class SavedGroupInventoryState:
     guidance_text: str = ""
     path: str = ""
     groups: tuple[CommandGroup, ...] = ()
+
+
+@dataclass(frozen=True)
+class CommandGroupExecutionResult:
+    group_id: str
+    step_count: int
+    completed_action_ids: tuple[str, ...] = ()
+    succeeded: bool = False
+    failed_action_id: str = ""
+    failed_step_index: int = 0
+    error: Exception | None = None
 
 
 def format_action_origin_label(origin: str) -> str:
@@ -1097,6 +1108,107 @@ def resolve_command_group(text: str, groups: Iterable[CommandGroup] = ()):
         if any(normalize_command_text(candidate) == normalized for candidate in build_callable_group_phrases(group.aliases)):
             return group
     return None
+
+
+def _emit_group_execution_marker(
+    marker_emitter: Callable[[str, dict[str, str]], None] | None,
+    marker_name: str,
+    **fields: object,
+):
+    if marker_emitter is None:
+        return
+
+    payload: dict[str, str] = {}
+    for key, value in fields.items():
+        if value is None:
+            continue
+        normalized = str(value).strip()
+        if not normalized:
+            continue
+        payload[key] = normalized.replace("|", "/")
+    marker_emitter(marker_name, payload)
+
+
+def execute_command_group(
+    group: CommandGroup,
+    *,
+    action_launcher: Callable[[CommandAction], None],
+    marker_emitter: Callable[[str, dict[str, str]], None] | None = None,
+) -> CommandGroupExecutionResult:
+    member_ids = tuple(group.member_action_ids)
+    member_actions = tuple(group.member_actions)
+    normalized_member_ids = tuple(member_id.casefold() for member_id in member_ids)
+    normalized_action_ids = tuple(action.id.casefold() for action in member_actions)
+
+    if normalized_action_ids != normalized_member_ids:
+        raise ValueError("Callable group execution order is ambiguous.")
+
+    _emit_group_execution_marker(
+        marker_emitter,
+        "GROUP_EXECUTION_STARTED",
+        group_id=group.id,
+        step_count=len(member_actions),
+    )
+
+    completed_action_ids: list[str] = []
+    for step_index, action in enumerate(member_actions, start=1):
+        _emit_group_execution_marker(
+            marker_emitter,
+            "GROUP_EXECUTION_STEP_STARTED",
+            group_id=group.id,
+            step_index=step_index,
+            action_id=action.id,
+        )
+        try:
+            action_launcher(action)
+        except Exception as exc:
+            _emit_group_execution_marker(
+                marker_emitter,
+                "GROUP_EXECUTION_STEP_FAILED",
+                group_id=group.id,
+                step_index=step_index,
+                action_id=action.id,
+                error=exc,
+            )
+            _emit_group_execution_marker(
+                marker_emitter,
+                "GROUP_EXECUTION_FAILED",
+                group_id=group.id,
+                failed_step_index=step_index,
+                failed_action_id=action.id,
+                completed_step_count=len(completed_action_ids),
+            )
+            return CommandGroupExecutionResult(
+                group_id=group.id,
+                step_count=len(member_actions),
+                completed_action_ids=tuple(completed_action_ids),
+                succeeded=False,
+                failed_action_id=action.id,
+                failed_step_index=step_index,
+                error=exc,
+            )
+
+        completed_action_ids.append(action.id)
+        _emit_group_execution_marker(
+            marker_emitter,
+            "GROUP_EXECUTION_STEP_SUCCEEDED",
+            group_id=group.id,
+            step_index=step_index,
+            action_id=action.id,
+        )
+
+    _emit_group_execution_marker(
+        marker_emitter,
+        "GROUP_EXECUTION_COMPLETED",
+        group_id=group.id,
+        step_count=len(member_actions),
+    )
+    return CommandGroupExecutionResult(
+        group_id=group.id,
+        step_count=len(member_actions),
+        completed_action_ids=tuple(completed_action_ids),
+        succeeded=True,
+    )
 
 
 def launch_command_action(action: CommandAction):

--- a/dev/orin_callable_group_execution_interactive_validation.ps1
+++ b/dev/orin_callable_group_execution_interactive_validation.ps1
@@ -1,0 +1,916 @@
+param(
+    [int]$TimeoutSeconds = 12
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = "Stop"
+
+Add-Type -AssemblyName UIAutomationClient
+Add-Type -AssemblyName UIAutomationTypes
+Add-Type -AssemblyName System.Windows.Forms
+Add-Type -AssemblyName System.Drawing
+
+$source = @"
+using System;
+using System.Runtime.InteropServices;
+
+public static class CodexFb041Win32
+{
+    [DllImport("user32.dll")]
+    public static extern void keybd_event(byte bVk, byte bScan, uint dwFlags, UIntPtr dwExtraInfo);
+
+    [DllImport("user32.dll", SetLastError=true)]
+    public static extern bool SetForegroundWindow(IntPtr hWnd);
+
+    [DllImport("user32.dll", SetLastError=true)]
+    public static extern bool ShowWindowAsync(IntPtr hWnd, int nCmdShow);
+
+    [DllImport("user32.dll", SetLastError=true)]
+    public static extern bool SetCursorPos(int X, int Y);
+
+    [DllImport("user32.dll")]
+    public static extern void mouse_event(uint dwFlags, uint dx, uint dy, uint dwData, UIntPtr dwExtraInfo);
+}
+"@
+
+Add-Type -TypeDefinition $source
+
+$RootDir = Split-Path -Parent $PSScriptRoot
+$Stamp = Get-Date -Format "yyyyMMdd_HHmmss"
+$OutputDir = Join-Path $RootDir "dev\logs\fb_041_callable_group_interactive_validation\$Stamp"
+$ReportPath = Join-Path $OutputDir "FB041CallableGroupInteractiveValidationReport_$Stamp.txt"
+$RuntimeLogPath = Join-Path $OutputDir "runtime.log"
+$ManifestPath = Join-Path $OutputDir "manifest.json"
+$SourcePath = Join-Path $env:LOCALAPPDATA "Nexus Desktop AI\saved_actions.json"
+$SourceBackupPath = Join-Path $OutputDir "saved_actions.backup.json"
+
+New-Item -ItemType Directory -Force -Path $OutputDir | Out-Null
+New-Item -ItemType Directory -Force -Path (Split-Path -Parent $SourcePath) | Out-Null
+
+$script:Captures = New-Object System.Collections.Generic.List[object]
+$script:ScenarioResults = New-Object System.Collections.Generic.List[object]
+$script:Notes = New-Object System.Collections.Generic.List[string]
+$script:RuntimeProcess = $null
+
+function Add-Note {
+    param([string]$Message)
+    $script:Notes.Add($Message)
+}
+
+function Add-Capture {
+    param(
+        [string]$Label,
+        [string]$Path
+    )
+
+    $script:Captures.Add([pscustomobject]@{
+            label = $Label
+            path  = $Path
+        })
+}
+
+function Add-ScenarioResult {
+    param(
+        [string]$Name,
+        [bool]$Passed,
+        [string]$Details
+    )
+
+    $script:ScenarioResults.Add([pscustomobject]@{
+            name    = $Name
+            passed  = $Passed
+            details = $Details
+        })
+}
+
+function Wait-Until {
+    param(
+        [scriptblock]$Condition,
+        [string]$Description,
+        [int]$TimeoutSeconds = $TimeoutSeconds
+    )
+
+    $deadline = (Get-Date).AddSeconds($TimeoutSeconds)
+    while ((Get-Date) -lt $deadline) {
+        $result = & $Condition
+        if ($result) {
+            return $result
+        }
+        Start-Sleep -Milliseconds 120
+    }
+
+    throw "Timed out waiting for $Description."
+}
+
+function Get-AllDescendants {
+    param(
+        [System.Windows.Automation.AutomationElement]$Element
+    )
+
+    if (-not $Element) {
+        return @()
+    }
+
+    try {
+        return @(
+            $Element.FindAll(
+                [System.Windows.Automation.TreeScope]::Subtree,
+                [System.Windows.Automation.Condition]::TrueCondition
+            )
+        )
+    } catch {
+        return @()
+    }
+}
+
+function Find-RootWindow {
+    param(
+        [string]$Name = "",
+        [string]$AutomationId = "",
+        [string]$ClassName = ""
+    )
+
+    $children = [System.Windows.Automation.AutomationElement]::RootElement.FindAll(
+        [System.Windows.Automation.TreeScope]::Children,
+        [System.Windows.Automation.Condition]::TrueCondition
+    )
+
+    for ($i = 0; $i -lt $children.Count; $i++) {
+        $window = $children.Item($i)
+        try {
+            if ($Name -and $window.Current.Name -ne $Name) {
+                continue
+            }
+            if ($AutomationId -and $window.Current.AutomationId -ne $AutomationId) {
+                continue
+            }
+            if ($ClassName -and $window.Current.ClassName -ne $ClassName) {
+                continue
+            }
+            if ($window.Current.IsOffscreen) {
+                continue
+            }
+            return $window
+        } catch {
+        }
+    }
+
+    return $null
+}
+
+function Find-ElementByAutomationIdDirect {
+    param(
+        [System.Windows.Automation.AutomationElement]$Root,
+        [string]$AutomationId
+    )
+
+    if (-not $Root -or [string]::IsNullOrWhiteSpace($AutomationId)) {
+        return $null
+    }
+
+    $condition = New-Object System.Windows.Automation.PropertyCondition(
+        [System.Windows.Automation.AutomationElement]::AutomationIdProperty,
+        $AutomationId
+    )
+    return $Root.FindFirst([System.Windows.Automation.TreeScope]::Subtree, $condition)
+}
+
+function Find-ElementByAutomationIdSuffix {
+    param(
+        [System.Windows.Automation.AutomationElement]$Root,
+        [string]$Suffix
+    )
+
+    if (-not $Root -or [string]::IsNullOrWhiteSpace($Suffix)) {
+        return $null
+    }
+
+    foreach ($candidate in (Get-AllDescendants -Element $Root)) {
+        try {
+            $automationId = [string]$candidate.Current.AutomationId
+            if ($automationId -and $automationId.EndsWith($Suffix, [System.StringComparison]::OrdinalIgnoreCase)) {
+                return $candidate
+            }
+        } catch {
+        }
+    }
+
+    return $null
+}
+
+function Find-FirstElementByName {
+    param(
+        [System.Windows.Automation.AutomationElement]$Root,
+        [string]$Name,
+        [System.Windows.Automation.ControlType]$ControlType = $null
+    )
+
+    if (-not $Root -or [string]::IsNullOrWhiteSpace($Name)) {
+        return $null
+    }
+
+    foreach ($candidate in (Get-AllDescendants -Element $Root)) {
+        try {
+            if ($candidate.Current.Name -ne $Name) {
+                continue
+            }
+            if ($null -ne $ControlType -and $candidate.Current.ControlType -ne $ControlType) {
+                continue
+            }
+            return $candidate
+        } catch {
+        }
+    }
+
+    return $null
+}
+
+function Test-ElementUsable {
+    param(
+        [System.Windows.Automation.AutomationElement]$Element,
+        [bool]$RequireEnabled = $true
+    )
+
+    if (-not $Element) {
+        return $false
+    }
+
+    try {
+        if ($Element.Current.IsOffscreen) {
+            return $false
+        }
+        if ($RequireEnabled -and -not $Element.Current.IsEnabled) {
+            return $false
+        }
+        $rect = $Element.Current.BoundingRectangle
+        return ($rect.Width -gt 0 -and $rect.Height -gt 0)
+    } catch {
+        return $false
+    }
+}
+
+function Focus-Element {
+    param(
+        [System.Windows.Automation.AutomationElement]$Element
+    )
+
+    if (-not $Element) {
+        return
+    }
+
+    try {
+        $handle = [int]$Element.Current.NativeWindowHandle
+        if ($handle -gt 0) {
+            [CodexFb041Win32]::ShowWindowAsync([IntPtr]$handle, 5) | Out-Null
+            [CodexFb041Win32]::SetForegroundWindow([IntPtr]$handle) | Out-Null
+        }
+    } catch {
+    }
+
+    try {
+        $Element.SetFocus()
+    } catch {
+    }
+}
+
+function Set-ElementValue {
+    param(
+        [System.Windows.Automation.AutomationElement]$Element,
+        [string]$Value,
+        [string]$Description
+    )
+
+    if (-not $Element) {
+        throw "Missing element for $Description."
+    }
+
+    Focus-Element -Element $Element
+
+    try {
+        $pattern = $Element.GetCurrentPattern([System.Windows.Automation.ValuePattern]::Pattern)
+        $pattern.SetValue($Value)
+        return
+    } catch {
+    }
+
+    throw "Could not set value for $Description."
+}
+
+function Send-VirtualKey {
+    param([byte]$Key)
+    [CodexFb041Win32]::keybd_event($Key, 0, 0, [UIntPtr]::Zero)
+    Start-Sleep -Milliseconds 35
+    [CodexFb041Win32]::keybd_event($Key, 0, 2, [UIntPtr]::Zero)
+}
+
+function Get-RectangleBounds {
+    param(
+        [System.Windows.Automation.AutomationElement]$Element,
+        [int]$Padding = 10
+    )
+
+    $rect = $Element.Current.BoundingRectangle
+    $left = [math]::Max([int]([math]::Floor($rect.Left)) - $Padding, 0)
+    $top = [math]::Max([int]([math]::Floor($rect.Top)) - $Padding, 0)
+    $width = [math]::Max([int]([math]::Ceiling($rect.Width)) + ($Padding * 2), 1)
+    $height = [math]::Max([int]([math]::Ceiling($rect.Height)) + ($Padding * 2), 1)
+    return [pscustomobject]@{
+        Left   = $left
+        Top    = $top
+        Width  = $width
+        Height = $height
+    }
+}
+
+function Capture-ElementScreenshot {
+    param(
+        [System.Windows.Automation.AutomationElement]$Element,
+        [string]$Label,
+        [int]$DelayMs = 220
+    )
+
+    Focus-Element -Element $Element
+    Start-Sleep -Milliseconds $DelayMs
+
+    $bounds = Get-RectangleBounds -Element $Element
+    $bitmap = New-Object System.Drawing.Bitmap $bounds.Width, $bounds.Height
+    $graphics = [System.Drawing.Graphics]::FromImage($bitmap)
+    $graphics.CopyFromScreen($bounds.Left, $bounds.Top, 0, 0, $bitmap.Size)
+    $path = Join-Path $OutputDir ($Label + ".png")
+    $bitmap.Save($path, [System.Drawing.Imaging.ImageFormat]::Png)
+    $graphics.Dispose()
+    $bitmap.Dispose()
+    Add-Capture -Label $Label -Path $path
+    return $path
+}
+
+function Get-ElementReadableText {
+    param(
+        [System.Windows.Automation.AutomationElement]$Element
+    )
+
+    if (-not $Element) {
+        return ""
+    }
+
+    try {
+        $pattern = $Element.GetCurrentPattern([System.Windows.Automation.ValuePattern]::Pattern)
+        if ($pattern) {
+            return [string]$pattern.Current.Value
+        }
+    } catch {
+    }
+
+    try {
+        return [string]$Element.Current.Name
+    } catch {
+        return ""
+    }
+}
+
+function Get-RuntimeLogLineCount {
+    if (-not (Test-Path -LiteralPath $RuntimeLogPath)) {
+        return 0
+    }
+    return @(Get-Content -LiteralPath $RuntimeLogPath).Count
+}
+
+function Get-RuntimeLinesSince {
+    param([int]$StartLine = 0)
+
+    if (-not (Test-Path -LiteralPath $RuntimeLogPath)) {
+        return @()
+    }
+
+    $lines = @(Get-Content -LiteralPath $RuntimeLogPath)
+    if ($lines.Count -le $StartLine) {
+        return @()
+    }
+    return @($lines | Select-Object -Skip $StartLine)
+}
+
+function Wait-ForRuntimeMarker {
+    param(
+        [string]$Marker,
+        [int]$StartLine = 0,
+        [int]$TimeoutSeconds = 12
+    )
+
+    return (Wait-Until -TimeoutSeconds $TimeoutSeconds -Description "runtime marker $Marker" -Condition {
+            foreach ($line in (Get-RuntimeLinesSince -StartLine $StartLine)) {
+                if ($line -like "*$Marker*") {
+                    return $line
+                }
+            }
+            return $null
+        })
+}
+
+function Stop-RuntimeHelper {
+    if ($script:RuntimeProcess) {
+        try {
+            Stop-Process -Id $script:RuntimeProcess.Id -Force -ErrorAction Stop
+        } catch {
+        }
+        $script:RuntimeProcess = $null
+        Start-Sleep -Milliseconds 350
+    }
+}
+
+function Start-RuntimeHelper {
+    Stop-RuntimeHelper
+
+    $python = (Get-Command python).Source
+    if (-not $python) {
+        throw "Could not resolve python executable for the interactive runtime helper."
+    }
+
+    if (Test-Path -LiteralPath $RuntimeLogPath) {
+        Remove-Item -LiteralPath $RuntimeLogPath -Force -ErrorAction SilentlyContinue
+    }
+
+    $argString = "dev\\orin_saved_action_authoring_interactive_runtime.py --runtime-log `"$RuntimeLogPath`" --auto-open-overlay"
+    $previousOverlayTrace = $env:NEXUS_OVERLAY_TRACE
+    $env:NEXUS_OVERLAY_TRACE = "1"
+    try {
+        $process = Start-Process -FilePath $python -ArgumentList $argString -WorkingDirectory $RootDir -PassThru -WindowStyle Hidden
+    } finally {
+        $env:NEXUS_OVERLAY_TRACE = $previousOverlayTrace
+    }
+
+    $script:RuntimeProcess = $process
+
+    Wait-Until -TimeoutSeconds 20 -Description "runtime log creation" -Condition {
+        Test-Path -LiteralPath $RuntimeLogPath
+    } | Out-Null
+
+    Wait-ForRuntimeMarker -Marker "RENDERER_MAIN|STARTUP_READY" -TimeoutSeconds 25 | Out-Null
+    Wait-ForRuntimeMarker -Marker "RENDERER_MAIN|DESKTOP_ATTACH_RESULT|success=true" -TimeoutSeconds 25 | Out-Null
+}
+
+function Get-OverlayWindow {
+    $overlay = Find-RootWindow -AutomationId "QApplication.commandOverlayWindow" -ClassName "CommandOverlayPanel"
+    if ($overlay) {
+        return $overlay
+    }
+    return $null
+}
+
+function Get-OverlayInput {
+    param([System.Windows.Automation.AutomationElement]$Overlay)
+    return Find-ElementByAutomationIdSuffix -Root $Overlay -Suffix "commandInputLine"
+}
+
+function Open-Overlay {
+    Start-RuntimeHelper
+
+    try {
+        Wait-ForRuntimeMarker -Marker "RENDERER_MAIN|INTERACTIVE_VALIDATION_AUTO_OPENED" -TimeoutSeconds 6 | Out-Null
+    } catch {
+    }
+
+    Wait-ForRuntimeMarker -Marker "RENDERER_MAIN|COMMAND_OVERLAY_READY" -TimeoutSeconds 8 | Out-Null
+    return (Wait-Until -TimeoutSeconds ([Math]::Max(4, $TimeoutSeconds)) -Description "overlay window" -Condition {
+            $overlay = Get-OverlayWindow
+            if (-not $overlay) {
+                return $null
+            }
+            $input = Get-OverlayInput -Overlay $overlay
+            if ($input -and (Test-ElementUsable -Element $input)) {
+                return $overlay
+            }
+            return $null
+        })
+}
+
+function Resolve-OverlayInput {
+    param([System.Windows.Automation.AutomationElement]$Overlay)
+    return (Wait-Until -Description "overlay input" -Condition {
+            $liveOverlay = Get-OverlayWindow
+            if (-not $liveOverlay) {
+                return $null
+            }
+            $input = Get-OverlayInput -Overlay $liveOverlay
+            if ($input -and (Test-ElementUsable -Element $input)) {
+                return $input
+            }
+            return $null
+        })
+}
+
+function Close-WindowByEsc {
+    param([System.Windows.Automation.AutomationElement]$Window)
+    Focus-Element -Element $Window
+    Send-VirtualKey -Key 0x1B
+    Start-Sleep -Milliseconds 220
+}
+
+function Backup-Source {
+    if (Test-Path -LiteralPath $SourcePath) {
+        Copy-Item -LiteralPath $SourcePath -Destination $SourceBackupPath -Force
+    }
+}
+
+function Restore-Source {
+    if (Test-Path -LiteralPath $SourceBackupPath) {
+        Copy-Item -LiteralPath $SourceBackupPath -Destination $SourcePath -Force
+    } elseif (Test-Path -LiteralPath $SourcePath) {
+        Remove-Item -LiteralPath $SourcePath -Force -ErrorAction SilentlyContinue
+    }
+}
+
+function Seed-Fb041Source {
+    $payload = [ordered]@{
+        schema_version = 1
+        actions        = @(
+            [ordered]@{
+                id              = "workspace_docs_folder"
+                title           = "Open Workspace Docs"
+                target_kind     = "folder"
+                target          = "C:\Nexus Desktop AI\Docs"
+                aliases         = @("workspace docs")
+                invocation_mode = "aliases_only"
+                trigger_mode    = "open"
+            },
+            [ordered]@{
+                id              = "open_notes_task"
+                title           = "Open Notes Task"
+                target_kind     = "app"
+                target          = "notepad.exe"
+                aliases         = @("notes task")
+                invocation_mode = "aliases_only"
+                trigger_mode    = "launch"
+            },
+            [ordered]@{
+                id              = "broken_notes_task"
+                title           = "Broken Notes Task"
+                target_kind     = "app"
+                target          = "C:\definitely_missing\does_not_exist.exe"
+                aliases         = @("broken notes")
+                invocation_mode = "aliases_only"
+                trigger_mode    = "launch"
+            }
+        )
+        groups         = @(
+            [ordered]@{
+                id                = "workspace_tools"
+                title             = "Workspace Tools"
+                aliases           = @("workspace tools")
+                member_action_ids = @("workspace_docs_folder", "open_notes_task")
+            },
+            [ordered]@{
+                id                = "broken_workspace_tools"
+                title             = "Broken Workspace Tools"
+                aliases           = @("broken workspace tools")
+                member_action_ids = @("broken_notes_task", "open_notes_task")
+            }
+        )
+    }
+
+    $json = ($payload | ConvertTo-Json -Depth 8) + "`n"
+    $encoding = New-Object System.Text.UTF8Encoding($false)
+    [System.IO.File]::WriteAllText($SourcePath, $json, $encoding)
+}
+
+function Get-NotepadProcessIds {
+    return @(
+        Get-CimInstance Win32_Process -ErrorAction SilentlyContinue |
+            Where-Object { $_.Name -eq "notepad.exe" } |
+            Select-Object -ExpandProperty ProcessId
+    )
+}
+
+function Wait-ForNewNotepadProcess {
+    param(
+        [int[]]$BaselineIds,
+        [int]$TimeoutSeconds = 8
+    )
+
+    return (Wait-Until -TimeoutSeconds $TimeoutSeconds -Description "new Notepad process" -Condition {
+            $newIds = @((Get-NotepadProcessIds) | Where-Object { $BaselineIds -notcontains $_ })
+            if ($newIds.Count -gt 0) {
+                return $newIds
+            }
+            return $null
+        })
+}
+
+function Stop-NewNotepadProcesses {
+    param([int[]]$BaselineIds)
+
+    $newIds = @((Get-NotepadProcessIds) | Where-Object { $BaselineIds -notcontains $_ })
+    foreach ($id in $newIds) {
+        try {
+            Stop-Process -Id $id -Force -ErrorAction Stop
+        } catch {
+        }
+    }
+}
+
+function Get-OverlayTextByAutomationIdSuffix {
+    param(
+        [System.Windows.Automation.AutomationElement]$Overlay,
+        [string]$Suffix
+    )
+
+    $element = Find-ElementByAutomationIdSuffix -Root $Overlay -Suffix $Suffix
+    return (Get-ElementReadableText -Element $element).Trim()
+}
+
+function Wait-ForOverlayStatusTextExact {
+    param(
+        [System.Windows.Automation.AutomationElement]$Overlay,
+        [string]$Expected
+    )
+
+    return (Wait-Until -Description "status text '$Expected'" -Condition {
+            $liveOverlay = Get-OverlayWindow
+            if (-not $liveOverlay) {
+                return $null
+            }
+            $text = Get-OverlayTextByAutomationIdSuffix -Overlay $liveOverlay -Suffix "commandStatus"
+            if ($text -eq $Expected) {
+                return $text
+            }
+            return $null
+        })
+}
+
+function Wait-ForOverlayStatusTextPrefix {
+    param(
+        [System.Windows.Automation.AutomationElement]$Overlay,
+        [string]$Prefix
+    )
+
+    return (Wait-Until -Description "status text prefix '$Prefix'" -Condition {
+            $liveOverlay = Get-OverlayWindow
+            if (-not $liveOverlay) {
+                return $null
+            }
+            $text = Get-OverlayTextByAutomationIdSuffix -Overlay $liveOverlay -Suffix "commandStatus"
+            if ($text.StartsWith($Prefix, [System.StringComparison]::Ordinal)) {
+                return $text
+            }
+            return $null
+        })
+}
+
+function Wait-ForOverlayHintText {
+    param(
+        [System.Windows.Automation.AutomationElement]$Overlay,
+        [string]$Expected
+    )
+
+    return (Wait-Until -Description "hint text '$Expected'" -Condition {
+            $liveOverlay = Get-OverlayWindow
+            if (-not $liveOverlay) {
+                return $null
+            }
+            $text = Get-OverlayTextByAutomationIdSuffix -Overlay $liveOverlay -Suffix "commandHint"
+            if ($text -eq $Expected) {
+                return $text
+            }
+            return $null
+        })
+}
+
+function Wait-ForTextPresence {
+    param(
+        [System.Windows.Automation.AutomationElement]$Root,
+        [string]$Text,
+        [int]$TimeoutSeconds = 6
+    )
+
+    return (Wait-Until -TimeoutSeconds $TimeoutSeconds -Description "text '$Text'" -Condition {
+            $liveRoot = Get-OverlayWindow
+            if (-not $liveRoot) {
+                return $null
+            }
+            $element = Find-FirstElementByName -Root $liveRoot -Name $Text
+            if ($element) {
+                return $element
+            }
+            return $null
+        })
+}
+
+function Assert-RuntimeMarkerOrder {
+    param(
+        [string[]]$Lines,
+        [string[]]$Markers
+    )
+
+    $lastIndex = -1
+    foreach ($marker in $Markers) {
+        $index = -1
+        for ($i = 0; $i -lt $Lines.Count; $i++) {
+            if ($Lines[$i] -like "*$marker*") {
+                $index = $i
+                break
+            }
+        }
+        if ($index -lt 0) {
+            throw "Missing runtime marker '$marker'."
+        }
+        if ($index -le $lastIndex) {
+            throw "Runtime marker '$marker' did not appear after the prior marker."
+        }
+        $lastIndex = $index
+    }
+}
+
+function Run-GroupSuccessScenario {
+    Seed-Fb041Source
+    $baselineNotepadIds = @(Get-NotepadProcessIds)
+    $overlay = Open-Overlay
+    $overlayInput = Resolve-OverlayInput -Overlay $overlay
+
+    $markerStart = Get-RuntimeLogLineCount
+    Set-ElementValue -Element $overlayInput -Value "workspace tools" -Description "group success invocation"
+    Send-VirtualKey -Key 0x0D
+    Wait-ForRuntimeMarker -Marker "RENDERER_MAIN|COMMAND_AMBIGUOUS|count=2" -StartLine $markerStart -TimeoutSeconds 6 | Out-Null
+
+    Focus-Element -Element $overlay
+    Start-Sleep -Milliseconds 180
+    $markerStart = Get-RuntimeLogLineCount
+    Send-VirtualKey -Key 0x32
+    Wait-ForRuntimeMarker -Marker "RENDERER_MAIN|COMMAND_CONFIRM_READY|action_id=open_notes_task" -StartLine $markerStart -TimeoutSeconds 6 | Out-Null
+
+    $expectedGroupHint = 'Review the selected member details below. Press Enter to run "Workspace Tools" group in stored order.'
+    $expectedGroupHelp = 'Press Enter to run "Workspace Tools" group in stored order, or Esc to return.'
+    Wait-ForOverlayHintText -Overlay $overlay -Expected $expectedGroupHint | Out-Null
+    Wait-ForTextPresence -Root $overlay -Text "Selected member" | Out-Null
+    Wait-ForTextPresence -Root $overlay -Text $expectedGroupHelp | Out-Null
+    Wait-ForTextPresence -Root $overlay -Text "Open Notes Task" | Out-Null
+    Capture-ElementScreenshot -Element $overlay -Label "group_success_confirm" | Out-Null
+
+    $markerStart = Get-RuntimeLogLineCount
+    Focus-Element -Element $overlay
+    Send-VirtualKey -Key 0x0D
+    Wait-ForRuntimeMarker -Marker "RENDERER_MAIN|GROUP_EXECUTION_COMPLETED|group_id=workspace_tools" -StartLine $markerStart -TimeoutSeconds 10 | Out-Null
+    $resultText = Wait-ForOverlayStatusTextExact -Overlay $overlay -Expected 'Group "Workspace Tools" executed in stored order.'
+    $hintText = Wait-ForOverlayHintText -Overlay $overlay -Expected "Returning to passive desktop mode."
+    Capture-ElementScreenshot -Element $overlay -Label "group_success_result" | Out-Null
+
+    $newNotepad = @(Wait-ForNewNotepadProcess -BaselineIds $baselineNotepadIds -TimeoutSeconds 8)
+    $runtimeLines = @(Get-RuntimeLinesSince -StartLine $markerStart)
+    Assert-RuntimeMarkerOrder -Lines $runtimeLines -Markers @(
+        "RENDERER_MAIN|GROUP_EXECUTION_STARTED|group_id=workspace_tools",
+        "RENDERER_MAIN|GROUP_EXECUTION_STEP_STARTED|group_id=workspace_tools|step_index=1|action_id=workspace_docs_folder",
+        "RENDERER_MAIN|GROUP_EXECUTION_STEP_SUCCEEDED|group_id=workspace_tools|step_index=1|action_id=workspace_docs_folder",
+        "RENDERER_MAIN|GROUP_EXECUTION_STEP_STARTED|group_id=workspace_tools|step_index=2|action_id=open_notes_task",
+        "RENDERER_MAIN|GROUP_EXECUTION_STEP_SUCCEEDED|group_id=workspace_tools|step_index=2|action_id=open_notes_task",
+        "RENDERER_MAIN|GROUP_EXECUTION_COMPLETED|group_id=workspace_tools"
+    )
+    Stop-NewNotepadProcesses -BaselineIds $baselineNotepadIds
+    Stop-RuntimeHelper
+
+    Add-ScenarioResult -Name "group_success" -Passed $true -Details (
+        "Real launched-process group execution ran Workspace Tools in stored order after the confirm surface kept Open Notes Task as inspection context. " +
+        "Result text was '$resultText', hint remained '$hintText', and a real Notepad process launched."
+    )
+}
+
+function Run-GroupFailureScenario {
+    Seed-Fb041Source
+    $baselineNotepadIds = @(Get-NotepadProcessIds)
+    $overlay = Open-Overlay
+    $overlayInput = Resolve-OverlayInput -Overlay $overlay
+
+    $markerStart = Get-RuntimeLogLineCount
+    Set-ElementValue -Element $overlayInput -Value "broken workspace tools" -Description "group failure invocation"
+    Send-VirtualKey -Key 0x0D
+    Wait-ForRuntimeMarker -Marker "RENDERER_MAIN|COMMAND_AMBIGUOUS|count=2" -StartLine $markerStart -TimeoutSeconds 6 | Out-Null
+
+    Focus-Element -Element $overlay
+    Start-Sleep -Milliseconds 180
+    $markerStart = Get-RuntimeLogLineCount
+    Send-VirtualKey -Key 0x32
+    Wait-ForRuntimeMarker -Marker "RENDERER_MAIN|COMMAND_CONFIRM_READY|action_id=open_notes_task" -StartLine $markerStart -TimeoutSeconds 6 | Out-Null
+
+    $markerStart = Get-RuntimeLogLineCount
+    Focus-Element -Element $overlay
+    Send-VirtualKey -Key 0x0D
+    Wait-ForRuntimeMarker -Marker "RENDERER_MAIN|GROUP_EXECUTION_FAILED|group_id=broken_workspace_tools" -StartLine $markerStart -TimeoutSeconds 10 | Out-Null
+    $resultText = Wait-ForOverlayStatusTextPrefix -Overlay $overlay -Prefix 'Group "Broken Workspace Tools" failed at step 1:'
+    $hintText = Wait-ForOverlayHintText -Overlay $overlay -Expected "Returning to passive desktop mode."
+    Capture-ElementScreenshot -Element $overlay -Label "group_failure_result" | Out-Null
+
+    $runtimeLines = @(Get-RuntimeLinesSince -StartLine $markerStart)
+    Assert-RuntimeMarkerOrder -Lines $runtimeLines -Markers @(
+        "RENDERER_MAIN|GROUP_EXECUTION_STARTED|group_id=broken_workspace_tools",
+        "RENDERER_MAIN|GROUP_EXECUTION_STEP_STARTED|group_id=broken_workspace_tools|step_index=1|action_id=broken_notes_task",
+        "RENDERER_MAIN|GROUP_EXECUTION_STEP_FAILED|group_id=broken_workspace_tools|step_index=1|action_id=broken_notes_task",
+        "RENDERER_MAIN|GROUP_EXECUTION_FAILED|group_id=broken_workspace_tools"
+    )
+    foreach ($line in $runtimeLines) {
+        if ($line -like "*GROUP_EXECUTION_STEP_STARTED*group_id=broken_workspace_tools*action_id=open_notes_task*") {
+            throw "Failure scenario unexpectedly started a later member after the first failure."
+        }
+    }
+
+    $newNotepad = @((Get-NotepadProcessIds) | Where-Object { $baselineNotepadIds -notcontains $_ })
+    if ($newNotepad.Count -gt 0) {
+        throw "Failure scenario unexpectedly launched Notepad."
+    }
+
+    Stop-RuntimeHelper
+    Add-ScenarioResult -Name "group_failure" -Passed $true -Details (
+        "Real launched-process group execution failed on Broken Workspace Tools step 1 without starting later members. " +
+        "Result text began with '$resultText' and the result hint remained '$hintText'."
+    )
+}
+
+function Run-SingleActionAuditScenario {
+    Seed-Fb041Source
+    $baselineNotepadIds = @(Get-NotepadProcessIds)
+    $overlay = Open-Overlay
+    $overlayInput = Resolve-OverlayInput -Overlay $overlay
+
+    $markerStart = Get-RuntimeLogLineCount
+    Set-ElementValue -Element $overlayInput -Value "notes task" -Description "single action invocation"
+    Send-VirtualKey -Key 0x0D
+    Wait-ForRuntimeMarker -Marker "RENDERER_MAIN|COMMAND_CONFIRM_READY|action_id=open_notes_task" -StartLine $markerStart -TimeoutSeconds 6 | Out-Null
+
+    $expectedSingleHint = "Review the resolved action origin and destination before execution."
+    $expectedSingleHelp = "Press Enter to confirm or Esc to return."
+    Wait-ForOverlayHintText -Overlay $overlay -Expected $expectedSingleHint | Out-Null
+    Wait-ForTextPresence -Root $overlay -Text "Resolved action" | Out-Null
+    Wait-ForTextPresence -Root $overlay -Text $expectedSingleHelp | Out-Null
+    Capture-ElementScreenshot -Element $overlay -Label "single_action_confirm" | Out-Null
+
+    $markerStart = Get-RuntimeLogLineCount
+    Focus-Element -Element $overlay
+    Send-VirtualKey -Key 0x0D
+    Wait-ForRuntimeMarker -Marker "RENDERER_MAIN|COMMAND_LAUNCH_REQUEST_SENT|action_id=open_notes_task" -StartLine $markerStart -TimeoutSeconds 8 | Out-Null
+    $resultText = Wait-ForOverlayStatusTextExact -Overlay $overlay -Expected "Launch request sent."
+    $hintText = Wait-ForOverlayHintText -Overlay $overlay -Expected "Returning to passive desktop mode."
+    Capture-ElementScreenshot -Element $overlay -Label "single_action_result" | Out-Null
+
+    $newNotepad = @(Wait-ForNewNotepadProcess -BaselineIds $baselineNotepadIds -TimeoutSeconds 8)
+    Stop-NewNotepadProcesses -BaselineIds $baselineNotepadIds
+    Stop-RuntimeHelper
+
+    Add-ScenarioResult -Name "single_action_audit" -Passed $true -Details (
+        "Single-action confirm and result surfaces stayed unchanged: confirm hint '$expectedSingleHint', result text '$resultText', hint '$hintText'."
+    )
+}
+
+try {
+    Backup-Source
+    Seed-Fb041Source
+
+    Run-GroupSuccessScenario
+    Run-GroupFailureScenario
+    Run-SingleActionAuditScenario
+} catch {
+    Add-ScenarioResult -Name "interactive_validation_failure" -Passed $false -Details $_.Exception.Message
+    throw
+} finally {
+    Stop-NewNotepadProcesses -BaselineIds @()
+    Stop-RuntimeHelper
+    Restore-Source
+}
+
+$reportLines = @()
+$reportLines += "FB-041 Callable Group Interactive Validation Report"
+$reportLines += "stamp: $Stamp"
+$reportLines += "output_dir: $OutputDir"
+$reportLines += "runtime_log: $RuntimeLogPath"
+$reportLines += ""
+$reportLines += "Scenarios:"
+foreach ($scenario in $script:ScenarioResults) {
+    $status = if ($scenario.passed) { "PASS" } else { "FAIL" }
+    $reportLines += "  $status :: $($scenario.name)"
+    $reportLines += "    $($scenario.details)"
+}
+$reportLines += ""
+$reportLines += "Captures:"
+foreach ($capture in $script:Captures) {
+    $reportLines += "  - $($capture.label): $($capture.path)"
+}
+if ($script:Notes.Count -gt 0) {
+    $reportLines += ""
+    $reportLines += "Notes:"
+    foreach ($note in $script:Notes) {
+        $reportLines += "  - $note"
+    }
+}
+
+Set-Content -LiteralPath $ReportPath -Value $reportLines -Encoding utf8
+
+$manifest = [pscustomobject]@{
+    report_path       = $ReportPath
+    runtime_log_path  = $RuntimeLogPath
+    captures          = $script:Captures
+    scenarios         = $script:ScenarioResults
+    notes             = $script:Notes
+}
+$manifest | ConvertTo-Json -Depth 8 | Set-Content -LiteralPath $ManifestPath -Encoding utf8
+
+$hasFailures = @($script:ScenarioResults | Where-Object { -not $_.passed }).Count -gt 0
+if ($hasFailures) {
+    throw "FB-041 interactive validation recorded one or more failed scenarios. See $ReportPath"
+}
+
+Write-Output $ReportPath

--- a/dev/orin_callable_group_execution_validation.py
+++ b/dev/orin_callable_group_execution_validation.py
@@ -1,0 +1,417 @@
+import os
+import sys
+import tempfile
+from pathlib import Path
+from types import SimpleNamespace
+
+
+CURRENT_DIR = Path(__file__).resolve().parent
+ROOT_DIR = CURRENT_DIR.parent
+
+if str(ROOT_DIR) not in sys.path:
+    sys.path.insert(0, str(ROOT_DIR))
+
+import desktop.desktop_renderer as renderer_mod
+from desktop.interaction_overlay_model import CommandOverlayModel
+from desktop.saved_action_authoring import (
+    CallableGroupDraft,
+    SavedActionDraft,
+    create_callable_group_from_draft,
+    create_saved_action_from_draft,
+)
+from desktop.shared_action_model import (
+    CommandGroup,
+    build_default_command_action_catalog,
+    execute_command_group,
+)
+
+
+def _assert(condition, message):
+    if not condition:
+        raise AssertionError(message)
+
+
+def _make_group(source_path: Path):
+    create_saved_action_from_draft(
+        SavedActionDraft(
+            title="Open Reports",
+            target_kind="folder",
+            target=r"C:\Reports",
+            aliases=("show reports",),
+        ),
+        source_path,
+    )
+    create_saved_action_from_draft(
+        SavedActionDraft(
+            title="Open Notes",
+            target_kind="app",
+            target="notepad.exe",
+            aliases=("notes",),
+        ),
+        source_path,
+    )
+    create_callable_group_from_draft(
+        CallableGroupDraft(
+            title="Workspace Tools",
+            aliases=("workspace tools",),
+            member_action_ids=("open_reports", "open_saved_actions_folder", "open_notes"),
+        ),
+        source_path,
+    )
+    catalog = build_default_command_action_catalog(source_path)
+    group = catalog.resolve_group("workspace tools")
+    _assert(group is not None, "callable-group execution validation should resolve the created group")
+    return group
+
+
+def _make_window():
+    window = SimpleNamespace(_events=[])
+    window._log_event = lambda event: window._events.append(event)
+    window._emit_group_execution_marker = lambda marker_name, fields: renderer_mod.DesktopRuntimeWindow._emit_group_execution_marker(
+        window,
+        marker_name,
+        fields,
+    )
+    return window
+
+
+def _make_dispatch_window(source_path: Path):
+    window = SimpleNamespace(_events=[], _shown_results=[], _cleared_launch_failure_action_ids=[])
+    window._command_model = CommandOverlayModel(action_catalog=build_default_command_action_catalog(source_path))
+    window._command_model.open(arm_input=True)
+    window._overlay_local_input_engaged = False
+    window._foreground_window_snapshot = lambda: {"hwnd": 0, "class_name": "", "title": ""}
+    window._trace_overlay = lambda *_args, **_kwargs: None
+    window._apply_command_overlay_state = lambda: None
+    window._refresh_overlay_input_capture = lambda *_args, **_kwargs: None
+    window._log_event = lambda event: window._events.append(event)
+    window._prepare_recoverable_launch_failure_report = lambda _action: None
+
+    def _show_command_result(status_kind: str, status_text: str, close_delay_ms: int = 1200):
+        del close_delay_ms
+        window._shown_results.append((status_kind, status_text))
+        window._command_model.show_result(status_kind, status_text)
+
+    def _clear_launch_failure_tracking(action_id: str):
+        window._cleared_launch_failure_action_ids.append(action_id)
+
+    window._show_command_result = _show_command_result
+    window._clear_launch_failure_tracking = _clear_launch_failure_tracking
+    window._emit_group_execution_marker = lambda marker_name, fields: renderer_mod.DesktopRuntimeWindow._emit_group_execution_marker(
+        window,
+        marker_name,
+        fields,
+    )
+    window._execute_callable_group = lambda group: renderer_mod.DesktopRuntimeWindow._execute_callable_group(window, group)
+    return window
+
+
+def _group_events(window):
+    return [event for event in window._events if event.startswith("RENDERER_MAIN|GROUP_EXECUTION_")]
+
+
+def _parse_group_event(event: str):
+    parts = event.split("|")
+    marker_name = parts[1] if len(parts) > 1 else ""
+    fields = {}
+    for part in parts[2:]:
+        if "=" not in part:
+            continue
+        key, value = part.split("=", 1)
+        fields[key] = value
+    return marker_name, fields
+
+
+def _test_group_execution_runs_in_persisted_order_with_gap_free_markers():
+    with tempfile.TemporaryDirectory() as temp_dir:
+        source_path = Path(temp_dir) / "saved_actions.json"
+        group = _make_group(source_path)
+        window = _make_window()
+
+        original_launch = renderer_mod.launch_command_action
+        launched_action_ids = []
+        renderer_mod.launch_command_action = lambda action: launched_action_ids.append(action.id)
+        try:
+            result = renderer_mod.DesktopRuntimeWindow._execute_callable_group(window, group)
+        finally:
+            renderer_mod.launch_command_action = original_launch
+
+        _assert(result.succeeded, "group execution should succeed when every step launcher succeeds")
+        _assert(
+            result.completed_action_ids == group.member_action_ids,
+            "successful group execution should report every completed action id in persisted stored order",
+        )
+        _assert(
+            launched_action_ids == list(group.member_action_ids),
+            "group execution should launch member actions exactly in persisted stored order",
+        )
+
+        parsed_events = [_parse_group_event(event) for event in _group_events(window)]
+        marker_names = [marker_name for marker_name, _fields in parsed_events]
+        _assert(
+            marker_names
+            == [
+                "GROUP_EXECUTION_STARTED",
+                "GROUP_EXECUTION_STEP_STARTED",
+                "GROUP_EXECUTION_STEP_SUCCEEDED",
+                "GROUP_EXECUTION_STEP_STARTED",
+                "GROUP_EXECUTION_STEP_SUCCEEDED",
+                "GROUP_EXECUTION_STEP_STARTED",
+                "GROUP_EXECUTION_STEP_SUCCEEDED",
+                "GROUP_EXECUTION_COMPLETED",
+            ],
+            "group execution should emit deterministic start, per-step, and completion markers",
+        )
+
+        started_steps = [fields for marker_name, fields in parsed_events if marker_name == "GROUP_EXECUTION_STEP_STARTED"]
+        completed_steps = [fields for marker_name, fields in parsed_events if marker_name == "GROUP_EXECUTION_STEP_SUCCEEDED"]
+        _assert(
+            [int(fields["step_index"]) for fields in started_steps] == [1, 2, 3],
+            "step-start markers should advance monotonically without gaps",
+        )
+        _assert(
+            [fields["action_id"] for fields in started_steps] == list(group.member_action_ids),
+            "step-start markers should reflect persisted member ids in order",
+        )
+        _assert(
+            [int(fields["step_index"]) for fields in completed_steps] == [1, 2, 3],
+            "step-success markers should advance monotonically without gaps",
+        )
+
+
+def _test_group_execution_stops_on_first_failure_and_reports_terminal_failure():
+    with tempfile.TemporaryDirectory() as temp_dir:
+        source_path = Path(temp_dir) / "saved_actions.json"
+        group = _make_group(source_path)
+        window = _make_window()
+
+        original_launch = renderer_mod.launch_command_action
+        launched_action_ids = []
+
+        def _failing_launcher(action):
+            launched_action_ids.append(action.id)
+            if action.id == "open_saved_actions_folder":
+                raise RuntimeError("expected failure")
+
+        renderer_mod.launch_command_action = _failing_launcher
+        try:
+            result = renderer_mod.DesktopRuntimeWindow._execute_callable_group(window, group)
+        finally:
+            renderer_mod.launch_command_action = original_launch
+
+        _assert(not result.succeeded, "group execution should fail when a member launcher raises")
+        _assert(
+            result.completed_action_ids == ("open_reports",),
+            "group execution should report only the successfully completed prefix before failure",
+        )
+        _assert(
+            result.failed_action_id == "open_saved_actions_folder" and result.failed_step_index == 2,
+            "group execution should surface the exact failed member id and step index",
+        )
+        _assert(
+            launched_action_ids == ["open_reports", "open_saved_actions_folder"],
+            "group execution should stop immediately after the first failed member",
+        )
+
+        parsed_events = [_parse_group_event(event) for event in _group_events(window)]
+        marker_names = [marker_name for marker_name, _fields in parsed_events]
+        _assert(
+            marker_names
+            == [
+                "GROUP_EXECUTION_STARTED",
+                "GROUP_EXECUTION_STEP_STARTED",
+                "GROUP_EXECUTION_STEP_SUCCEEDED",
+                "GROUP_EXECUTION_STEP_STARTED",
+                "GROUP_EXECUTION_STEP_FAILED",
+                "GROUP_EXECUTION_FAILED",
+            ],
+            "group execution should emit a terminal failure marker immediately after the failed step",
+        )
+        started_steps = [fields for marker_name, fields in parsed_events if marker_name == "GROUP_EXECUTION_STEP_STARTED"]
+        _assert(
+            [int(fields["step_index"]) for fields in started_steps] == [1, 2],
+            "group execution should not emit later step markers after the first failure",
+        )
+
+
+def _test_group_execution_rejects_ambiguous_member_order():
+    with tempfile.TemporaryDirectory() as temp_dir:
+        source_path = Path(temp_dir) / "saved_actions.json"
+        group = _make_group(source_path)
+        ambiguous_group = CommandGroup(
+            id="ambiguous_workspace_tools",
+            title="Ambiguous Workspace Tools",
+            aliases=("ambiguous workspace tools",),
+            member_action_ids=("open_saved_actions_folder", "open_reports"),
+            member_actions=(
+                group.member_actions[0],
+                group.member_actions[1],
+            ),
+        )
+
+        try:
+            execute_command_group(
+                ambiguous_group,
+                action_launcher=lambda _action: None,
+            )
+        except ValueError as exc:
+            _assert(
+                "ambiguous" in str(exc).casefold(),
+                "ambiguous member ordering should fail with an explicit ambiguity error",
+            )
+        else:
+            raise AssertionError("group execution should reject ambiguous member ordering before any launch")
+
+
+def _test_dispatch_routes_group_execution_without_double_launch():
+    with tempfile.TemporaryDirectory() as temp_dir:
+        source_path = Path(temp_dir) / "saved_actions.json"
+        group = _make_group(source_path)
+        window = _make_dispatch_window(source_path)
+
+        original_launch = renderer_mod.launch_command_action
+        launched_action_ids = []
+        renderer_mod.launch_command_action = lambda action: launched_action_ids.append(action.id)
+        try:
+            window._command_model.set_input_text("workspace tools")
+            renderer_mod.DesktopRuntimeWindow.handle_command_submit(window)
+            match_ids = [match.get("id") for match in window._command_model.view_payload().get("ambiguous_matches") or []]
+            selected_index = match_ids.index("open_saved_actions_folder")
+            renderer_mod.DesktopRuntimeWindow.handle_ambiguous_match_selected(window, selected_index)
+            renderer_mod.DesktopRuntimeWindow.handle_command_submit(window)
+        finally:
+            renderer_mod.launch_command_action = original_launch
+
+        _assert(
+            launched_action_ids == list(group.member_action_ids),
+            "dispatch integration should route group execution through the deterministic helper in persisted order",
+        )
+        _assert(
+            window._shown_results[-1][0] == "launch_requested",
+            "successful group dispatch should preserve the existing launch-requested result surface",
+        )
+        _assert(
+            any("COMMAND_GROUP_EXECUTION_COMPLETED|group_id=workspace_tools|step_count=3" in event for event in window._events),
+            "dispatch integration should log explicit group completion after deterministic execution",
+        )
+        _assert(
+            not any("COMMAND_LAUNCH_REQUEST_SENT|action_id=open_saved_actions_folder" in event for event in window._events),
+            "group dispatch should not fall back into the single-action launch path after helper execution",
+        )
+        parsed_group_events = [_parse_group_event(event) for event in _group_events(window)]
+        _assert(
+            [marker_name for marker_name, _fields in parsed_group_events][-1] == "GROUP_EXECUTION_COMPLETED",
+            "group dispatch should emit terminal group markers only through the deterministic helper",
+        )
+
+
+def _test_dispatch_preserves_single_action_execution_path():
+    with tempfile.TemporaryDirectory() as temp_dir:
+        source_path = Path(temp_dir) / "saved_actions.json"
+        _make_group(source_path)
+        window = _make_dispatch_window(source_path)
+
+        original_launch = renderer_mod.launch_command_action
+        launched_action_ids = []
+        renderer_mod.launch_command_action = lambda action: launched_action_ids.append(action.id)
+        try:
+            window._command_model.set_input_text("show reports")
+            renderer_mod.DesktopRuntimeWindow.handle_command_submit(window)
+            renderer_mod.DesktopRuntimeWindow.handle_command_submit(window)
+        finally:
+            renderer_mod.launch_command_action = original_launch
+
+        _assert(
+            launched_action_ids == ["open_reports"],
+            "single-action dispatch should still execute through the original launch path only once",
+        )
+        _assert(
+            any("COMMAND_LAUNCH_REQUEST_SENT|action_id=open_reports" in event for event in window._events),
+            "single-action dispatch should preserve the existing launch-request marker",
+        )
+        _assert(
+            not _group_events(window),
+            "single-action dispatch should not emit group execution markers",
+        )
+
+
+def _test_dispatch_group_failure_stops_without_later_execution():
+    with tempfile.TemporaryDirectory() as temp_dir:
+        source_path = Path(temp_dir) / "saved_actions.json"
+        _make_group(source_path)
+        window = _make_dispatch_window(source_path)
+
+        original_launch = renderer_mod.launch_command_action
+        launched_action_ids = []
+
+        def _failing_launcher(action):
+            launched_action_ids.append(action.id)
+            if action.id == "open_saved_actions_folder":
+                raise RuntimeError("expected failure")
+
+        renderer_mod.launch_command_action = _failing_launcher
+        try:
+            window._command_model.set_input_text("workspace tools")
+            renderer_mod.DesktopRuntimeWindow.handle_command_submit(window)
+            renderer_mod.DesktopRuntimeWindow.handle_ambiguous_match_selected(window, 0)
+            renderer_mod.DesktopRuntimeWindow.handle_command_submit(window)
+        finally:
+            renderer_mod.launch_command_action = original_launch
+
+        _assert(
+            launched_action_ids == ["open_reports", "open_saved_actions_folder"],
+            "group dispatch should stop immediately after the first failed member and never launch later steps",
+        )
+        _assert(
+            window._shown_results[-1][0] == "launch_failed",
+            "group dispatch failure should preserve the existing launch-failed result surface",
+        )
+        _assert(
+            any("GROUP_EXECUTION_STEP_FAILED" in event for event in _group_events(window))
+            and any("GROUP_EXECUTION_FAILED" in event for event in _group_events(window)),
+            "group dispatch failure should emit deterministic step-failure and terminal-failure markers",
+        )
+        _assert(
+            not any("COMMAND_LAUNCH_REQUEST_SENT|action_id=" in event for event in window._events),
+            "failed group dispatch should not emit single-action launch success markers",
+        )
+
+
+def main():
+    tests = [
+        (
+            "group execution runs in persisted order with gap-free markers",
+            _test_group_execution_runs_in_persisted_order_with_gap_free_markers,
+        ),
+        (
+            "group execution stops on first failure",
+            _test_group_execution_stops_on_first_failure_and_reports_terminal_failure,
+        ),
+        (
+            "group execution rejects ambiguous member order",
+            _test_group_execution_rejects_ambiguous_member_order,
+        ),
+        (
+            "dispatch routes group execution without double launch",
+            _test_dispatch_routes_group_execution_without_double_launch,
+        ),
+        (
+            "dispatch preserves single-action execution path",
+            _test_dispatch_preserves_single_action_execution_path,
+        ),
+        (
+            "dispatch group failure stops without later execution",
+            _test_dispatch_group_failure_stops_without_later_execution,
+        ),
+    ]
+
+    for name, fn in tests:
+        fn()
+        print(f"PASS: {name}")
+
+    print("CALLABLE GROUP EXECUTION VALIDATION: PASS")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/dev/orin_callable_group_execution_validation.py
+++ b/dev/orin_callable_group_execution_validation.py
@@ -31,7 +31,12 @@ def _assert(condition, message):
         raise AssertionError(message)
 
 
-def _make_group(source_path: Path):
+def _make_group(
+    source_path: Path,
+    *,
+    group_title: str = "Workspace Tools",
+    group_aliases: tuple[str, ...] = ("workspace tools",),
+):
     create_saved_action_from_draft(
         SavedActionDraft(
             title="Open Reports",
@@ -52,14 +57,14 @@ def _make_group(source_path: Path):
     )
     create_callable_group_from_draft(
         CallableGroupDraft(
-            title="Workspace Tools",
-            aliases=("workspace tools",),
+            title=group_title,
+            aliases=group_aliases,
             member_action_ids=("open_reports", "open_saved_actions_folder", "open_notes"),
         ),
         source_path,
     )
     catalog = build_default_command_action_catalog(source_path)
-    group = catalog.resolve_group("workspace tools")
+    group = catalog.resolve_group(group_aliases[0])
     _assert(group is not None, "callable-group execution validation should resolve the created group")
     return group
 
@@ -76,7 +81,12 @@ def _make_window():
 
 
 def _make_dispatch_window(source_path: Path):
-    window = SimpleNamespace(_events=[], _shown_results=[], _cleared_launch_failure_action_ids=[])
+    window = SimpleNamespace(
+        _events=[],
+        _shown_results=[],
+        _cleared_launch_failure_action_ids=[],
+        _prepare_calls=[],
+    )
     window._command_model = CommandOverlayModel(action_catalog=build_default_command_action_catalog(source_path))
     window._command_model.open(arm_input=True)
     window._overlay_local_input_engaged = False
@@ -85,7 +95,34 @@ def _make_dispatch_window(source_path: Path):
     window._apply_command_overlay_state = lambda: None
     window._refresh_overlay_input_capture = lambda *_args, **_kwargs: None
     window._log_event = lambda event: window._events.append(event)
-    window._prepare_recoverable_launch_failure_report = lambda _action: None
+    window._bound_execution_trace = lambda execution_trace, *, fallback_action_id="": renderer_mod.DesktopRuntimeWindow._bound_execution_trace(
+        window,
+        execution_trace,
+        fallback_action_id=fallback_action_id,
+    )
+    window._normalize_launch_failure_context = (
+        lambda action_id, failure_context=None: renderer_mod.DesktopRuntimeWindow._normalize_launch_failure_context(
+            window,
+            action_id,
+            failure_context,
+        )
+    )
+    def _prepare_recoverable_launch_failure_report(action, *, failure_context=None):
+        normalized_failure_context = renderer_mod.DesktopRuntimeWindow._normalize_launch_failure_context(
+            window,
+            action.id,
+            failure_context,
+        )
+        window._prepare_calls.append(
+            {
+                "action_id": action.id,
+                "failure_context": dict(failure_context or {}),
+                "normalized_failure_context": dict(normalized_failure_context),
+            }
+        )
+        return None
+
+    window._prepare_recoverable_launch_failure_report = _prepare_recoverable_launch_failure_report
 
     def _show_command_result(status_kind: str, status_text: str, close_delay_ms: int = 1200):
         del close_delay_ms
@@ -97,13 +134,43 @@ def _make_dispatch_window(source_path: Path):
 
     window._show_command_result = _show_command_result
     window._clear_launch_failure_tracking = _clear_launch_failure_tracking
+    window._format_failure_context_suffix = lambda failure_context: renderer_mod.DesktopRuntimeWindow._format_failure_context_suffix(
+        window,
+        failure_context,
+    )
+    window._classify_recoverable_launch_failed_incident = (
+        lambda action_id, failure_count, *, failure_context=None: renderer_mod.DesktopRuntimeWindow._classify_recoverable_launch_failed_incident(
+            window,
+            action_id,
+            failure_count,
+            failure_context=failure_context,
+        )
+    )
     window._emit_group_execution_marker = lambda marker_name, fields: renderer_mod.DesktopRuntimeWindow._emit_group_execution_marker(
         window,
         marker_name,
         fields,
     )
+    window._resolve_group_failure_action = lambda group, failed_action_id: renderer_mod.DesktopRuntimeWindow._resolve_group_failure_action(
+        window,
+        group,
+        failed_action_id,
+    )
+    window._build_group_failure_context = lambda group, result: renderer_mod.DesktopRuntimeWindow._build_group_failure_context(
+        window,
+        group,
+        result,
+    )
     window._execute_callable_group = lambda group: renderer_mod.DesktopRuntimeWindow._execute_callable_group(window, group)
     return window
+
+
+def _freeze_result_state(window):
+    def _show_command_result(status_kind: str, status_text: str, close_delay_ms: int = 1200):
+        del close_delay_ms
+        window._shown_results.append((status_kind, status_text))
+
+    window._show_command_result = _show_command_result
 
 
 def _group_events(window):
@@ -120,6 +187,132 @@ def _parse_group_event(event: str):
         key, value = part.split("=", 1)
         fields[key] = value
     return marker_name, fields
+
+
+def _test_result_hint_text_remains_unchanged():
+    renderer_source = (ROOT_DIR / "desktop" / "desktop_renderer.py").read_text(encoding="utf-8").replace("\r\n", "\n")
+    _assert(
+        'elif phase == "result":\n            self.hint_label.setText("Returning to passive desktop mode.")' in renderer_source,
+        "result hint text should remain unchanged",
+    )
+
+
+def _test_group_result_text_uses_execution_intent_group_name():
+    with tempfile.TemporaryDirectory() as temp_dir:
+        source_path = Path(temp_dir) / "saved_actions.json"
+        group = _make_group(
+            source_path,
+            group_title="Alpha Toolchain",
+            group_aliases=("alpha toolchain",),
+        )
+        window = _make_dispatch_window(source_path)
+
+        original_launch = renderer_mod.launch_command_action
+        renderer_mod.launch_command_action = lambda _action: None
+        try:
+            window._command_model.set_input_text("alpha toolchain")
+            renderer_mod.DesktopRuntimeWindow.handle_command_submit(window)
+            renderer_mod.DesktopRuntimeWindow.handle_ambiguous_match_selected(window, 0)
+            intent = window._command_model.pending_execution_intent
+            _assert(intent is not None, "group confirm should bind an execution intent before dispatch")
+            _assert(
+                intent.group is not None and intent.group.title == "Alpha Toolchain",
+                "group execution intent should carry the selected group's title",
+            )
+            renderer_mod.DesktopRuntimeWindow.handle_command_submit(window)
+        finally:
+            renderer_mod.launch_command_action = original_launch
+
+        _assert(
+            window._shown_results[-1] == ("launch_requested", 'Group "Alpha Toolchain" executed in stored order.'),
+            "group success result text should use the execution intent group title",
+        )
+        _assert(
+            group.title == "Alpha Toolchain",
+            "the validation fixture should preserve the expected group title for comparison",
+        )
+
+
+def _test_group_result_text_is_stable_under_overlay_mutation():
+    with tempfile.TemporaryDirectory() as temp_dir:
+        source_path = Path(temp_dir) / "saved_actions.json"
+        group = _make_group(source_path)
+        window = _make_dispatch_window(source_path)
+
+        original_launch = renderer_mod.launch_command_action
+        renderer_mod.launch_command_action = lambda _action: None
+        try:
+            window._command_model.set_input_text("workspace tools")
+            renderer_mod.DesktopRuntimeWindow.handle_command_submit(window)
+            renderer_mod.DesktopRuntimeWindow.handle_ambiguous_match_selected(window, 0)
+            intent = window._command_model.pending_execution_intent
+            _assert(intent is not None and intent.group is not None, "group confirm should bind an execution intent before dispatch")
+            window._command_model.pending_group = CommandGroup(
+                id="wrong_overlay_group",
+                title="Wrong Overlay Name",
+                aliases=("wrong overlay name",),
+                member_action_ids=group.member_action_ids,
+                member_actions=group.member_actions,
+            )
+            renderer_mod.DesktopRuntimeWindow.handle_command_submit(window)
+        finally:
+            renderer_mod.launch_command_action = original_launch
+
+        shown_status = window._shown_results[-1][1]
+        _assert(
+            shown_status == 'Group "Workspace Tools" executed in stored order.',
+            "result text should remain bound to the execution intent group title after overlay mutation",
+        )
+        _assert(
+            "Wrong Overlay Name" not in shown_status,
+            "overlay pending_group mutation should not change the group name shown in result text",
+        )
+
+
+def _test_group_result_text_is_not_hardcoded():
+    with tempfile.TemporaryDirectory() as first_dir, tempfile.TemporaryDirectory() as second_dir:
+        first_source_path = Path(first_dir) / "saved_actions.json"
+        second_source_path = Path(second_dir) / "saved_actions.json"
+        _make_group(
+            first_source_path,
+            group_title="Alpha Toolchain",
+            group_aliases=("alpha toolchain",),
+        )
+        _make_group(
+            second_source_path,
+            group_title="Beta Utilities",
+            group_aliases=("beta utilities",),
+        )
+        first_window = _make_dispatch_window(first_source_path)
+        second_window = _make_dispatch_window(second_source_path)
+
+        original_launch = renderer_mod.launch_command_action
+        renderer_mod.launch_command_action = lambda _action: None
+        try:
+            first_window._command_model.set_input_text("alpha toolchain")
+            renderer_mod.DesktopRuntimeWindow.handle_command_submit(first_window)
+            renderer_mod.DesktopRuntimeWindow.handle_ambiguous_match_selected(first_window, 0)
+            renderer_mod.DesktopRuntimeWindow.handle_command_submit(first_window)
+
+            second_window._command_model.set_input_text("beta utilities")
+            renderer_mod.DesktopRuntimeWindow.handle_command_submit(second_window)
+            renderer_mod.DesktopRuntimeWindow.handle_ambiguous_match_selected(second_window, 0)
+            renderer_mod.DesktopRuntimeWindow.handle_command_submit(second_window)
+        finally:
+            renderer_mod.launch_command_action = original_launch
+
+        _assert(
+            first_window._shown_results[-1] == ("launch_requested", 'Group "Alpha Toolchain" executed in stored order.'),
+            "first group result text should use its own dynamic title",
+        )
+        _assert(
+            second_window._shown_results[-1] == ("launch_requested", 'Group "Beta Utilities" executed in stored order.'),
+            "second group result text should use its own dynamic title",
+        )
+        _assert(
+            first_window._shown_results[-1][1] != second_window._shown_results[-1][1],
+            "group result text should vary with the executed group's title rather than a fixed string",
+        )
 
 
 def _test_group_execution_runs_in_persisted_order_with_gap_free_markers():
@@ -263,6 +456,136 @@ def _test_group_execution_rejects_ambiguous_member_order():
             raise AssertionError("group execution should reject ambiguous member ordering before any launch")
 
 
+def _test_group_execution_intent_is_consumed_once_before_dispatch():
+    with tempfile.TemporaryDirectory() as temp_dir:
+        source_path = Path(temp_dir) / "saved_actions.json"
+        group = _make_group(source_path)
+        model = CommandOverlayModel(action_catalog=build_default_command_action_catalog(source_path))
+        model.open(arm_input=True)
+        model.set_input_text("workspace tools")
+
+        result, payload = model.submit()
+        _assert(result == "ambiguous", "group input should still enter choose before confirm")
+        _assert(payload == group.member_actions, "group choose payload should expose the resolved member actions")
+
+        result, payload = model.choose_match(1)
+        _assert(result == "confirm_ready", "group member selection should enter confirm")
+        _assert(payload.id == "open_saved_actions_folder", "chosen member should remain the confirm payload")
+        _assert(model.pending_execution_intent is not None, "confirm should bind a group execution intent")
+
+        result, payload = model.submit()
+        _assert(result == "execute_confirmed", "first confirm submit should consume the bound group intent")
+        _assert(
+            payload.execution_type == "group"
+            and payload.group_id == "workspace_tools"
+            and payload.action_id == "open_saved_actions_folder"
+            and payload.resolved_member_action_ids == group.member_action_ids,
+            "consumed group intent should preserve execution type, selected action, group id, and stored member order",
+        )
+        _assert(model.pending_execution_intent is None, "group execution intent should clear immediately after the first submit")
+
+        result, payload = model.submit()
+        _assert(
+            result == "ignored" and payload is None,
+            "a second confirm submit must not be able to reuse the already-consumed group intent",
+        )
+
+
+def _test_single_execution_intent_is_consumed_once_before_dispatch():
+    with tempfile.TemporaryDirectory() as temp_dir:
+        source_path = Path(temp_dir) / "saved_actions.json"
+        _make_group(source_path)
+        model = CommandOverlayModel(action_catalog=build_default_command_action_catalog(source_path))
+        model.open(arm_input=True)
+        model.set_input_text("show reports")
+
+        result, payload = model.submit()
+        _assert(result == "confirm_ready", "exact single-action input should enter confirm")
+        _assert(payload.id == "open_reports", "single-action confirm payload should preserve the matched action")
+        _assert(model.pending_execution_intent is not None, "single-action confirm should bind an execution intent")
+
+        result, payload = model.submit()
+        _assert(result == "execute_confirmed", "first confirm submit should consume the single-action intent")
+        _assert(
+            payload.execution_type == "single"
+            and payload.action_id == "open_reports"
+            and payload.group_id == ""
+            and payload.resolved_member_action_ids == (),
+            "consumed single-action intent should remain single-scoped without group metadata",
+        )
+        _assert(model.pending_execution_intent is None, "single-action intent should clear immediately after the first submit")
+
+        result, payload = model.submit()
+        _assert(
+            result == "ignored" and payload is None,
+            "a second confirm submit must not be able to reuse the already-consumed single-action intent",
+        )
+
+
+def _test_execution_intent_clears_on_cancel_and_reset():
+    with tempfile.TemporaryDirectory() as temp_dir:
+        source_path = Path(temp_dir) / "saved_actions.json"
+        _make_group(source_path)
+        model = CommandOverlayModel(action_catalog=build_default_command_action_catalog(source_path))
+        model.open(arm_input=True)
+
+        model.set_input_text("show reports")
+        result, _payload = model.submit()
+        _assert(result == "confirm_ready", "single-action setup should reach confirm before cancel testing")
+        _assert(model.pending_execution_intent is not None, "confirm should bind intent before cancellation")
+        _assert(model.escape() == "confirm_cancelled", "escape from confirm should cancel the pending execution")
+        _assert(model.pending_execution_intent is None, "confirm cancel should clear any pending execution intent")
+
+        model.set_input_text("show reports")
+        result, _payload = model.submit()
+        _assert(result == "confirm_ready", "single-action setup should reach confirm before reset testing")
+        _assert(model.pending_execution_intent is not None, "confirm should bind intent before reset testing")
+        model.show_result("launch_requested", "Launch request sent.")
+        _assert(model.pending_execution_intent is None, "result transitions should clear any pending execution intent")
+
+        model.open(arm_input=True)
+        model.set_input_text("show reports")
+        result, _payload = model.submit()
+        _assert(result == "confirm_ready", "single-action setup should reach confirm before close testing")
+        _assert(model.pending_execution_intent is not None, "confirm should bind intent before close testing")
+        model.close()
+        _assert(model.pending_execution_intent is None, "overlay close should clear any pending execution intent")
+
+
+def _test_confirm_surface_copy_is_group_aware_only_for_group_context():
+    window = SimpleNamespace()
+
+    group_copy = renderer_mod.CommandOverlayPanel._build_confirm_surface_copy(
+        window,
+        "group",
+        {"title": "Workspace Tools"},
+    )
+    _assert(
+        group_copy
+        == {
+            "title_label": "Selected member",
+            "hint_text": 'Review the selected member details below. Press Enter to run "Workspace Tools" group in stored order.',
+            "help_text": 'Press Enter to run "Workspace Tools" group in stored order, or Esc to return.',
+        },
+        "group confirm surface copy should clarify that Enter runs the full group in stored order while the selected member stays inspection context",
+    )
+
+    single_copy = renderer_mod.CommandOverlayPanel._build_confirm_surface_copy(
+        window,
+        "",
+        {},
+    )
+    _assert(
+        single_copy
+        == {
+            "title_label": "Resolved action",
+            "hint_text": "Review the resolved action origin and destination before execution.",
+            "help_text": "Press Enter to confirm or Esc to return.",
+        },
+        "single-action confirm surface copy should remain unchanged",
+    )
+
+
 def _test_dispatch_routes_group_execution_without_double_launch():
     with tempfile.TemporaryDirectory() as temp_dir:
         source_path = Path(temp_dir) / "saved_actions.json"
@@ -278,17 +601,46 @@ def _test_dispatch_routes_group_execution_without_double_launch():
             match_ids = [match.get("id") for match in window._command_model.view_payload().get("ambiguous_matches") or []]
             selected_index = match_ids.index("open_saved_actions_folder")
             renderer_mod.DesktopRuntimeWindow.handle_ambiguous_match_selected(window, selected_index)
+            intent = window._command_model.pending_execution_intent
+            _assert(intent is not None, "group chooser selection should bind an execution intent before dispatch")
+            _assert(
+                intent.execution_type == "group"
+                and intent.group_id == "workspace_tools"
+                and intent.action_id == "open_saved_actions_folder"
+                and intent.resolved_member_action_ids == group.member_action_ids,
+                "group execution intent should capture execution type, selected action id, group id, and resolved member order",
+            )
+            window._command_model.pending_group = None
+            window._command_model.pending_action = None
             renderer_mod.DesktopRuntimeWindow.handle_command_submit(window)
         finally:
             renderer_mod.launch_command_action = original_launch
 
+        expected_status_text = 'Group "Workspace Tools" executed in stored order.'
         _assert(
             launched_action_ids == list(group.member_action_ids),
             "dispatch integration should route group execution through the deterministic helper in persisted order",
         )
         _assert(
-            window._shown_results[-1][0] == "launch_requested",
-            "successful group dispatch should preserve the existing launch-requested result surface",
+            window._shown_results[-1] == ("launch_requested", expected_status_text),
+            "successful group dispatch should emit group-aware success result text",
+        )
+        _assert(
+            window._prepare_calls == [],
+            "successful group dispatch should not populate any recoverable failure payloads",
+        )
+        _assert(
+            len(window._shown_results) == 1,
+            "successful group dispatch should emit exactly one result event",
+        )
+        result_payload = window._command_model.view_payload()
+        _assert(
+            result_payload["phase"] == "result"
+            and result_payload["status_text"] == expected_status_text
+            and result_payload["pending_action"] is None
+            and result_payload["pending_group"] is None
+            and result_payload["selection_context"] == "",
+            "successful group dispatch should not retain confirm payload or group context beyond status text",
         )
         _assert(
             any("COMMAND_GROUP_EXECUTION_COMPLETED|group_id=workspace_tools|step_count=3" in event for event in window._events),
@@ -317,6 +669,16 @@ def _test_dispatch_preserves_single_action_execution_path():
         try:
             window._command_model.set_input_text("show reports")
             renderer_mod.DesktopRuntimeWindow.handle_command_submit(window)
+            intent = window._command_model.pending_execution_intent
+            _assert(intent is not None, "single-action confirm should bind an execution intent before dispatch")
+            _assert(
+                intent.execution_type == "single"
+                and intent.action_id == "open_reports"
+                and not intent.group_id
+                and intent.resolved_member_action_ids == (),
+                "single-action execution intent should stay single-scoped without group metadata",
+            )
+            window._command_model.pending_group = object()
             renderer_mod.DesktopRuntimeWindow.handle_command_submit(window)
         finally:
             renderer_mod.launch_command_action = original_launch
@@ -326,12 +688,97 @@ def _test_dispatch_preserves_single_action_execution_path():
             "single-action dispatch should still execute through the original launch path only once",
         )
         _assert(
+            window._shown_results[-1] == ("launch_requested", "Launch request sent."),
+            "single-action dispatch should preserve the exact existing result copy",
+        )
+        _assert(
             any("COMMAND_LAUNCH_REQUEST_SENT|action_id=open_reports" in event for event in window._events),
             "single-action dispatch should preserve the existing launch-request marker",
         )
         _assert(
             not _group_events(window),
             "single-action dispatch should not emit group execution markers",
+        )
+        _assert(
+            window._prepare_calls == [],
+            "successful single-action dispatch should not populate any recoverable failure payloads",
+        )
+
+
+def _test_dispatch_does_not_reuse_consumed_group_intent_on_success():
+    with tempfile.TemporaryDirectory() as temp_dir:
+        source_path = Path(temp_dir) / "saved_actions.json"
+        group = _make_group(source_path)
+        window = _make_dispatch_window(source_path)
+        _freeze_result_state(window)
+
+        original_launch = renderer_mod.launch_command_action
+        launched_action_ids = []
+        renderer_mod.launch_command_action = lambda action: launched_action_ids.append(action.id)
+        try:
+            window._command_model.set_input_text("workspace tools")
+            renderer_mod.DesktopRuntimeWindow.handle_command_submit(window)
+            renderer_mod.DesktopRuntimeWindow.handle_ambiguous_match_selected(window, 0)
+            renderer_mod.DesktopRuntimeWindow.handle_command_submit(window)
+            _assert(
+                window._command_model.phase == "confirm" and window._command_model.pending_execution_intent is None,
+                "group intent should be gone immediately after dispatch even if the confirm surface is still present",
+            )
+            renderer_mod.DesktopRuntimeWindow.handle_command_submit(window)
+        finally:
+            renderer_mod.launch_command_action = original_launch
+
+        _assert(
+            launched_action_ids == list(group.member_action_ids),
+            "repeated dispatch attempts must not replay a successfully consumed group intent",
+        )
+        _assert(
+            len([event for event in window._events if "COMMAND_EXECUTION_REQUESTED|" in event]) == 1,
+            "group success should emit only one execution-request event for a single consumed intent",
+        )
+        _assert(
+            len(window._shown_results) == 1,
+            "group success should surface only one result when the same confirm cycle is submitted twice",
+        )
+
+
+def _test_dispatch_does_not_reuse_consumed_single_intent_on_success():
+    with tempfile.TemporaryDirectory() as temp_dir:
+        source_path = Path(temp_dir) / "saved_actions.json"
+        _make_group(source_path)
+        window = _make_dispatch_window(source_path)
+        _freeze_result_state(window)
+
+        original_launch = renderer_mod.launch_command_action
+        launched_action_ids = []
+        renderer_mod.launch_command_action = lambda action: launched_action_ids.append(action.id)
+        try:
+            window._command_model.set_input_text("show reports")
+            renderer_mod.DesktopRuntimeWindow.handle_command_submit(window)
+            _assert(
+                window._command_model.pending_execution_intent is not None,
+                "single-action confirm should bind intent before the first execution dispatch",
+            )
+            renderer_mod.DesktopRuntimeWindow.handle_command_submit(window)
+            _assert(
+                window._command_model.phase == "confirm" and window._command_model.pending_execution_intent is None,
+                "single-action intent should be gone immediately after dispatch even if the confirm surface is still present",
+            )
+            renderer_mod.DesktopRuntimeWindow.handle_command_submit(window)
+        finally:
+            renderer_mod.launch_command_action = original_launch
+
+        _assert(
+            launched_action_ids == ["open_reports"],
+            "repeated dispatch attempts must not replay a successfully consumed single-action intent",
+        )
+        _assert(
+            len([event for event in window._events if "COMMAND_EXECUTION_REQUESTED|" in event]) == 1,
+            "single-action success should emit only one execution-request event for a single consumed intent",
+        )
+        _assert(
+            len(window._shown_results) == 1,
+            "single-action success should surface only one result when the same confirm cycle is submitted twice",
         )
 
 
@@ -340,6 +787,7 @@ def _test_dispatch_group_failure_stops_without_later_execution():
         source_path = Path(temp_dir) / "saved_actions.json"
         _make_group(source_path)
         window = _make_dispatch_window(source_path)
+        _freeze_result_state(window)
 
         original_launch = renderer_mod.launch_command_action
         launched_action_ids = []
@@ -354,6 +802,12 @@ def _test_dispatch_group_failure_stops_without_later_execution():
             window._command_model.set_input_text("workspace tools")
             renderer_mod.DesktopRuntimeWindow.handle_command_submit(window)
             renderer_mod.DesktopRuntimeWindow.handle_ambiguous_match_selected(window, 0)
+            window._command_model.pending_group = None
+            renderer_mod.DesktopRuntimeWindow.handle_command_submit(window)
+            _assert(
+                window._command_model.phase == "confirm" and window._command_model.pending_execution_intent is None,
+                "group failure should still consume the execution intent before failure handling completes",
+            )
             renderer_mod.DesktopRuntimeWindow.handle_command_submit(window)
         finally:
             renderer_mod.launch_command_action = original_launch
@@ -363,8 +817,49 @@ def _test_dispatch_group_failure_stops_without_later_execution():
             "group dispatch should stop immediately after the first failed member and never launch later steps",
         )
         _assert(
-            window._shown_results[-1][0] == "launch_failed",
-            "group dispatch failure should preserve the existing launch-failed result surface",
+            len(window._prepare_calls) == 1,
+            "group dispatch failure should call the shared recoverable failure helper exactly once",
+        )
+        _assert(
+            window._prepare_calls[0]["action_id"] == "open_saved_actions_folder",
+            "group dispatch failure should reuse the shared helper with the failing member action id",
+        )
+        _assert(
+            window._prepare_calls[0]["failure_context"]
+            == {
+                "execution_type": "group",
+                "group_id": "workspace_tools",
+                "failed_action_id": "open_saved_actions_folder",
+                "step_index": "2",
+                "error_type": "launch_exception",
+                "execution_trace": "open_reports>open_saved_actions_folder",
+            },
+            "group dispatch failure should pass the complete structured group payload into the shared helper",
+        )
+        _assert(
+            window._prepare_calls[0]["normalized_failure_context"]
+            == {
+                "execution_type": "group",
+                "failed_action_id": "open_saved_actions_folder",
+                "group_id": "workspace_tools",
+                "step_index": "2",
+                "error_type": "launch_exception",
+                "execution_trace": "open_reports>open_saved_actions_folder",
+            },
+            "group dispatch failure should preserve the complete normalized group payload through the shared helper pipeline",
+        )
+        expected_status_text = 'Group "Workspace Tools" failed at step 2: expected failure'
+        _assert(
+            window._shown_results[-1] == ("launch_failed", expected_status_text),
+            "group dispatch fallback failure should emit group-aware failure result text",
+        )
+        _assert(
+            len([event for event in window._events if "COMMAND_GROUP_EXECUTION_FAILED|" in event]) == 1,
+            "group dispatch should emit exactly one explicit group failure event",
+        )
+        _assert(
+            len(window._shown_results) == 1,
+            "failed group dispatch should emit exactly one result event",
         )
         _assert(
             any("GROUP_EXECUTION_STEP_FAILED" in event for event in _group_events(window))
@@ -372,13 +867,91 @@ def _test_dispatch_group_failure_stops_without_later_execution():
             "group dispatch failure should emit deterministic step-failure and terminal-failure markers",
         )
         _assert(
-            not any("COMMAND_LAUNCH_REQUEST_SENT|action_id=" in event for event in window._events),
-            "failed group dispatch should not emit single-action launch success markers",
+            not any("COMMAND_LAUNCH_REQUEST_SENT|action_id=" in event for event in window._events)
+            and not any("COMMAND_LAUNCH_FAILED|action_id=" in event for event in window._events),
+            "failed group dispatch should not emit single-action launch success or failure events",
+        )
+
+
+def _test_single_action_failure_behavior_remains_unchanged():
+    with tempfile.TemporaryDirectory() as temp_dir:
+        source_path = Path(temp_dir) / "saved_actions.json"
+        _make_group(source_path)
+        window = _make_dispatch_window(source_path)
+        _freeze_result_state(window)
+
+        original_launch = renderer_mod.launch_command_action
+
+        def _failing_launcher(_action):
+            raise RuntimeError("expected single failure")
+
+        renderer_mod.launch_command_action = _failing_launcher
+        try:
+            window._command_model.set_input_text("show reports")
+            renderer_mod.DesktopRuntimeWindow.handle_command_submit(window)
+            _assert(
+                window._command_model.pending_execution_intent is not None,
+                "single-action confirm should bind intent before the failure-path dispatch",
+            )
+            renderer_mod.DesktopRuntimeWindow.handle_command_submit(window)
+            _assert(
+                window._command_model.phase == "confirm" and window._command_model.pending_execution_intent is None,
+                "single-action failure should still consume the execution intent before failure handling completes",
+            )
+            renderer_mod.DesktopRuntimeWindow.handle_command_submit(window)
+        finally:
+            renderer_mod.launch_command_action = original_launch
+
+        _assert(
+            len(window._prepare_calls) == 1
+            and window._prepare_calls[0]["action_id"] == "open_reports"
+            and window._prepare_calls[0]["failure_context"] == {},
+            "single-action failure dispatch should remain unchanged at the caller boundary",
+        )
+        _assert(
+            window._prepare_calls[0]["normalized_failure_context"]
+            == {
+                "execution_type": "single",
+                "action_id": "open_reports",
+                "group_id": "",
+                "step_index": "",
+                "error_type": "launch_exception",
+                "execution_trace": "open_reports",
+            },
+            "single-action failure should normalize into the same structured payload schema inside the shared helper pipeline",
+        )
+        _assert(
+            any("COMMAND_LAUNCH_FAILED|action_id=open_reports" in event for event in window._events),
+            "single-action failure behavior should preserve the existing single-action failure event",
+        )
+        _assert(
+            not any("COMMAND_GROUP_EXECUTION_FAILED|" in event for event in window._events),
+            "single-action failure behavior should not emit group failure events",
+        )
+        _assert(
+            window._shown_results[-1] == ("launch_failed", "Launch failed: expected single failure"),
+            "single-action failure should preserve the exact existing failure result copy",
         )
 
 
 def main():
     tests = [
+        (
+            "result hint text remains unchanged",
+            _test_result_hint_text_remains_unchanged,
+        ),
+        (
+            "group result text uses execution intent group name",
+            _test_group_result_text_uses_execution_intent_group_name,
+        ),
+        (
+            "group result text is stable under overlay mutation",
+            _test_group_result_text_is_stable_under_overlay_mutation,
+        ),
+        (
+            "group result text is not hardcoded",
+            _test_group_result_text_is_not_hardcoded,
+        ),
         (
             "group execution runs in persisted order with gap-free markers",
             _test_group_execution_runs_in_persisted_order_with_gap_free_markers,
@@ -392,6 +965,22 @@ def main():
             _test_group_execution_rejects_ambiguous_member_order,
         ),
         (
+            "group execution intent is consumed once before dispatch",
+            _test_group_execution_intent_is_consumed_once_before_dispatch,
+        ),
+        (
+            "single execution intent is consumed once before dispatch",
+            _test_single_execution_intent_is_consumed_once_before_dispatch,
+        ),
+        (
+            "execution intent clears on cancel and reset",
+            _test_execution_intent_clears_on_cancel_and_reset,
+        ),
+        (
+            "confirm surface copy is group-aware only for group context",
+            _test_confirm_surface_copy_is_group_aware_only_for_group_context,
+        ),
+        (
             "dispatch routes group execution without double launch",
             _test_dispatch_routes_group_execution_without_double_launch,
         ),
@@ -400,8 +989,20 @@ def main():
             _test_dispatch_preserves_single_action_execution_path,
         ),
         (
+            "dispatch does not reuse consumed group intent on success",
+            _test_dispatch_does_not_reuse_consumed_group_intent_on_success,
+        ),
+        (
+            "dispatch does not reuse consumed single intent on success",
+            _test_dispatch_does_not_reuse_consumed_single_intent_on_success,
+        ),
+        (
             "dispatch group failure stops without later execution",
             _test_dispatch_group_failure_stops_without_later_execution,
+        ),
+        (
+            "single-action failure behavior remains unchanged",
+            _test_single_action_failure_behavior_remains_unchanged,
         ),
     ]
 


### PR DESCRIPTION
## Summary

Completes FB-041 with deterministic stored-order callable-group execution and full execution alignment across dispatch, lifecycle, failure semantics, and UI surfaces.

## What Changed

Includes:
- deterministic group execution
- intent-driven dispatch
- single-use execution lifecycle
- failure-path parity
- payload normalization
- confirm-surface clarification
- result status-text clarification
- full validation suite (repo-side, adversarial, and interactive)

All validation passes:
- repo-side validation: PASS
- adversarial validation: PASS
- interactive/manual validation: PASS

No regressions detected in FB-036 behavior.

Closeout is complete at branch level; merging will promote this to repo truth.

Includes:
- deterministic group execution
- intent-driven dispatch
- single-use execution lifecycle
- failure-path parity
- payload normalization
- confirm-surface clarification
- result status-text clarification
- full validation suite (repo-side, adversarial, and interactive)

All validation passes:
- repo-side validation: PASS
- adversarial validation: PASS
- interactive/manual validation: PASS
