### PR TITLE
[codex] adopt strict branch governance v5

### DIFF
--- a/Docs/Main.md
+++ b/Docs/Main.md
@@ -76,6 +76,8 @@ The startup assessment should make these items explicit:
 - `Reuse Baseline`
 - `Next Safe Move`
 
+If no legal branch may execute, `Next Safe Move` must report `No Active Branch` plus the blocking repair path instead of inventing a later phase.
+
 ## Routing Layers
 
 ### Governance And Prompting
@@ -90,7 +92,7 @@ Use these for workflow posture, prompt framing, lifecycle rules, and execution s
 - `Docs/codex_user_guide.md`
 
 Repo-wide validation-helper rules also live in this governance layer.
-Use `Docs/phase_governance.md` for the validation helper contract, proof hierarchy, default-budget closeout rule, and desktop UI audit rule instead of recreating those rules inside a workstream doc.
+Use `Docs/phase_governance.md` for the exact phase enum, blocker rules, branch classes, phase resolver, validation helper contract, proof hierarchy, default-budget closeout rule, and desktop UI audit rule instead of recreating those rules inside a workstream doc.
 
 ### Product And Boundary Truth
 
@@ -174,6 +176,7 @@ These are reference layers, not active workstream or roadmap owners.
 
 - route through the layer that owns the truth you need
 - when work is phase-sensitive, route through `Docs/phase_governance.md` before choosing execution posture
+- require the exact prompt contract from `Docs/phase_governance.md` before phase-sensitive execution
 - prefer index docs for historical or high-cardinality layers
 - do not treat a local-only document as canonical just because it exists in the workspace
 - keep future post-Beta AI behavior, privacy, and execution intent in `Docs/orin_vision.md` until a later selected workstream turns part of it into execution truth
@@ -181,15 +184,27 @@ These are reference layers, not active workstream or roadmap owners.
 - do not treat workstream docs as the owner of repo-wide phase, timeout, stop-loss, proof-authority, validation-helper, or desktop UI audit rules; those belong to `Docs/phase_governance.md`
 - keep historical Jarvis material preserved, but mark it as historical rather than current reality
 - after a release, do not default to a standalone docs-only canon lane when a plausible next workstream can be selected from updated `main`
-- the normal pre-PR sequence for a branch that changes release-facing canon is:
+- the normal governed branch lifecycle is:
+  1. `Branch Readiness`
+  2. `Workstream`
+  3. `Hardening`
+  4. `Live Validation`
+  5. `PR Readiness`
+  6. `Release Readiness`
+- `Post-Release Canon Repair` is not a normal phase; it is an emergency-only exception path after merged or released truth already exists
+- before any branch may enter `Branch Readiness`, the repo-level admission gate from `Docs/phase_governance.md` must pass on updated `main`
+- if the admission gate fails, report `No Active Branch` and the blocking repair path
+- the normal `PR Readiness` sequence for a branch that changes release-facing canon is:
   1. validate current branch truth
   2. complete the merge-target canon updates on that same branch
-  3. select the next workstream from current canon
-  4. confirm the next workstream has canon-valid record state
-  5. create the fresh successor branch
-  6. keep that successor branch reserved until it is revalidated after merge
-  7. only then allow the current branch to enter PR creation
+  3. run the Governance Drift Audit
+  4. select the next workstream from current canon
+  5. confirm the next workstream has canon-valid record state
+  6. create the fresh successor branch
+  7. keep that successor branch reserved until it is revalidated after merge
+  8. only then allow the current branch to enter PR creation
 - a standalone post-release canon repair is an emergency-only exception path when merged canon is already stale or when external drift made pre-merge prevention impossible
+- returned `UTS`, screenshot, interactive, PR-review, or release-review evidence must be digested into the authority record before phase advancement is recommended
 - when a slice changes user-visible behavior or another operator-facing path, do not treat `## User Test Summary` as a recap slot; route through `Docs/user_test_summary_guidance.md` and require a real manual checklist unless no meaningful manual test exists
 - when an active desktop workstream has a canonical repo-level `UTS` artifact, do not stop at response text; update that workstream-owned artifact as well unless an explicit exception from `Docs/user_test_summary_guidance.md` applies
 - for relevant desktop user-facing slices, also export or refresh `C:\Users\anden\OneDrive\Desktop\User Test Summary.txt` unless an explicit exception from `Docs/user_test_summary_guidance.md` applies

--- a/Docs/Main.md
+++ b/Docs/Main.md
@@ -198,11 +198,13 @@ These are reference layers, not active workstream or roadmap owners.
   1. validate current branch truth
   2. complete the merge-target canon updates on that same branch
   3. run the Governance Drift Audit
-  4. select the next workstream from current canon
-  5. confirm the next workstream has canon-valid record state
-  6. create the fresh successor branch
-  7. keep that successor branch reserved until it is revalidated after merge
-  8. only then allow the current branch to enter PR creation
+  4. if post-merge truth will admit a next branch, select the next workstream from current canon
+  5. if post-merge truth will admit a next branch, confirm the next workstream has canon-valid record state
+  6. if post-merge truth will admit a next branch, create the fresh successor branch
+  7. if post-merge truth will admit a next branch, keep that successor branch reserved until it is revalidated after merge
+  8. If post-merge truth will resolve to `No Active Branch` because `Release Debt` or another repo-level admission blocker remains open, successor-lane selection and reserved successor-branch creation are waived for that PR-readiness pass.
+  9. when that waiver applies, record the blocked repo state explicitly
+  10. only then allow the current branch to enter PR creation
 - a standalone post-release canon repair is an emergency-only exception path when merged canon is already stale or when external drift made pre-merge prevention impossible
 - returned `UTS`, screenshot, interactive, PR-review, or release-review evidence must be digested into the authority record before phase advancement is recommended
 - when a slice changes user-visible behavior or another operator-facing path, do not treat `## User Test Summary` as a recap slot; route through `Docs/user_test_summary_guidance.md` and require a real manual checklist unless no meaningful manual test exists

--- a/Docs/closeout_guidance.md
+++ b/Docs/closeout_guidance.md
@@ -30,13 +30,14 @@ They do not replace:
 
 ## Current Nexus Posture
 
-The historical Jarvis line already has preserved closeouts through `v2.2.1`.
+This guide is policy only.
+It is not the owner of live current-baseline truth.
 
-The modern Nexus pre-Beta line now resumes epoch-summary coverage through:
+For the current Nexus-era baseline, always use:
 
-- `Docs/closeouts/nexus_prebeta_rebaseline_through_v1.2.8-prebeta.md`
+- `Docs/closeout_index.md`
 
-That rebaseline is the current modern carry-forward baseline.
+For the current epoch summary itself, route to the file referenced there.
 
 ## When To Use A Closeout
 
@@ -76,7 +77,7 @@ When those facts change, the repo may legitimately need a docs-only canon repair
 ## Current Policy
 
 - preserve historical closeouts
-- route historical lookup through `Docs/closeout_index.md`
+- route historical lookup and current-baseline lookup through `Docs/closeout_index.md`
 - use canonical workstream records for workstream-level detail
-- use the modern Nexus rebaseline for epoch truth through `v1.2.8-prebeta`
+- do not let this guidance doc become a live current-state owner
 - create new closeouts or rebaselines only when they materially improve future planning clarity

--- a/Docs/codex_modes.md
+++ b/Docs/codex_modes.md
@@ -159,6 +159,8 @@ Workflow mode should usually return:
 When the approved phase is `PR Readiness`, the output must also explicitly include:
 
 - confirmation that the merge-target canon completeness gate passed
+- confirmation that the Governance Drift Audit ran
+- whether governance drift was found
 - the selected next workstream identity
 - the next workstream `Record State`
 - the successor branch name
@@ -210,6 +212,8 @@ While release debt exists, the default next move is usually:
 
 not another unrelated implementation lane.
 
+If release debt or another repo-level admission blocker means no branch may legally begin execution, report repo state as `No Active Branch` instead of inventing a next implementation phase.
+
 ### Fresh Branch Start After A Closed Workstream
 
 After a workstream is merged and closed, the next workstream should execute from updated `main` on a fresh branch.
@@ -233,6 +237,7 @@ When that happens:
 
 - analyze before changing anything
 - anchor phase-sensitive work to the current phase named in `Docs/phase_governance.md`
+- do not infer a later phase from user intent alone
 - verify exact behavior or doc alignment before editing
 - preserve architecture boundaries
 - call out source-of-truth conflicts explicitly
@@ -289,11 +294,19 @@ Phases define the current governed lifecycle state.
 
 For phase-sensitive work, prompts and execution records should explicitly state:
 
-- `Current approved phase: <phase name>`
+- `Mode: <mode name>`
+- `Phase: <exact phase name>`
+- `Workstream: <workstream id or authority record>`
+- `Branch: <branch name or No Active Branch>`
 
 When a branch is in governed closeout recovery, prompts should also state:
 
+- `Branch Class: <branch class>`
 - `Current active seam: <seam name>`
+- `Validation Contract: <summary or authority reference>`
+- `Timeout Contract: <summary or authority reference>`
+
+If `Phase` is missing or is not one of the exact canonical phase names from `Docs/phase_governance.md`, execution must stop at truth-validation or analysis.
 
 ## Live-State Readiness Sanity Check
 

--- a/Docs/codex_modes.md
+++ b/Docs/codex_modes.md
@@ -161,11 +161,16 @@ When the approved phase is `PR Readiness`, the output must also explicitly inclu
 - confirmation that the merge-target canon completeness gate passed
 - confirmation that the Governance Drift Audit ran
 - whether governance drift was found
-- the selected next workstream identity
-- the next workstream `Record State`
-- the successor branch name
-- confirmation that the successor branch was created
-- confirmation that the successor branch is reserved until revalidated after merge
+- when post-merge truth will admit a next branch:
+  - the selected next workstream identity
+  - the next workstream `Record State`
+  - the successor branch name
+  - confirmation that the successor branch was created
+  - confirmation that the successor branch is reserved until revalidated after merge
+- when post-merge truth will resolve to `No Active Branch` because `Release Debt` or another repo-level admission blocker remains open:
+  - repo state `No Active Branch`
+  - the blocking admission item
+  - confirmation that successor lock was waived for the pass
 
 Do not report cleanup as complete unless the pass has explicitly checked for leftover apps, windows, dialogs, helper processes, probe files, or other temporary artifacts it created or opened.
 
@@ -219,6 +224,8 @@ If release debt or another repo-level admission blocker means no branch may lega
 After a workstream is merged and closed, the next workstream should execute from updated `main` on a fresh branch.
 
 That successor branch may be created during `PR Readiness`, but it must stay reserved until the current branch merges and the successor branch is revalidated against updated `main`.
+
+If post-merge truth will resolve to `No Active Branch` because `Release Debt` or another repo-level admission blocker remains open, successor-lane selection and reserved successor-branch creation are waived for that PR-readiness pass.
 
 If a branch is stale, merged, or identical to `main`, call it out explicitly and stop using it as the base for next-lane planning.
 

--- a/Docs/codex_user_guide.md
+++ b/Docs/codex_user_guide.md
@@ -53,7 +53,7 @@ Examples:
 - `Analyze for drift: post-release canon on updated main`
 - `Workflow mode: execute the approved canon phase on current branch`
 - `docs-only pass: align README to the merged source-of-truth model`
-- `use latest User Test Summary as authoritative and continue`
+- `digest latest User Test Summary, reevaluate blockers and phase, then continue only if the next legal phase allows it`
 
 The prompt may be concise.
 Codex's investigation should still be complete enough for the task.
@@ -62,11 +62,17 @@ Codex's investigation should still be complete enough for the task.
 
 For phase-sensitive work, prompts should explicitly include:
 
-- `Current approved phase: <phase name>`
+- `Mode: <mode name>`
+- `Phase: <exact phase name>`
+- `Workstream: <workstream id or authority record>`
+- `Branch: <branch name or No Active Branch>`
 
 For governed closeout recovery, also include:
 
+- `Branch Class: <branch class>`
 - `Current active seam: <seam name>`
+- `Validation Contract: <summary or authority reference>` when validation governance matters
+- `Timeout Contract: <summary or authority reference>` when interactive/manual timing governance matters
 
 ## What Codex Should Do Automatically
 
@@ -166,7 +172,7 @@ Helpful cues:
 Helpful add-ons:
 
 - `analysis only`
-- `use latest User Test Summary as authoritative`
+- `digest latest User Test Summary before recommending the next legal phase`
 - `use origin/main as authoritative truth`
 - `do not patch`
 
@@ -282,7 +288,7 @@ Use this bounded form when the user wants a stop-and-report recovery pass rather
 
 Required add-ons:
 
-- `Current approved phase: Validation / Hardening`
+- `Phase: Hardening`
 - `Current active seam: [seam name]`
 - `do not widen scope`
 - `stop after the governed seam budget is exhausted`
@@ -295,7 +301,7 @@ Use:
 
 Required add-ons:
 
-- `Current approved phase: Validation / Hardening`
+- `Phase: Hardening`
 - `use the documented validation timeout profile`
 - `do not widen scope`
 - `do not stop between seam iterations unless blocker, truth drift, stop-loss, or required canon sync appears`
@@ -315,7 +321,7 @@ Use:
 
 or:
 
-- `use latest User Test Summary as authoritative and continue`
+- `digest latest User Test Summary to files-of-truth standards, reevaluate blockers and phase, and continue only if the next legal phase allows it`
 
 ### Ask For A Prompt
 
@@ -355,7 +361,7 @@ The key distinction is prompt length, not analysis depth.
 - use one cue plus one anchor by default
 - add control language only when it materially protects truth or scope
 - use `Analyze for drift` before merge, release, or major canon carry-forward decisions
-- use `use latest User Test Summary as authoritative` when returned validation evidence should control the next move
+- use evidence-digestion language when returned validation evidence should control the next move, rather than implying that phase advancement is automatic
 - route through `Docs/Main.md` whenever authority is unclear
 - treat local unmerged overlays as reference material until revalidated against updated `origin/main`
 

--- a/Docs/development_rules.md
+++ b/Docs/development_rules.md
@@ -198,10 +198,12 @@ That means:
   - a branch is not PR-ready if merging it would leave `main` canon-stale
 - when a branch closes a workstream, changes released milestone posture, changes the current rebaseline, changes closeout-index routing, changes backlog or roadmap release posture, changes workstream-index release posture, or changes `Docs/Main.md` baseline routing, the required release-facing canon updates must already be on that branch before PR creation is allowed
 - no PR-ready without successor branch created:
+  - If post-merge truth will resolve to `No Active Branch` because `Release Debt` or another repo-level admission blocker remains open, successor-lane selection and reserved successor-branch creation are waived for that PR-readiness pass.
   - the next workstream must be selected from canon
   - that workstream must have canon-valid `Record State`
   - a fresh successor branch must already be created using an approved naming family such as `feature/<lane>`, `fix/<issue>`, or `docs/<lane>`
   - that successor branch must remain reserved until the current branch merges and the successor branch is revalidated against updated `main`
+  - when that waiver applies, the branch must instead record `No Active Branch` plus the blocking admission item explicitly in merged current-state canon
 - post-release canon repair is emergency-only:
   - use it only when canon drift already exists on updated `main` and could not be prevented before merge or release
 - do not default to a standalone docs-only post-release branch for routine canon completion

--- a/Docs/development_rules.md
+++ b/Docs/development_rules.md
@@ -44,6 +44,7 @@ Before recommending the next move after a merge, release, or major lane transiti
 - whether docs and canon reflect live repo truth
 
 If prompt framing is stale, report the real state first and plan from that state.
+If no legal branch may execute, report `No Active Branch` and the blocking repair path instead of inventing a later phase.
 
 ## Source-Of-Truth Ownership Model
 
@@ -56,13 +57,15 @@ Use this layered ownership model:
 - incident patterns = generalized reusable lessons
 - bugs = backlog-first, with promoted bug docs only when warranted
 - User Test Summary = validation-contract layer owned by workstreams
-- phase governance = repo-wide execution, proof, timeout, seam, stop-loss, validation-helper, and desktop UI audit contract
+- phase governance = repo-wide execution, exact phase enum, blockers, branch classes, proof, timeout, seam, stop-loss, validation-helper, Governance Drift Audit, phase resolver, and desktop UI audit contract
 - `Docs/Main.md` = routing authority aligned to merged truth
 
 Use `Docs/phase_governance.md` for:
 
 - named execution phases
+- blocker rules and branch classes
 - phase entry and exit rules
+- rollback and next-legal-phase rules
 - proof authority rules
 - interactive timeout governance
 - validation helper rules
@@ -107,6 +110,34 @@ That startup pass must make explicit:
 - the reuse baseline
 - the next safe move
 
+## Exact Prompt Contract And Phase Resolver
+
+Every phase-sensitive execution prompt must include:
+
+- `Mode`
+- `Phase`
+- `Workstream`
+- `Branch`
+
+Add these when relevant:
+
+- `Branch Class`
+- `Active Seam`
+- `Validation Contract`
+- `Timeout Contract`
+
+If `Phase` is missing or is not one of the exact canonical phase names from `Docs/phase_governance.md`, execution is blocked and only truth-validation or analysis may continue.
+
+Before answering “what phase are we in?” or “what’s next?”, run the phase resolver from `Docs/phase_governance.md` and return:
+
+- `Current Phase`
+- `Phase Status`
+- `Branch Class`
+- `Blockers`
+- `Governance Drift Found`
+- `Next Legal Phase`
+- `Plan To Reach That Phase`
+
 ## Branch And Lane Governance
 
 PR-readiness is not the default checkpoint after a clean slice.
@@ -122,7 +153,7 @@ Stay inside the active grouped lane until one of these is true:
 - the next work crosses subsystem boundaries
 - the user explicitly stops
 
-After a lane is closed:
+After a lane is closed or merged:
 
 - the next workstream must execute from updated `main` on a fresh branch
 - the successor branch may be created during `PR Readiness`, but it remains reserved and may not be used for execution until the current branch merges and the successor branch is revalidated against updated `main`
@@ -134,6 +165,27 @@ If a branch becomes:
 - identical to `main`
 
 Codex must call that out explicitly and recommend a fresh branch from updated `main`.
+
+Before any next branch may enter `Branch Readiness`, the repo-level admission gate from `Docs/phase_governance.md` must pass.
+
+If the admission gate fails:
+
+- repo state becomes `No Active Branch`
+- no next implementation branch may begin
+- the next safe move is blocker repair, not next-lane execution
+
+For active promoted work, the canonical workstream doc is the single authoritative owner of:
+
+- `Current Phase`
+- `Phase Status`
+- `Branch Class`
+- `Blockers`
+- `Entry Basis`
+- `Exit Criteria`
+- `Rollback Target`
+- `Next Legal Phase`
+
+Backlog, roadmap, and prompt text may reference phase state, but they must not override the workstream doc.
 
 ## Canon Freshness Rules
 
@@ -150,12 +202,60 @@ That means:
   - that workstream must have canon-valid `Record State`
   - a fresh successor branch must already be created using an approved naming family such as `feature/<lane>`, `fix/<issue>`, or `docs/<lane>`
   - that successor branch must remain reserved until the current branch merges and the successor branch is revalidated against updated `main`
-- post-release canon sync is emergency-only:
+- post-release canon repair is emergency-only:
   - use it only when canon drift already exists on updated `main` and could not be prevented before merge or release
 - do not default to a standalone docs-only post-release branch for routine canon completion
 - do not use canon sync as an excuse for broad unrelated documentation churn
 
 Local docs overlays are reference material only until revalidated against updated `origin/main`.
+
+Time-sensitive current-state claims must live only in designated current-state owners, or be part of the merge-target canon update set.
+
+Allowed current-state owners are:
+
+- backlog
+- roadmap
+- active workstream doc
+- workstreams index
+- closeout index
+- current rebaseline or closeout file
+- `Docs/Main.md` routing
+
+Auxiliary guidance docs should be timeless by default.
+If they carry live-current claims, they must either be updated as part of canon sync or stop owning current-state truth.
+
+## Governance Drift Rule
+
+If a branch exposes a governance weakness such as:
+
+- a missing blocker
+- a weak phase entry or exit rule
+- a weak source-of-truth ownership rule
+- stale prompt scaffolding or stale examples
+- a missing validator requirement
+
+that weakness must be classified as `Governance Drift`.
+
+If governance drift is discovered:
+
+- stop normal progression immediately
+- either fix it inside the approved governance or docs boundary, or
+- produce the exact required canon delta and wait for user confirmation
+
+Do not defer known governance weaknesses silently to a later branch.
+
+When a branch changes:
+
+- repo-wide phase governance
+- current-state owners
+- prompt scaffolds
+- active promoted workstream phase-state records
+
+it must also run:
+
+- `python dev/orin_branch_governance_validation.py`
+
+and keep that validator green before calling the branch ready.
 
 ## Change Discipline
 
@@ -212,7 +312,7 @@ That means:
 - live re-resolution of windows, dialogs, overlays, and controls across close/open seams
 - seam classification before product code is changed during validation hardening
 
-When the approved boundary is a continuous `Validation / Hardening` pass on the current branch, Codex should keep iterating through seams without waiting for a new user prompt after every rerun unless:
+When the approved boundary is a continuous `Hardening` pass on the current branch, Codex should keep iterating through seams without waiting for a new user prompt after every rerun unless:
 
 - a blocker appears
 - truth drift appears
@@ -340,6 +440,15 @@ If Codex does not update the canonical repo-level `UTS` artifact, it must say ex
 
 If Codex does not export or refresh the desktop `User Test Summary.txt` copy for a relevant desktop slice, it must also say explicitly why.
 
+Returned evidence such as `UTS`, screenshots, interactive reports, PR review comments, or release-review findings may satisfy exit criteria, but they must never auto-advance phase by implication.
+
+Required sequence:
+
+1. digest the evidence
+2. update the authority record
+3. reevaluate blockers
+4. only then advance phase
+
 ## Runtime Evidence And Logging
 
 - logs are the source of truth for runtime behavior
@@ -397,6 +506,9 @@ For every post-merge, post-release, or next-lane review, classify prior recommen
 - discard
 
 Never treat prior suggestions as automatic scope.
+
+For every `PR Readiness` pass, also run the formal Governance Drift Audit from `Docs/phase_governance.md`.
+If that audit finds required canon strengthening, do not silently merge past it.
 
 Use `Docs/Main.md` as the routing index for the merged canon.
 

--- a/Docs/feature_backlog.md
+++ b/Docs/feature_backlog.md
@@ -35,7 +35,7 @@ Release Stage: pre-Beta
 Target Version: TBD
 Canonical Workstream Doc: Docs/workstreams/FB-041_deterministic_callable_group_execution_layer.md
 Summary: Land the first bounded callable-group follow-through execution layer for deterministic linear member execution in stored order with stop-on-failure, terminal success or failure propagation, and runtime progression markers.
-Why it matters: Released FB-036 intentionally deferred callable-group execution follow-through. FB-041 is now merged unreleased implementation debt on `main`, so it remains the promoted current-truth owner until merged canon is repaired and release-debt handling is complete.
+Why it matters: Released FB-036 intentionally deferred callable-group execution follow-through. FB-041 is now merged unreleased implementation debt on `main`, so it remains the promoted current-truth owner until release-debt handling is complete.
 
 ## Registry Items
 

--- a/Docs/feature_backlog.md
+++ b/Docs/feature_backlog.md
@@ -28,14 +28,14 @@ Historical note:
 
 ### [ID: FB-041] Deterministic callable-group execution layer
 
-Status: Promoted for pre-implementation setup
+Status: Merged unreleased on `main`
 Record State: Promoted
 Priority: High
 Release Stage: pre-Beta
 Target Version: TBD
 Canonical Workstream Doc: Docs/workstreams/FB-041_deterministic_callable_group_execution_layer.md
-Summary: Promote the first bounded callable-group follow-through execution layer for deterministic linear member execution in stored order with stop-on-failure, terminal success or failure propagation, and runtime progression markers.
-Why it matters: Released FB-036 intentionally deferred callable-group execution follow-through. This lane isolates that first execution seam without reopening authoring or UI scope and without overlapping FB-037 through FB-040.
+Summary: Land the first bounded callable-group follow-through execution layer for deterministic linear member execution in stored order with stop-on-failure, terminal success or failure propagation, and runtime progression markers.
+Why it matters: Released FB-036 intentionally deferred callable-group execution follow-through. FB-041 is now merged unreleased implementation debt on `main`, so it remains the promoted current-truth owner until merged canon is repaired and release-debt handling is complete.
 
 ## Registry Items
 

--- a/Docs/orin_task_template.md
+++ b/Docs/orin_task_template.md
@@ -38,17 +38,34 @@ Version:
 Branch:
 [fill in branch]
 
-Task mode:
+Mode:
 [analysis-only / planning-only / docs-only / patch / review / release-workflow]
 
-Current approved phase:
-[Workstream Analysis / Approved Execution / Validation / Hardening / Docs / Canon Sync / PR Readiness / Release Readiness / Post-Release Canon Sync]
+Workstream:
+[fill in workstream id or authority record]
+
+Phase:
+[Branch Readiness / Workstream / Hardening / Live Validation / PR Readiness / Release Readiness]
+
+Branch Class:
+[implementation / docs/governance / emergency canon repair / release packaging]
+
+Validation Contract:
+[fill in only when validation governance matters]
+
+Timeout Contract:
+[fill in only when interactive timing governance matters]
+
+Repo state:
+[Active Branch / No Active Branch]
 
 Current active seam:
 [fill in only when the task is in governed closeout recovery]
 
 Note: task mode defines the task type. Codex collaboration posture is defined separately in `C:\Nexus Desktop AI\Docs\codex_modes.md`.
-If the task is phase-sensitive and the current approved phase or active seam is missing, stop and clarify before execution.
+If the task is phase-sensitive and the exact `Phase` field is missing, stop and clarify before execution.
+If repo state is `No Active Branch`, execution is blocked and the task should resolve the blocking repair path instead of starting implementation.
+Add `Validation Contract`, `Timeout Contract`, and `Current active seam` when the governed task needs them.
 
 Default expectation:
 
@@ -124,7 +141,7 @@ Use this section when the branch matters to the task:
 
 - milestone value: [why this branch or docs program is worth completing]
 - same-branch follow-through: [dependent work that still belongs on this branch before readiness]
-- branch posture: [fresh branch from updated main / continue approved active branch / analysis only]
+- branch posture: [fresh branch from updated main / continue approved active branch / release packaging branch / emergency canon repair branch / No Active Branch]
 
 If a lane was already closed, merged, or released, the next workstream should start from updated `main` on a fresh branch.
 
@@ -234,8 +251,9 @@ If an execution task is too broad for one approved pass, explain the cleaner exe
 
 1. Explain the approved execution scope.
 2. Explain the branch or workstream posture.
-3. Explain the current approved phase and, when relevant, the current active seam.
-4. Explain the validation plan.
+3. Explain the exact current phase, branch class, and blockers.
+4. Explain the next legal phase or say explicitly that repo state is `No Active Branch`.
+5. Explain the validation plan.
 
 If the task includes interactive validation, the validation plan should also state:
 

--- a/Docs/phase_governance.md
+++ b/Docs/phase_governance.md
@@ -10,8 +10,9 @@ It exists so:
 - validation truth
 - closeout truth
 - prompt routing
+- next-phase recommendations
 
-all use the same phase names and the same control rules.
+all use the same phase names, blocker rules, and transition rules.
 
 This is the canonical cross-workstream governance layer.
 It does not replace:
@@ -20,43 +21,142 @@ It does not replace:
 - canonical workstream docs as branch-local feature-state, evidence, and closure records
 - release or rebaseline docs as milestone summaries
 
-## Required Prompt Anchors
+## Exact Prompt Contract
 
-For phase-sensitive work, prompts should explicitly include:
+For phase-sensitive execution, prompts must include:
 
-- `Current approved phase: <phase name>`
+- `Mode: <mode name>`
+- `Phase: <exact canonical phase name>`
+- `Workstream: <workstream id or equivalent authority record>`
+- `Branch: <branch name or No Active Branch>`
 
-When the branch is in closeout recovery, prompts should also include:
+Add these fields when relevant:
 
-- `Current active seam: <seam name>`
+- `Branch Class: <implementation / docs/governance / emergency canon repair / release packaging>`
+- `Active Seam: <seam name>`
+- `Validation Contract: <summary or authority reference>`
+- `Timeout Contract: <summary or authority reference>`
+
+If `Phase` is missing or is not one of the exact canonical phase names below, execution is blocked and only truth-validation or analysis may continue.
+
+## Canonical Phase Enum
+
+The only normal branch phases are:
+
+- `Branch Readiness`
+- `Workstream`
+- `Hardening`
+- `Live Validation`
+- `PR Readiness`
+- `Release Readiness`
+
+These are not normal phases:
+
+- `No Active Branch`
+- `Post-Release Canon Repair`
+
+`No Active Branch` is a repo-level blocked state.
+`Post-Release Canon Repair` is an emergency-only exception path after merged or released truth already exists.
 
 ## Cross-Phase Rules
 
 - repo canon is the detailed authority
-- prompt and instruction layers should mirror the same phase names in compressed form
-- workstream docs must record the current phase when promoted work is active
-- a branch must not be treated as PR-ready or release-ready while its active workstream still sits in `Validation / Hardening`
-- if the validation contract, timeout contract, harness behavior, or active seam changes materially during closeout recovery, canon must be updated before continued execution is recommended
+- prompt and instruction layers should mirror the same exact phase names rather than aliases
+- active promoted workstream docs are the single authoritative phase owners for their lane
+- backlog, roadmap, and prompts may reference phase state but must not override the workstream doc
+- a phase must never be inferred from user intent alone
+- if the validation contract, timeout contract, harness behavior, active seam, or blocker set changes materially during late-phase work, canon must be updated before continued execution is recommended
+- auxiliary guidance docs should be timeless by default and must not quietly become current-state owners
 
 ## Canonical Governance Rules
 
 ### Source-Of-Truth Enforcement
 
-- `Docs/phase_governance.md` is the repo-wide authority for phase names, proof governance, timeout governance, seam governance, and stop-loss rules
+- `Docs/phase_governance.md` is the repo-wide authority for exact phase names, blocker rules, proof governance, timeout governance, seam governance, stop-loss rules, branch classes, the Governance Drift Audit, and the phase resolver contract
 - workstream docs must consume this model rather than redefining repo-wide process rules locally
-- workstream docs may record branch-local validation contracts, tighter time budgets, active seams, and evidence references, but those narrower contracts must be explicit
+- workstream docs may record branch-local validation contracts, tighter time budgets, active seams, artifact references, and explicit waivers, but those narrower contracts must be explicit
+
+### Single Phase Authority Rule
+
+For active promoted work, the canonical workstream doc must own:
+
+- `Current Phase`
+- `Phase Status`
+- `Branch Class`
+- `Blockers`
+- `Entry Basis`
+- `Exit Criteria`
+- `Rollback Target`
+- `Next Legal Phase`
+
+If any of those are missing for active promoted work, the branch is blocked by `Workstream Phase Authority Missing`.
+
+### Repo-Level Admission Gate
+
+Before any next branch may enter `Branch Readiness`, all of the following must be true on updated `main`:
+
+- `main` is aligned with `origin/main`
+- merged canon is internally consistent
+- no emergency canon repair is outstanding
+- no unresolved governance-drift blocker exists
+- no unresolved release-debt blocker exists
+- no current branch is being treated as executable if it is stale, merged, or identical to `main`
+
+If any of those fail:
+
+- repo state becomes `No Active Branch`
+- branch execution is blocked
+- the next safe move is blocker repair, not a later phase
+
+### Blocker Catalog
+
+The default named blockers are:
+
+- `Prompt Phase Missing`
+- `Prompt Phase Mismatch`
+- `Workstream Phase Authority Missing`
+- `Branch Base Invalid`
+- `Merged Canon Drift`
+- `Phase Exit Unmet`
+- `Successor Lock Missing`
+- `Release Debt`
+- `Governance Drift`
+- `Current-State Claim Drift`
+- `Phase Waiver Missing`
+
+Blockers stop progression immediately and must be reported before any later-phase recommendation.
 
 ### Blocker Rule
 
 Phase-sensitive work is blocked until the following are explicit and mutually consistent:
 
-- current approved phase
+- exact current phase
 - active workstream or equivalent authority record
+- branch class when branch-sensitive execution is in scope
 - validation contract when validation is in scope
 - timeout contract when interactive validation is in scope
-- current active seam when the branch is in governed closeout recovery
+- current active seam when the branch is in governed recovery
+- current blocker set
 
-If the live harness behavior and documented timeout contract drift, execution is blocked until they are reconciled.
+If live behavior and the documented timeout contract drift, execution is blocked until they are reconciled.
+
+### Branch Class And Phase Waiver Rule
+
+Every active branch must declare a `Branch Class`:
+
+- `implementation`
+- `docs/governance`
+- `emergency canon repair`
+- `release packaging`
+
+The same six normal phases apply to all branch classes.
+Phases may be waived only when:
+
+- the waiver is explicit in the active workstream or branch authority record
+- the reason is recorded
+- the waiver does not weaken merge-target canon completeness, successor lock, or release-debt protections
+
+Silent phase skipping is prohibited.
 
 ### Merge-Target Canon Completeness Gate
 
@@ -67,7 +167,7 @@ Rule:
 This gate is mandatory when a branch would:
 
 - close a workstream
-- become the latest released implementation milestone
+- become the latest released or merged-unreleased implementation milestone
 - change the current rebaseline or closeout baseline
 - change the current closeout-index pointer
 - change backlog, roadmap, or workstream-index release posture
@@ -80,10 +180,10 @@ When this gate applies, the branch must already contain the required release-fac
 - `Docs/prebeta_roadmap.md`
 - `Docs/workstreams/index.md`
 - `Docs/closeout_index.md`
-- the new or updated closeout or rebaseline file
+- the new or updated closeout or rebaseline file when current baseline routing changed
 - `Docs/Main.md` routing updates when the current baseline pointer changed
 
-If any required merge-target canon update is missing, the branch remains blocked in `Docs / Canon Sync` or `PR Readiness`.
+If any required merge-target canon update is missing, the branch remains blocked in `PR Readiness`.
 
 ### Successor Lane Lock Gate
 
@@ -102,9 +202,125 @@ This gate requires all of the following before PR creation is allowed:
 - the successor branch is explicitly treated as reserved
 - execution on the successor branch must not begin until the current branch merges and the successor branch is revalidated against updated `main`
 
-If the next workstream is not selected, its record state is not canon-valid, or the successor branch has not been created, the current branch is not PR-ready.
+If the next workstream is not selected, its record state is not canon-valid, or the successor branch has not been created, the branch is blocked by `Successor Lock Missing`.
 
-### Proof Authority Matrix
+### Governance Drift Audit
+
+Inside `PR Readiness`, the branch must run a formal Governance Drift Audit before it may advance to `Release Readiness`.
+
+The audit must explicitly answer:
+
+- `Governance Drift Found: Yes/No`
+- `Drift Type`
+- `Why Current Canon Failed To Prevent It`
+- `Required Canon Changes`
+- `Whether The Drift Blocks Merge`
+- `Whether User Confirmation Is Required`
+
+The audit must explicitly check whether the branch exposed:
+
+- a missing blocker
+- a weak phase entry or exit rule
+- a weak source-of-truth ownership rule
+- stale prompt scaffolding or stale operator examples
+- a missing validator requirement
+
+If governance drift is found and unresolved, the branch is blocked by `Governance Drift`.
+
+### Governance Drift Escalation Rule
+
+If governance drift is discovered in any earlier phase:
+
+- stop normal progression immediately
+- classify it as `Governance Drift`
+- either fix it inside the approved governance or docs boundary, or
+- produce the exact required canon delta and wait for user confirmation
+
+Do not defer known governance weaknesses silently to a later branch.
+
+### Manual Evidence And Review Digestion Rule
+
+Returned evidence such as:
+
+- `UTS`
+- screenshots
+- interactive reports
+- PR review comments
+- release review findings
+
+may satisfy exit criteria, but must never auto-advance phase by implication.
+
+Required sequence:
+
+1. digest the evidence
+2. update the authority record
+3. reevaluate blockers
+4. only then advance phase
+
+### Current-State Claim Containment
+
+Time-sensitive current-state claims must live only in designated current-state owners, or be part of the merge-target canon update set.
+
+Allowed current-state owners:
+
+- backlog
+- roadmap
+- active workstream doc
+- workstreams index
+- closeout index
+- current rebaseline or closeout file
+- `Docs/Main.md` routing
+
+Auxiliary guidance docs should be timeless by default.
+If they contain live-current claims, they must either:
+
+- be updated as part of canon sync, or
+- stop owning current-state truth
+
+### Governance Validator
+
+Repo-wide governance changes should be checked with the machine-readable governance validator:
+
+- `python dev/orin_branch_governance_validation.py`
+
+That validator should verify at minimum:
+
+- the exact phase enum only
+- active prompt scaffolds no longer teach deprecated phase names or stale prompt contracts
+- active promoted workstreams carry the required phase-state block
+- phase values and branch-class values are valid
+- backlog, roadmap, workstreams index, and active workstream docs agree on active or merged-unreleased posture
+- stale merge-era wording does not remain in active current-state owners
+- Governance Drift Audit output exists before `Release Readiness`
+- unresolved blockers prevent phase advancement
+
+A governance or current-state canon branch is not complete until that validator is green.
+
+### Phase Resolver Contract
+
+Before any answer about current phase or next move, run this resolver:
+
+1. validate live repo truth
+2. determine whether there is an active executable branch or `No Active Branch`
+3. identify the active workstream authority record
+4. detect blockers first
+5. read the exact `Current Phase`
+6. validate entry basis and exit criteria against live truth
+7. return only the next legal phase, or no phase if blocked
+
+Required output for any “what phase are we in?” or “what’s next?” answer:
+
+- `Current Phase`
+- `Phase Status`
+- `Branch Class`
+- `Blockers`
+- `Governance Drift Found`
+- `Next Legal Phase`
+- `Plan To Reach That Phase`
+
+If a blocker exists, do not recommend a later phase or next-lane execution.
+
+## Proof Authority Matrix
 
 When multiple evidence layers exist, use this authority order unless a workstream explicitly documents a tighter requirement:
 
@@ -115,13 +331,13 @@ When multiple evidence layers exist, use this authority order unless a workstrea
 
 UI-only observations may be logged as notes, but they must not override stronger runtime and persisted-source proof unless the UI interaction itself is the thing being validated.
 
-### Proof Ownership Rule
+## Proof Ownership Rule
 
 - repo-wide phase governance defines the allowed proof model
 - the active workstream doc defines the branch-local validation contract, active seam, and any explicit tighter requirements
 - runtime markers and persisted source truth own correctness for product behavior unless the scenario is explicitly about UI interaction quality or reachability
 
-### Validation Helper Contract
+## Validation Helper Contract
 
 Interactive validation helpers should default to a reusable repo-wide contract unless a workstream explicitly documents a tighter branch-local need.
 
@@ -145,7 +361,7 @@ Closeout-grade proof has one extra rule:
 
 Exploratory command-line overrides may still be used during hardening, but a one-off override profile is not enough to call the branch green unless that same profile becomes the documented default or the documented default also proves green.
 
-### Seam Classification Rule
+## Seam Classification Rule
 
 Validation seams should be classified before they are fixed:
 
@@ -156,22 +372,22 @@ Validation seams should be classified before they are fixed:
 
 Do not treat a seam as a product defect merely because the interactive harness failed first.
 
-### Single-Seam Iteration Rule
+## Single-Seam Iteration Rule
 
-- only one active seam may be fixed at a time during governed closeout recovery
+- only one active seam may be fixed at a time during governed recovery
 - rerun the full governed gate immediately after that seam fix
 - if a new seam appears, log it before selecting it as the next active seam
 
 Single-seam ownership does not require a new operator prompt after every rerun.
 It means one seam is active at a time, even when a longer continuous validation pass is allowed.
 
-### Continuous Validation Loop Rule
+## Continuous Validation Loop Rule
 
-When the approved prompt or execution boundary explicitly authorizes a continuous validation pass inside `Validation / Hardening`, Codex may continue across seam iterations without waiting for a new user prompt after every rerun.
+When the approved prompt or execution boundary explicitly authorizes a continuous validation pass inside `Hardening`, Codex may continue across seam iterations without waiting for a new user prompt after every rerun.
 
 That is allowed only while all of the following remain true:
 
-- the branch is still in `Validation / Hardening`
+- the branch is still in `Hardening`
 - the same workstream boundary and closeout goal remain valid
 - the proof hierarchy, timeout contract, and helper default profile remain unchanged
 - no blocker, truth drift, or required canon-sync stop appears
@@ -185,11 +401,9 @@ Inside that continuous loop, Codex should:
 - rerun the full governed gate immediately
 - continue until the full gate is green or a hard stop is reached
 
-This rule exists so governed validation can keep moving toward full green without unnecessary stop-and-report churn between every seam.
+## Stop-Loss Rule
 
-### Stop-Loss Rule
-
-For governed closeout recovery or another approved continuous validation pass:
+For governed recovery or another approved continuous validation pass:
 
 - stop immediately if a blocker appears
 - stop immediately if truth drift appears
@@ -199,9 +413,9 @@ For governed closeout recovery or another approved continuous validation pass:
 - stop if roughly `90 minutes` of validation work pass without material end-to-end progress toward green
 - when stop-loss is reached, continued execution is blocked until a decision memo or equivalent phase-state update is recorded
 
-### Timeout Governance
+## Timeout Governance
 
-Interactive closeout and hardening work must use tiered hard stops.
+Interactive hardening and live-validation work must use tiered hard stops.
 
 Repo-wide target contract for hardened desktop interactive helpers:
 
@@ -224,13 +438,13 @@ Additional repo-wide rule:
 - when hardening proves that a tighter and faster default helper profile is stable, that profile should replace the older relaxed default before closeout-grade proof is claimed
 - if a seam keeps breaching the documented `3s` or `60s` targets, treat that as validation-helper or process debt and redesign the proof path instead of silently letting the run sit longer
 
-### Truth-Drift Enforcement Rule
+## Truth-Drift Enforcement Rule
 
 - if validation or harness behavior changes materially, canon must be updated before continued execution is recommended
 - if a workstream changes which evidence layer is authoritative for success, that change must be written into the active workstream doc before the next seam-fix iteration
-- if a workstream doc, harness defaults, and live execution evidence disagree, the workflow remains in `Validation / Hardening` until the drift is reconciled
+- if a workstream doc, harness defaults, and live execution evidence disagree, the workflow remains in `Hardening` or `Live Validation` until the drift is reconciled
 
-### Preflight Requirement
+## Preflight Requirement
 
 Before a full interactive gate is used as a closeout proof surface, run or confirm a preflight that proves:
 
@@ -240,9 +454,10 @@ Before a full interactive gate is used as a closeout proof surface, run or confi
 - the cleanup path works
 - no stale helper processes, probe windows, or leftover session artifacts are still active from an earlier failed run
 
-If preflight fails, the branch remains in `Validation / Hardening`; do not burn a full closeout run first.
+If preflight fails, the branch remains in `Hardening`.
+Do not burn a full closeout run first.
 
-### Desktop UI Audit Rule
+## Desktop UI Audit Rule
 
 When a branch materially changes user-facing desktop UI and that UI is relevant to the closeout claim:
 
@@ -257,70 +472,76 @@ The canonical rule is narrower:
 - marker-first proof for behavior
 - live launched-process UI audit when meaningful desktop UI changed and closeout depends on user-facing UI quality
 
-### Iteration Discipline
+## Phase Transition Rule
 
-- full interactive reruns are for proof, not exploration
-- do not keep fixing seams informally without updating the seam ledger
-- after a green rerun, move to `Docs / Canon Sync` before calling PR readiness
-- after a non-green rerun inside a continuous validation pass, either select the next single active seam inside stop-loss or stop at the hard-stop boundary
-- do not stop a continuous validation pass merely because one seam finished; stop only at green, truth drift, a blocker, or stop-loss
+- `Branch Readiness` -> `Workstream` only after branch base, branch class, authority record, and execution boundary are explicit
+- `Workstream` -> `Hardening` when the changed branch truth must be pressure-tested or stabilized before closeout
+- `Hardening` -> `Live Validation` only after repo-side hardening proof is sufficient for interactive or manual closeout work
+- `Live Validation` -> `PR Readiness` only after branch-local proof is sufficient for closeout and returned evidence has been digested into the authority record
+- `PR Readiness` -> `Release Readiness` only after merge-target canon completeness passes, successor lock passes, the Governance Drift Audit passes, and no unresolved blocker remains
+- `Release Readiness` -> `Post-Release Canon Repair` only as an emergency repair path after merged or released truth already exists and canon drift escaped the earlier gates
 
-### Phase Transition Rule
-
-- `Workstream Analysis` -> `Approved Execution` only after the execution boundary is explicit
-- `Approved Execution` -> `Validation / Hardening` when branch truth must be proven or hardened
-- `Validation / Hardening` -> `Docs / Canon Sync` only after branch-local proof is sufficient for closeout
-- `Docs / Canon Sync` -> `PR Readiness` only after the docs reflect the proven branch truth, the merge-target canon completeness gate passes, the successor lane lock gate passes, and no active seam remains
-- `PR Readiness` -> `Release Readiness` only when the branch is a legitimate merge or release candidate
-- `Release Readiness` -> `Post-Release Canon Sync` only as an emergency repair path after merged or released truth already exists and canon drift escaped the earlier gates
+Later phases must not paper over missing earlier-phase requirements.
+If a later phase discovers an earlier-phase defect, reopen the branch to the failed earlier phase.
 
 ## Phase Definitions
 
-### Workstream Analysis
+### Branch Readiness
 
 Purpose:
 
-- determine current truth
-- identify drift
-- choose the correct next move
+- validate branch base
+- declare branch class
+- set up or confirm the promoted workstream authority record
+- align branch-start canon
+- lock execution, validation, and timeout boundaries
 
 Allowed:
 
-- broad repo analysis
-- source-of-truth audits
-- branch and release validation
-- non-mutating exploration
+- source-of-truth audit
+- branch-base validation
+- branch-start canon sync
+- workstream promotion or authority setup
+- execution-boundary definition
 
 Forbidden:
 
 - implementation
-- silent scope narrowing before analysis completes
+- PR material preparation
+- release packaging
 
 Required evidence:
 
-- current branch truth
-- relevant authority docs
-- live repo or log evidence where truth could have changed
+- updated `main` truth
+- correct execution base
+- explicit branch class
+- explicit phase block in the authority record
 
 Exit:
 
-- one recommended next move or approved execution boundary
+- branch base is valid
+- active workstream authority exists
+- exact phase state is recorded
+- branch-start canon is coherent
+- execution boundary is explicit
 
-### Approved Execution
+### Workstream
 
 Purpose:
 
-- carry an approved change through implementation and verification
+- execute the approved bounded implementation or bounded governance/docs work
+- run normal repo-side regression validation inside that boundary
 
 Allowed:
 
 - bounded code or docs changes
-- validation inside the approved scope
+- direct verification inside the approved scope
 
 Forbidden:
 
 - silent scope expansion
-- free-form lane redesign
+- hidden hardening or closure claims
+- PR or release packaging
 
 Required evidence:
 
@@ -329,16 +550,16 @@ Required evidence:
 
 Exit:
 
-- implementation slice is complete
-- branch either remains in execution, moves to validation/hardening, or returns to analysis
+- approved scope is implemented
+- direct verification is complete
+- no unresolved same-slice correctness gaps remain
 
-### Validation / Hardening
+### Hardening
 
 Purpose:
 
-- prove the current branch truth
-- harden validation infrastructure when proof gaps remain
-- when explicitly approved, continue a bounded seam-by-seam validation loop until the full gate is green or a hard stop is reached
+- pressure-test the current branch truth
+- stabilize defects, seams, validators, or harnesses before closeout
 
 Allowed:
 
@@ -346,48 +567,58 @@ Allowed:
 - harness work
 - runtime helper work
 - small supporting evidence infrastructure
+- bounded corrective fixes
 
 Forbidden:
 
 - unrelated feature work
-- treating green repo-side validation as automatic closeout
+- new lane selection
+- release packaging
 
 Required evidence:
 
 - validator results
-- live/runtime results when relevant
-- interactive results when feasible
-- explicit distinction between product defects, harness defects, and environment issues
+- runtime results when relevant
+- explicit distinction between product defects, harness defects, environment issues, and canon or contract drift
 
 Exit:
 
-- branch-local proof is sufficient for closeout
-- or the pass stops with a bounded active seam and findings
+- branch-local hardening gate is green
+- no unresolved first-failing seam remains
+- no truth-drift contradiction remains
 
-### Docs / Canon Sync
+### Live Validation
 
 Purpose:
 
-- align source-of-truth docs to the proven current branch truth
+- prove the user-facing or operator-facing branch truth through interactive, manual, or launched-process evidence
+- digest that evidence into canon
 
 Allowed:
 
-- workstream evidence refresh
-- manual validation artifact refresh
-- canon alignment inside the approved scope
+- interactive validation
+- manual validation digestion
+- UI audit when relevant
+- validation-only support changes if the branch reopens to `Hardening` first
 
 Forbidden:
 
-- speculative governance or roadmap churn
-- advancing closeout truth without proof
+- new implementation
+- PR packaging
+- behavior widening without reopening earlier phase
 
 Required evidence:
 
-- passing proof artifacts or explicitly bounded limitation notes
+- required interactive or manual evidence
+- required UI audit evidence when applicable
+- evidence digestion into the authority record
 
 Exit:
 
-- docs reflect current proven truth
+- required interactive or manual evidence is green
+- required UI audit exists when applicable
+- returned evidence is digested into canon
+- no unresolved validation contradiction remains
 
 ### PR Readiness
 
@@ -398,60 +629,83 @@ Purpose:
 Allowed:
 
 - readiness review
-- PR material preparation
+- merge-target canon sync
 - final drift checks
 - next-workstream confirmation
 - successor-branch creation
+- Governance Drift Audit
+- PR material preparation
 
 Forbidden:
 
-- assuming readiness because the worktree is clean
-- skipping active validation blockers
-- allowing a branch to enter PR creation while merge-target canon updates are still missing
-- allowing a branch to enter PR creation while the next workstream identity or successor branch is still unresolved
+- implementation
+- hardening
+- release tagging
+- skipping governance drift review
 
 Required evidence:
 
 - branch-local proof complete
-- closeout truth current
 - merge-target canon completeness gate passed
-- next workstream identity selected from canon
-- next workstream record state is canon-valid
-- successor branch created and marked reserved until post-merge revalidation
+- successor lane lock gate passed
+- Governance Drift Audit completed
 - no active seam
+- no unresolved blocker
 
 Exit:
 
 - ready for PR creation
-- or returned to validation/hardening with explicit blockers
+- or returned to the failed earlier phase with explicit blockers
 
 ### Release Readiness
 
 Purpose:
 
-- determine whether merged truth is ready for release packaging
+- determine whether merged or merge-ready truth is ready for release packaging
 
 Allowed:
 
 - release review
 - release notes prep
-- version/tag recommendations
+- version or tag recommendations
+- final release-candidate verification
 
 Forbidden:
 
-- treating branch-local success as released truth
+- implementation
+- canon-sync mutation
+- hidden fix work
+- hidden next-lane planning
 
 Required evidence:
 
-- merged or merge-ready truth
+- merged or legitimately merge-ready truth
 - release-context verification
+- no unresolved blocker
 
 Exit:
 
 - ready for release packaging
-- or returned to analysis/docs sync for unresolved release debt
+- or returned to the failed earlier phase with explicit blockers
 
-### Post-Release Canon Sync
+## Repo-Level State: No Active Branch
+
+`No Active Branch` is the repo-level state when no branch may legally begin execution.
+
+Use it when:
+
+- the repo-level admission gate is failing
+- merged canon drift remains unresolved
+- release debt remains unresolved
+- the only available branch is stale, merged, or identical to `main`
+
+When `No Active Branch` is active:
+
+- do not recommend a later branch phase
+- do not start next-lane implementation
+- report the blocker and the exact repair path instead
+
+## Exception Path: Post-Release Canon Repair
 
 Purpose:
 
@@ -463,9 +717,9 @@ Allowed:
 
 Forbidden:
 
-- treating post-release canon sync as a normal part of the standard merge lifecycle
-- using post-release canon sync instead of the merge-target canon completeness gate
-- turning post-release sync into a new implementation lane by accident
+- treating post-release canon repair as a normal part of the standard lifecycle
+- using post-release repair instead of the merge-target canon completeness gate
+- turning the repair path into a new implementation lane by accident
 
 Required evidence:
 

--- a/Docs/phase_governance.md
+++ b/Docs/phase_governance.md
@@ -191,6 +191,10 @@ Rule:
 
 - a branch is not `PR Readiness`-complete unless the next workstream is selected, canon-valid, and a fresh successor branch is created
 
+Exception:
+
+- If post-merge truth will resolve to `No Active Branch` because `Release Debt` or another repo-level admission blocker remains open, successor-lane selection and reserved successor-branch creation are waived for that PR-readiness pass.
+
 This gate requires all of the following before PR creation is allowed:
 
 - the next workstream identity is selected from current canon
@@ -201,6 +205,12 @@ This gate requires all of the following before PR creation is allowed:
   - `docs/<lane>`
 - the successor branch is explicitly treated as reserved
 - execution on the successor branch must not begin until the current branch merges and the successor branch is revalidated against updated `main`
+
+When the exception applies, the branch must instead:
+
+- make the post-merge `No Active Branch` state explicit in current-state canon
+- name the blocking admission item explicitly
+- avoid selecting or branching the next implementation lane by inertia
 
 If the next workstream is not selected, its record state is not canon-valid, or the successor branch has not been created, the branch is blocked by `Successor Lock Missing`.
 
@@ -478,7 +488,7 @@ The canonical rule is narrower:
 - `Workstream` -> `Hardening` when the changed branch truth must be pressure-tested or stabilized before closeout
 - `Hardening` -> `Live Validation` only after repo-side hardening proof is sufficient for interactive or manual closeout work
 - `Live Validation` -> `PR Readiness` only after branch-local proof is sufficient for closeout and returned evidence has been digested into the authority record
-- `PR Readiness` -> `Release Readiness` only after merge-target canon completeness passes, successor lock passes, the Governance Drift Audit passes, and no unresolved blocker remains
+- `PR Readiness` -> `Release Readiness` only after merge-target canon completeness passes, the Governance Drift Audit passes, and either successor lock passes or successor lock is explicitly waived because post-merge truth resolves to `No Active Branch` due to `Release Debt` or another repo-level admission blocker
 - `Release Readiness` -> `Post-Release Canon Repair` only as an emergency repair path after merged or released truth already exists and canon drift escaped the earlier gates
 
 Later phases must not paper over missing earlier-phase requirements.
@@ -624,7 +634,7 @@ Exit:
 
 Purpose:
 
-- determine whether the branch is ready to become a merge candidate without leaving merged canon stale and with the next lane already locked
+- determine whether the branch is ready to become a merge candidate without leaving merged canon stale and, when post-merge truth will admit a next branch, with the next lane already locked
 
 Allowed:
 
@@ -647,10 +657,10 @@ Required evidence:
 
 - branch-local proof complete
 - merge-target canon completeness gate passed
-- successor lane lock gate passed
+- successor lane lock gate passed, or successor lock explicitly waived because post-merge truth resolves to `No Active Branch` due to `Release Debt` or another repo-level admission blocker
 - Governance Drift Audit completed
 - no active seam
-- no unresolved blocker
+- no unresolved blocker that should have been repaired on the current branch before merge
 
 Exit:
 

--- a/Docs/prebeta_roadmap.md
+++ b/Docs/prebeta_roadmap.md
@@ -66,7 +66,7 @@ Current merged truth indicates:
 - merged unreleased non-doc implementation debt currently exists on `main`
 - the latest public released implementation milestone is FB-036 saved-action authoring and callable groups in `v1.3.0-prebeta`
 - that merged unreleased implementation debt is FB-041 deterministic callable-group execution layer
-- no next implementation branch may enter `Branch Readiness` until merged-canon repair and release-debt handling are complete
+- no next implementation branch may enter `Branch Readiness` until release-debt handling is complete
 
 That means the released FB-027 interaction baseline plus the later released FB-036 authoring-and-callable-group milestone remain the latest public shared pre-Beta baseline, while FB-041 is now merged unreleased truth above that baseline.
 
@@ -80,7 +80,7 @@ That means the released FB-027 interaction baseline plus the later released FB-0
 - target version: `TBD`
 - release state: `merged unreleased`
 - canonical workstream doc: `Docs/workstreams/FB-041_deterministic_callable_group_execution_layer.md`
-- sequencing note: the first bounded callable-group execution follow-through lane is now merged to `main`, but merged canon and release-debt handling still need to catch up before a next implementation branch may begin
+- sequencing note: the first bounded callable-group execution follow-through lane is now merged to `main`, merged current-state canon is aligned by this governance pass, and release-debt handling still needs to complete before a next implementation branch may begin
 
 ## Most Recent Released Workstream Context
 
@@ -163,7 +163,7 @@ Current merged truth indicates:
 - the recent released workstreams above remain part of the locked current baseline
 - merged unreleased non-doc implementation debt currently exists on `main`
 - FB-041 is the merged unreleased implementation-debt owner on current merged truth
-- repo state is `No Active Branch` for next-lane execution until merged-canon repair and release-debt handling are complete
+- repo state is `No Active Branch` for next-lane execution until release-debt handling is complete
 - if a branch changes release-facing canon, those canon updates must land on that same branch before PR readiness is allowed
 - post-release canon repair is emergency-only when merged canon is already stale or external drift made pre-merge prevention impossible
 - the released FB-027 baseline does not authorize further saved-action authoring, resolution, voice, Action Studio, routines, profiles, hotkey cleanup, or shutdown-confirmation work by inertia
@@ -174,7 +174,7 @@ Current merged truth indicates:
   - FB-040 for monitoring, thermals, and performance HUD surfaces
 - those candidate lanes must be selected deliberately rather than bundled together as one implicit interaction continuation
 - FB-041 remains the promoted current-truth owner only as the merged-unreleased release-debt record, not as permission to start another execution branch by inertia
-- the next implementation workstream must not be selected or branched until FB-041 canon repair and release-debt handling are complete
+- the next implementation workstream must not be selected or branched until FB-041 release-debt handling is complete
 
 Use canonical workstream docs for execution detail.
 Use the backlog for item identity.

--- a/Docs/prebeta_roadmap.md
+++ b/Docs/prebeta_roadmap.md
@@ -63,23 +63,24 @@ Current merged truth indicates:
 
 - latest public prerelease: `v1.3.0-prebeta`
 - latest public release commit: `11eb8ad`
-- no merged unreleased non-doc implementation debt currently exists on `main`
+- merged unreleased non-doc implementation debt currently exists on `main`
 - the latest public released implementation milestone is FB-036 saved-action authoring and callable groups in `v1.3.0-prebeta`
-- the next active non-doc implementation workstream selected on `main` is FB-041 deterministic callable-group execution layer
+- that merged unreleased implementation debt is FB-041 deterministic callable-group execution layer
+- no next implementation branch may enter `Branch Readiness` until merged-canon repair and release-debt handling are complete
 
-That means the released FB-027 interaction baseline plus the later released FB-036 authoring-and-callable-group milestone remain the current shared pre-Beta baseline, and FB-041 is now the promoted next bounded execution lane above that baseline.
+That means the released FB-027 interaction baseline plus the later released FB-036 authoring-and-callable-group milestone remain the latest public shared pre-Beta baseline, while FB-041 is now merged unreleased truth above that baseline.
 
-## Current Selected Workstream
+## Current Release-Debt Workstream
 
 ### FB-041 Deterministic Callable-Group Execution Layer
 
-- status: `promoted`
+- status: `merged unreleased on main`
 - lane type: `implementation`
 - release floor: `patch prerelease`
 - target version: `TBD`
-- release state: `active delta`
+- release state: `merged unreleased`
 - canonical workstream doc: `Docs/workstreams/FB-041_deterministic_callable_group_execution_layer.md`
-- sequencing note: promote the first bounded callable-group execution follow-through lane for deterministic stored-order execution, stop-on-failure, terminal result propagation, and runtime progression markers without reopening authoring, UI, or broader automation scope
+- sequencing note: the first bounded callable-group execution follow-through lane is now merged to `main`, but merged canon and release-debt handling still need to catch up before a next implementation branch may begin
 
 ## Most Recent Released Workstream Context
 
@@ -160,8 +161,9 @@ Current merged truth indicates:
 - the released FB-036 authoring-and-callable-group milestone is now part of the locked current pre-Beta baseline
 - the released FB-035 lane is closed
 - the recent released workstreams above remain part of the locked current baseline
-- no merged unreleased non-doc implementation debt currently exists on `main`
-- the next implementation workstream has now been selected and promoted as FB-041 deterministic callable-group execution layer
+- merged unreleased non-doc implementation debt currently exists on `main`
+- FB-041 is the merged unreleased implementation-debt owner on current merged truth
+- repo state is `No Active Branch` for next-lane execution until merged-canon repair and release-debt handling are complete
 - if a branch changes release-facing canon, those canon updates must land on that same branch before PR readiness is allowed
 - post-release canon repair is emergency-only when merged canon is already stale or external drift made pre-merge prevention impossible
 - the released FB-027 baseline does not authorize further saved-action authoring, resolution, voice, Action Studio, routines, profiles, hotkey cleanup, or shutdown-confirmation work by inertia
@@ -171,8 +173,8 @@ Current merged truth indicates:
   - FB-039 for external trigger and plugin integration architecture
   - FB-040 for monitoring, thermals, and performance HUD surfaces
 - those candidate lanes must be selected deliberately rather than bundled together as one implicit interaction continuation
-- FB-041 is now `Promoted`, and its canonical workstream record owns the active execution truth for that lane
-- the reserved FB-041 branch must stay aligned to updated `main` before implementation begins and must not silently widen into other deferred candidate spaces
+- FB-041 remains the promoted current-truth owner only as the merged-unreleased release-debt record, not as permission to start another execution branch by inertia
+- the next implementation workstream must not be selected or branched until FB-041 canon repair and release-debt handling are complete
 
 Use canonical workstream docs for execution detail.
 Use the backlog for item identity.

--- a/Docs/workstreams/FB-041_deterministic_callable_group_execution_layer.md
+++ b/Docs/workstreams/FB-041_deterministic_callable_group_execution_layer.md
@@ -41,7 +41,7 @@ This workstream exists so callable groups can move from exact invocation only in
 
 - `No Active Branch`
 - `FB-041` is the merged-unreleased release-debt owner on updated `main`
-- merged-canon repair and release-debt handling remain outstanding before the repo may legally begin next-lane execution
+- merged current-state canon is aligned by the governance correction pass; release-debt handling remains outstanding before the repo may legally begin next-lane execution
 
 ## Branch Class
 
@@ -49,20 +49,17 @@ This workstream exists so callable groups can move from exact invocation only in
 
 ## Blockers
 
-- `Merged Canon Drift`
-- `Current-State Claim Drift`
 - `Release Debt`
 
 ## Entry Basis
 
 - merged `main` includes the FB-041 implementation merge from PR `#58`
 - latest public prerelease remains `v1.3.0-prebeta`, so FB-041 is merged unreleased implementation debt above the latest public baseline
-- merged canon still carries stale active or pre-implementation FB-041 claims in backlog, roadmap, and workstream indexing layers
-- no next implementation branch may legally begin until those blockers are repaired and release-debt handling is explicit
+- merged current-state canon now reflects FB-041 as the merged-unreleased release-debt owner across backlog, roadmap, and workstream indexing layers
+- no next implementation branch may legally begin until release-debt handling is explicit
 
 ## Exit Criteria
 
-- merged current-state canon reflects FB-041 as merged-unreleased truth rather than pre-implementation truth
 - backlog, roadmap, workstreams index, and this workstream doc agree on the same merged-unreleased posture
 - release packaging inputs are explicit and no unresolved blocker remains
 - if a real correctness, canon, regression, or governance issue appears during release review, the repo reopens to the failed earlier phase instead of starting next-lane execution
@@ -73,13 +70,13 @@ This workstream exists so callable groups can move from exact invocation only in
 
 ## Next Legal Phase
 
-- `Release Readiness` on a release packaging or emergency canon repair branch once the current blockers are cleared
+- `Release Readiness` on a release packaging or emergency canon repair branch once release-debt handling is explicitly opened
 
 ## Current Branch Truth
 
 - the latest public shared baseline remains the released FB-027 interaction floor plus the released FB-036 authoring-and-callable-group milestone in `v1.3.0-prebeta`
 - `main` now also contains merged unreleased FB-041 callable-group execution follow-through above that public baseline
-- repo state is currently `No Active Branch` for next-lane execution until merged canon is repaired and release-debt handling is complete
+- repo state is currently `No Active Branch` for next-lane execution until release-debt handling is complete
 - exact group invocation still enters through the released chooser and confirm flow, but group follow-through now executes the full stored-order callable group after confirm
 - deterministic callable-group execution now emits bounded runtime markers for:
   - group start
@@ -107,7 +104,7 @@ This workstream exists so callable groups can move from exact invocation only in
   - add the governance validator
   - strengthen current-state claim containment
   - update prompt scaffolds to the exact prompt contract
-- Whether The Drift Blocks Merge: `The code is already merged; the drift now blocks next-lane execution and truthful release-debt handling`
+- Whether The Drift Blocks Merge: `This governance branch resolves the drift; after merge the remaining blocker is release debt, which still blocks next-lane execution`
 - Whether User Confirmation Is Required: `No for the current approved governance pass`
 
 ## Scope

--- a/Docs/workstreams/FB-041_deterministic_callable_group_execution_layer.md
+++ b/Docs/workstreams/FB-041_deterministic_callable_group_execution_layer.md
@@ -11,7 +11,7 @@
 
 ## Status
 
-- `Completed on branch (pending merge)`
+- `Merged unreleased on main`
 
 ## Release Stage
 
@@ -23,7 +23,9 @@
 
 ## Canonical Branch
 
-- `feature/fb-041-deterministic-callable-group-execution`
+- `No Active Branch`
+- historical implementation branch:
+  - `feature/fb-041-deterministic-callable-group-execution`
 
 ## Purpose / Why It Matters
 
@@ -33,29 +35,51 @@ This workstream exists so callable groups can move from exact invocation only in
 
 ## Current Phase
 
-- Phase: `Completed`
-- Substate: `Exact-branch closeout evidence captured; ready for merge-facing closeout flow`
+- Phase: `Release Readiness`
 
-## Phase Entry Basis
+## Phase Status
 
-- merged `main` included the governance-hardening merge from PR `#56`
-- merged `main` included `FB-041` in backlog as the selected successor lane
-- merged `main` included the promoted canonical workstream record before implementation started
-- the implementation branch was recreated from updated `main` so no stale pre-promotion execution state was reused
-- product work in this lane then stayed bounded to deterministic callable-group execution plus the two explicitly documented UI clarification exceptions
+- `No Active Branch`
+- `FB-041` is the merged-unreleased release-debt owner on updated `main`
+- merged-canon repair and release-debt handling remain outstanding before the repo may legally begin next-lane execution
 
-## Phase Exit Criteria
+## Branch Class
 
-- deterministic callable-group execution is implemented and bounded to stored-order, stop-on-failure follow-through
-- dispatch routing, execution intent binding, failure-path parity, and failure payload normalization are complete
-- the confirm-surface clarification exception and the result status-text clarification exception are both complete without widening into broader UI redesign
-- repo-side validation is green on the exact branch truth
-- interactive launched-process success and failure validation is green on the exact branch truth
-- live confirm and result surface audit evidence is captured on the exact branch truth
+- `release packaging`
+
+## Blockers
+
+- `Merged Canon Drift`
+- `Current-State Claim Drift`
+- `Release Debt`
+
+## Entry Basis
+
+- merged `main` includes the FB-041 implementation merge from PR `#58`
+- latest public prerelease remains `v1.3.0-prebeta`, so FB-041 is merged unreleased implementation debt above the latest public baseline
+- merged canon still carries stale active or pre-implementation FB-041 claims in backlog, roadmap, and workstream indexing layers
+- no next implementation branch may legally begin until those blockers are repaired and release-debt handling is explicit
+
+## Exit Criteria
+
+- merged current-state canon reflects FB-041 as merged-unreleased truth rather than pre-implementation truth
+- backlog, roadmap, workstreams index, and this workstream doc agree on the same merged-unreleased posture
+- release packaging inputs are explicit and no unresolved blocker remains
+- if a real correctness, canon, regression, or governance issue appears during release review, the repo reopens to the failed earlier phase instead of starting next-lane execution
+
+## Rollback Target
+
+- `PR Readiness`
+
+## Next Legal Phase
+
+- `Release Readiness` on a release packaging or emergency canon repair branch once the current blockers are cleared
 
 ## Current Branch Truth
 
-- the current shared baseline remains the released FB-027 interaction floor plus the released FB-036 authoring-and-callable-group milestone
+- the latest public shared baseline remains the released FB-027 interaction floor plus the released FB-036 authoring-and-callable-group milestone in `v1.3.0-prebeta`
+- `main` now also contains merged unreleased FB-041 callable-group execution follow-through above that public baseline
+- repo state is currently `No Active Branch` for next-lane execution until merged canon is repaired and release-debt handling is complete
 - exact group invocation still enters through the released chooser and confirm flow, but group follow-through now executes the full stored-order callable group after confirm
 - deterministic callable-group execution now emits bounded runtime markers for:
   - group start
@@ -65,6 +89,26 @@ This workstream exists so callable groups can move from exact invocation only in
 - dispatch now consumes immutable execution intent captured at confirm time rather than ambient overlay group state
 - group failures now reuse the existing recoverable launch-failure classification pipeline with structured group-aware payloads
 - single-action dispatch, confirm text, result text, and failure behavior remain unchanged except where the documented confirm/result group-only clarification exceptions apply
+
+## Governance Drift Audit
+
+- Governance Drift Found: `Yes`
+- Drift Type:
+  - merge-target canon completeness failure
+  - stale current-state claim ownership
+  - stale prompt scaffolding and operator examples
+- Why Current Canon Failed To Prevent It:
+  - merged truth advanced without all release-facing canon surfaces being updated together
+  - active prompt scaffolds still taught the older phase model
+  - current-state claims still lived in guidance and sequencing layers that were not reconciled after merge
+- Required Canon Changes:
+  - adopt the strict six-phase governance model
+  - add the repo-level admission gate and `No Active Branch` state
+  - add the governance validator
+  - strengthen current-state claim containment
+  - update prompt scaffolds to the exact prompt contract
+- Whether The Drift Blocks Merge: `The code is already merged; the drift now blocks next-lane execution and truthful release-debt handling`
+- Whether User Confirmation Is Required: `No for the current approved governance pass`
 
 ## Scope
 

--- a/Docs/workstreams/index.md
+++ b/Docs/workstreams/index.md
@@ -35,13 +35,16 @@ Use `Docs/phase_governance.md` for phase names, proof authority, seam governance
 - that UI audit expectation is a post-green closeout rule for meaningful desktop UI changes, not a rule that every seam iteration must always take screenshots
 - when Codex creates or materially extends lane-specific validators, harnesses, runtime helpers, scripts, workers, report roots, exported manual-test artifacts, or other reusable support assets on an active workstream branch, the workstream doc should keep a durable artifact-history or artifact-reference section for them
 - that artifact-history section should record the path, purpose, introduced-when or introduced-why note, classification such as `baseline`, `supporting`, `interactive-only`, or `temporary`, and how future work should reuse the artifact
-- when an active workstream enters governed closeout recovery or another late hardening phase, it should also record the current phase
-- when an active workstream enters governed closeout recovery or another late hardening phase, it should also record the phase exit criteria
-- when an active workstream enters governed closeout recovery or another late hardening phase, it should also record the validation contract
-- when an active workstream enters governed closeout recovery or another late hardening phase, it should also record the timeout contract
-- when an active workstream enters governed closeout recovery or another late hardening phase, it should also record the current active seam
-- when an active workstream enters governed closeout recovery or another late hardening phase, it should also record the seam ledger
-- when an active workstream enters governed closeout recovery or another late hardening phase, it should also record the stop-loss threshold
+- active promoted workstreams must carry the modern phase-state block:
+  - `## Current Phase`
+  - `## Phase Status`
+  - `## Branch Class`
+  - `## Blockers`
+  - `## Entry Basis`
+  - `## Exit Criteria`
+  - `## Rollback Target`
+  - `## Next Legal Phase`
+- that phase-state block is mandatory for active promoted work and may be omitted from preserved closed historical workstreams unless they are reopened or needed for current-truth repair
 - branch-local "what worked", reuse guidance, and future-branch carry-forward notes belong in the canonical workstream doc first
 - only generalized cross-branch lessons should be distilled into `Docs/incident_patterns.md`
 - closed workstream docs remain historical lane truth and must not be treated as active execution authority by inertia
@@ -56,7 +59,7 @@ For an active or recently closed canonical workstream, keep these durable tracea
 - current branch truth or equivalent promoted-lane truth
 - scope and non-goals
 - executed slices or equivalent progress log
-- current phase and phase-specific validation, seam, timeout, or stop-loss state when phase-sensitive work is active
+- current phase, phase status, branch class, blockers, phase-specific validation, seam, timeout, or stop-loss state when phase-sensitive work is active
 - durable validation or proof references that materially justify continuation or closeout
 - artifact history or artifact references for lane-specific validators, harnesses, helpers, reports, or manual-test exports that future work should reuse
 - branch-local reuse notes or "what worked" guidance when a future branch would otherwise need to rediscover the same lesson
@@ -66,6 +69,12 @@ For an active or recently closed canonical workstream, keep these durable tracea
 ## Current Canonical Workstream Records
 
 ### Active
+
+Active here means the current promoted truth owner.
+That may be:
+
+- an executable branch owner, or
+- a merged-unreleased release-debt owner while repo state is `No Active Branch`
 
 - `Docs/workstreams/FB-041_deterministic_callable_group_execution_layer.md`
 

--- a/dev/orin_branch_governance_validation.py
+++ b/dev/orin_branch_governance_validation.py
@@ -1,0 +1,391 @@
+import re
+import sys
+from pathlib import Path
+
+
+ROOT_DIR = Path(__file__).resolve().parent.parent
+
+PHASES = (
+    "Branch Readiness",
+    "Workstream",
+    "Hardening",
+    "Live Validation",
+    "PR Readiness",
+    "Release Readiness",
+)
+
+BRANCH_CLASSES = (
+    "implementation",
+    "docs/governance",
+    "emergency canon repair",
+    "release packaging",
+)
+
+PROMPT_CONTRACT_DOCS = (
+    Path("Docs/phase_governance.md"),
+    Path("Docs/development_rules.md"),
+    Path("Docs/codex_modes.md"),
+    Path("Docs/codex_user_guide.md"),
+    Path("Docs/orin_task_template.md"),
+)
+
+CURRENT_STATE_OWNER_DOCS = (
+    Path("Docs/Main.md"),
+    Path("Docs/feature_backlog.md"),
+    Path("Docs/prebeta_roadmap.md"),
+    Path("Docs/workstreams/index.md"),
+    Path("Docs/closeout_index.md"),
+)
+
+AUXILIARY_GUIDANCE_DOCS = (
+    Path("Docs/closeout_guidance.md"),
+    Path("Docs/codex_user_guide.md"),
+    Path("Docs/orin_task_template.md"),
+)
+
+OLD_PHASE_TERMS = (
+    "Workstream Analysis",
+    "Approved Execution",
+    "Validation / Hardening",
+    "Docs / Canon Sync",
+    "Post-Release Canon Sync",
+    "post-release canon sync",
+)
+
+BANNED_BRANCH_CLASS_SPELLINGS = (
+    "docs-governance",
+    "emergency-canon-repair",
+    "release-packaging",
+)
+
+STALE_CURRENT_STATE_TERMS = (
+    "pending merge",
+    "Promoted for pre-implementation setup",
+    "Current Selected Workstream",
+)
+
+STALE_AUXILIARY_TERMS = (
+    "v1.2.8-prebeta",
+)
+
+REQUIRED_WORKSTREAM_HEADINGS = (
+    "## Current Phase",
+    "## Phase Status",
+    "## Branch Class",
+    "## Blockers",
+    "## Entry Basis",
+    "## Exit Criteria",
+    "## Rollback Target",
+    "## Next Legal Phase",
+)
+
+
+def _read_text(relative_path: Path) -> str:
+    return (ROOT_DIR / relative_path).read_text(encoding="utf-8")
+
+
+def _line_number(text: str, needle: str) -> int:
+    index = text.find(needle)
+    if index < 0:
+        return 0
+    return text.count("\n", 0, index) + 1
+
+
+def _section(text: str, heading: str) -> str:
+    match = re.search(rf"(?ms)^## {re.escape(heading)}\n(.*?)(?=^## |\Z)", text)
+    return match.group(1).strip() if match else ""
+
+
+def _subsection(text: str, heading_prefix: str) -> str:
+    match = re.search(rf"(?ms)^### {re.escape(heading_prefix)}.*?\n(.*?)(?=^### |\Z)", text)
+    return match.group(0).strip() if match else ""
+
+
+def _extract_backtick_values(text: str) -> list[str]:
+    return re.findall(r"`([^`]+)`", text)
+
+
+def _extract_first_backtick_value(text: str) -> str:
+    values = _extract_backtick_values(text)
+    return values[0] if values else ""
+
+
+def _normalize_status(value: str) -> str:
+    lowered = value.strip().lower()
+    if "merged unreleased" in lowered:
+        return "merged unreleased"
+    if "released" in lowered:
+        return "released"
+    if "closed" in lowered:
+        return "closed"
+    if "active" in lowered:
+        return "active"
+    if "deferred" in lowered:
+        return "deferred"
+    return lowered
+
+
+def _parse_backlog_sections(text: str) -> list[dict[str, str]]:
+    entries: list[dict[str, str]] = []
+    matches = list(re.finditer(r"^### \[ID: (?P<id>FB-\d+)\] (?P<title>.+)$", text, flags=re.M))
+    for index, match in enumerate(matches):
+        start = match.start()
+        end = matches[index + 1].start() if index + 1 < len(matches) else len(text)
+        block = text[start:end]
+        entries.append(
+            {
+                "id": match.group("id"),
+                "title": match.group("title").strip(),
+                "block": block,
+                "status": _extract_colon_value(block, "Status"),
+                "record_state": _extract_colon_value(block, "Record State"),
+                "canonical_path": _extract_colon_value(block, "Canonical Workstream Doc"),
+            }
+        )
+    return entries
+
+
+def _extract_colon_value(block: str, label: str) -> str:
+    match = re.search(rf"^{re.escape(label)}:\s*(.+)$", block, flags=re.M)
+    return match.group(1).strip() if match else ""
+
+
+def _parse_workstream_doc(text: str) -> dict[str, object]:
+    record_state = _extract_first_backtick_value(_section(text, "Record State"))
+    status = _extract_first_backtick_value(_section(text, "Status"))
+    current_phase_section = _section(text, "Current Phase")
+    current_phase_match = re.search(r"Phase:\s*`([^`]+)`", current_phase_section)
+    current_phase = current_phase_match.group(1) if current_phase_match else ""
+    branch_class = _extract_first_backtick_value(_section(text, "Branch Class"))
+    blockers = _extract_backtick_values(_section(text, "Blockers"))
+    rollback_target = _extract_first_backtick_value(_section(text, "Rollback Target"))
+    next_legal_phase = _extract_first_backtick_value(_section(text, "Next Legal Phase"))
+    governance_audit = _section(text, "Governance Drift Audit")
+    return {
+        "record_state": record_state,
+        "status": status,
+        "current_phase": current_phase,
+        "branch_class": branch_class,
+        "blockers": blockers,
+        "rollback_target": rollback_target,
+        "next_legal_phase": next_legal_phase,
+        "governance_audit": governance_audit,
+    }
+
+
+def _collect_active_index_paths(text: str) -> set[str]:
+    active_section = _subsection(text, "Active")
+    return set(re.findall(r"Docs/workstreams/[A-Za-z0-9._-]+\.md", active_section))
+
+
+def _collect_closed_index_paths(text: str) -> set[str]:
+    closed_section = _subsection(text, "Closed")
+    return set(re.findall(r"Docs/workstreams/[A-Za-z0-9._-]+\.md", closed_section))
+
+
+def _roadmap_section_for_id(text: str, workstream_id: str) -> str:
+    match = re.search(rf"(?ms)^### {re.escape(workstream_id)}.*?(?=^### |\Z)", text)
+    return match.group(0).strip() if match else ""
+
+
+def _phase_index(phase_name: str) -> int:
+    return PHASES.index(phase_name)
+
+
+def main() -> int:
+    errors: list[str] = []
+    checks = 0
+
+    backlog_text = _read_text(Path("Docs/feature_backlog.md"))
+    roadmap_text = _read_text(Path("Docs/prebeta_roadmap.md"))
+    index_text = _read_text(Path("Docs/workstreams/index.md"))
+
+    def require(condition: bool, message: str) -> None:
+        nonlocal checks
+        checks += 1
+        if not condition:
+            errors.append(message)
+
+    for relative_path in PROMPT_CONTRACT_DOCS:
+        text = _read_text(relative_path)
+        for old_term in OLD_PHASE_TERMS:
+            require(
+                old_term not in text,
+                f"{relative_path}: deprecated phase term '{old_term}' is still present (line {_line_number(text, old_term)})",
+            )
+        for bad_spelling in BANNED_BRANCH_CLASS_SPELLINGS:
+            require(
+                bad_spelling not in text,
+                f"{relative_path}: deprecated branch-class spelling '{bad_spelling}' is still present (line {_line_number(text, bad_spelling)})",
+            )
+
+    for relative_path in CURRENT_STATE_OWNER_DOCS:
+        text = _read_text(relative_path)
+        for stale_term in STALE_CURRENT_STATE_TERMS:
+            require(
+                stale_term not in text,
+                f"{relative_path}: stale current-state term '{stale_term}' is still present (line {_line_number(text, stale_term)})",
+            )
+
+    for relative_path in AUXILIARY_GUIDANCE_DOCS:
+        text = _read_text(relative_path)
+        for stale_term in STALE_AUXILIARY_TERMS:
+            require(
+                stale_term not in text,
+                f"{relative_path}: stale auxiliary current-state term '{stale_term}' is still present (line {_line_number(text, stale_term)})",
+            )
+
+    template_text = _read_text(Path("Docs/orin_task_template.md"))
+    for field_label in ("Mode:", "Phase:", "Workstream:", "Branch:", "Branch Class:"):
+        require(
+            field_label in template_text,
+            f"Docs/orin_task_template.md: required prompt field '{field_label}' is missing",
+        )
+
+    user_guide_text = _read_text(Path("Docs/codex_user_guide.md"))
+    for field_label in ("Mode:", "Phase:", "Workstream:", "Branch:"):
+        require(
+            field_label in user_guide_text,
+            f"Docs/codex_user_guide.md: exact prompt contract no longer mentions '{field_label}'",
+        )
+
+    promoted_entries = [
+        entry
+        for entry in _parse_backlog_sections(backlog_text)
+        if entry.get("record_state") == "Promoted"
+    ]
+    require(bool(promoted_entries), "Docs/feature_backlog.md: expected at least one promoted workstream")
+
+    active_index_paths = _collect_active_index_paths(index_text)
+    closed_index_paths = _collect_closed_index_paths(index_text)
+
+    for entry in promoted_entries:
+        workstream_id = entry["id"]
+        canonical_path = entry["canonical_path"]
+        require(
+            bool(canonical_path),
+            f"Docs/feature_backlog.md: promoted workstream {workstream_id} is missing Canonical Workstream Doc",
+        )
+        if not canonical_path:
+            continue
+
+        workstream_path = Path(canonical_path)
+        require(
+            (ROOT_DIR / workstream_path).is_file(),
+            f"{canonical_path}: promoted workstream doc for {workstream_id} does not exist",
+        )
+        if not (ROOT_DIR / workstream_path).is_file():
+            continue
+
+        workstream_text = _read_text(workstream_path)
+        workstream_info = _parse_workstream_doc(workstream_text)
+
+        require(
+            workstream_info["record_state"] == entry["record_state"],
+            (
+                f"{canonical_path}: Record State '{workstream_info['record_state']}' does not match "
+                f"backlog '{entry['record_state']}' for {workstream_id}"
+            ),
+        )
+        require(
+            _normalize_status(str(workstream_info["status"])) == _normalize_status(entry["status"]),
+            (
+                f"{canonical_path}: Status '{workstream_info['status']}' does not match "
+                f"backlog status '{entry['status']}' for {workstream_id}"
+            ),
+        )
+
+        for heading in REQUIRED_WORKSTREAM_HEADINGS:
+            require(
+                heading in workstream_text,
+                f"{canonical_path}: required heading '{heading}' is missing",
+            )
+
+        current_phase = str(workstream_info["current_phase"])
+        branch_class = str(workstream_info["branch_class"])
+        rollback_target = str(workstream_info["rollback_target"])
+        next_legal_phase = str(workstream_info["next_legal_phase"])
+        blockers = list(workstream_info["blockers"])
+
+        require(
+            current_phase in PHASES,
+            f"{canonical_path}: Current Phase '{current_phase}' is not in the canonical phase enum",
+        )
+        require(
+            branch_class in BRANCH_CLASSES,
+            f"{canonical_path}: Branch Class '{branch_class}' is not in the canonical branch-class enum",
+        )
+        require(
+            rollback_target in PHASES,
+            f"{canonical_path}: Rollback Target '{rollback_target}' is not in the canonical phase enum",
+        )
+        require(
+            next_legal_phase in PHASES,
+            f"{canonical_path}: Next Legal Phase '{next_legal_phase}' is not in the canonical phase enum",
+        )
+        if blockers and current_phase in PHASES and next_legal_phase in PHASES:
+            require(
+                _phase_index(next_legal_phase) <= _phase_index(current_phase),
+                (
+                    f"{canonical_path}: blockers are present ({', '.join(blockers)}) but "
+                    f"Next Legal Phase advances from '{current_phase}' to '{next_legal_phase}'"
+                ),
+            )
+
+        if current_phase in {"PR Readiness", "Release Readiness"}:
+            governance_audit = str(workstream_info["governance_audit"])
+            require(
+                bool(governance_audit),
+                f"{canonical_path}: Governance Drift Audit section is required before or during '{current_phase}'",
+            )
+            require(
+                "Governance Drift Found:" in governance_audit,
+                f"{canonical_path}: Governance Drift Audit is missing 'Governance Drift Found:'",
+            )
+
+        require(
+            canonical_path in active_index_paths,
+            f"Docs/workstreams/index.md: promoted workstream {canonical_path} is missing from the Active list",
+        )
+        require(
+            canonical_path not in closed_index_paths,
+            f"Docs/workstreams/index.md: promoted workstream {canonical_path} is incorrectly listed under Closed",
+        )
+
+        roadmap_section = _roadmap_section_for_id(roadmap_text, workstream_id)
+        require(
+            bool(roadmap_section),
+            f"Docs/prebeta_roadmap.md: promoted workstream {workstream_id} is missing from the roadmap",
+        )
+        if roadmap_section:
+            require(
+                canonical_path in roadmap_section,
+                f"Docs/prebeta_roadmap.md: roadmap section for {workstream_id} does not cite {canonical_path}",
+            )
+            roadmap_status = _extract_first_backtick_value(roadmap_section)
+            require(
+                _normalize_status(roadmap_status) == _normalize_status(entry["status"]),
+                (
+                    f"Docs/prebeta_roadmap.md: roadmap status '{roadmap_status}' does not match "
+                    f"backlog status '{entry['status']}' for {workstream_id}"
+                ),
+            )
+
+    governance_text = _read_text(Path("Docs/phase_governance.md"))
+    require(
+        "python dev/orin_branch_governance_validation.py" in governance_text,
+        "Docs/phase_governance.md: Governance Validator section does not cite python dev/orin_branch_governance_validation.py",
+    )
+
+    if errors:
+        print(f"FAIL: branch governance validation found {len(errors)} issue(s).")
+        for issue in errors:
+            print(f"- {issue}")
+        return 1
+
+    print(f"PASS: branch governance validation passed {checks} checks.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/dev/orin_branch_governance_validation.py
+++ b/dev/orin_branch_governance_validation.py
@@ -62,6 +62,9 @@ STALE_CURRENT_STATE_TERMS = (
     "pending merge",
     "Promoted for pre-implementation setup",
     "Current Selected Workstream",
+    "until merged-canon repair and release-debt handling are complete",
+    "merged-canon repair and release-debt handling remain outstanding",
+    "merged canon still carries stale active or pre-implementation",
 )
 
 STALE_AUXILIARY_TERMS = (
@@ -77,6 +80,18 @@ REQUIRED_WORKSTREAM_HEADINGS = (
     "## Exit Criteria",
     "## Rollback Target",
     "## Next Legal Phase",
+)
+
+SUCCESSOR_LOCK_WAIVER_DOCS = (
+    Path("Docs/phase_governance.md"),
+    Path("Docs/development_rules.md"),
+    Path("Docs/Main.md"),
+    Path("Docs/codex_modes.md"),
+)
+
+SUCCESSOR_LOCK_WAIVER_PHRASE = (
+    "If post-merge truth will resolve to `No Active Branch` because `Release Debt` "
+    "or another repo-level admission blocker remains open"
 )
 
 
@@ -249,6 +264,16 @@ def main() -> int:
             f"Docs/codex_user_guide.md: exact prompt contract no longer mentions '{field_label}'",
         )
 
+    for relative_path in SUCCESSOR_LOCK_WAIVER_DOCS:
+        text = _read_text(relative_path)
+        require(
+            SUCCESSOR_LOCK_WAIVER_PHRASE in text,
+            (
+                f"{relative_path}: successor-lock waiver for post-merge `No Active Branch` "
+                "state due to `Release Debt` or another admission blocker is missing"
+            ),
+        )
+
     promoted_entries = [
         entry
         for entry in _parse_backlog_sections(backlog_text)
@@ -341,6 +366,27 @@ def main() -> int:
             require(
                 "Governance Drift Found:" in governance_audit,
                 f"{canonical_path}: Governance Drift Audit is missing 'Governance Drift Found:'",
+            )
+
+        phase_status_section = _section(workstream_text, "Phase Status")
+        if (
+            _normalize_status(str(workstream_info["status"])) == "merged unreleased"
+            and "`No Active Branch`" in phase_status_section
+            and "Release Debt" in blockers
+        ):
+            require(
+                current_phase == "Release Readiness",
+                (
+                    f"{canonical_path}: merged-unreleased `No Active Branch` release-debt owner "
+                    "must use `Release Readiness` as Current Phase"
+                ),
+            )
+            require(
+                "Merged Canon Drift" not in blockers and "Current-State Claim Drift" not in blockers,
+                (
+                    f"{canonical_path}: merged-unreleased `No Active Branch` release-debt owner "
+                    "must not keep resolved current-state drift blockers active"
+                ),
             )
 
         require(


### PR DESCRIPTION
## Summary

This PR installs the strict branch-governance v5 model and reconciles the merged-current-state canon around FB-041.

## What Changed

### What Changed

- replaced the prior flexible phase model with the exact six normal phases:
  - `Branch Readiness`
  - `Workstream`
  - `Hardening`
  - `Live Validation`
  - `PR Readiness`
  - `Release Readiness`
- added explicit non-phase repo states and blockers, including:
  - `No Active Branch`
  - `Post-Release Canon Repair`
  - `Merged Canon Drift`
  - `Release Debt`
  - `Governance Drift`
- made the active promoted workstream doc the single phase authority
- added the Governance Drift Audit and strict phase resolver contract
- updated operator scaffolds to require the exact prompt contract
- repaired FB-041 merged-current-state canon so it is modeled as merged-unreleased release debt on `main`
- refined successor-lock rules so they are waived when post-merge truth correctly resolves to `No Active Branch` because release debt or another admission blocker remains open
- added a machine-checkable governance validator at `dev/orin_branch_governance_validation.py`

### Why

FB-041 merged to `main`, but merged canon and prompt scaffolds were still teaching stale execution truth. This branch hardens the governance layer so prompt drift and process-flow drift are blocked by canon and by validator checks, and so post-merge truth no longer conflicts with successor-lock expectations.

### Impact

- future phase-sensitive prompts now have one exact contract
- post-merge phase resolution can truthfully return `No Active Branch` when release debt is still open
- next-lane execution is blocked until repo-level admission conditions are satisfied
- governance/current-state drift becomes machine-detectable instead of purely interpretive

### Notes

This PR is governance/docs only.
It does not change product/runtime behavior.

### What Changed

- replaced the prior flexible phase model with the exact six normal phases:
  - `Branch Readiness`
  - `Workstream`
  - `Hardening`
  - `Live Validation`
  - `PR Readiness`
  - `Release Readiness`
- added explicit non-phase repo states and blockers, including:
  - `No Active Branch`
  - `Post-Release Canon Repair`
  - `Merged Canon Drift`
  - `Release Debt`
  - `Governance Drift`
- made the active promoted workstream doc the single phase authority
- added the Governance Drift Audit and strict phase resolver contract
- updated operator scaffolds to require the exact prompt contract
- repaired FB-041 merged-current-state canon so it is modeled as merged-unreleased release debt on `main`
- refined successor-lock rules so they are waived when post-merge truth correctly resolves to `No Active Branch` because release debt or another admission blocker remains open
- added a machine-checkable governance validator at `dev/orin_branch_governance_validation.py`

### Why

### Impact

- future phase-sensitive prompts now have one exact contract
- post-merge phase resolution can truthfully return `No Active Branch` when release debt is still open
- next-lane execution is blocked until repo-level admission conditions are satisfied
- governance/current-state drift becomes machine-detectable instead of purely interpretive

### Notes
