### PR TITLE
docs(release): publish fb-041 prebeta baseline

### DIFF
--- a/Docs/Main.md
+++ b/Docs/Main.md
@@ -148,7 +148,7 @@ Use these for closeout policy, historical closeout lookup, and the modern Nexus-
 
 - `Docs/closeout_guidance.md`
 - `Docs/closeout_index.md`
-- `Docs/closeouts/nexus_prebeta_rebaseline_through_v1.3.0-prebeta.md`
+- `Docs/closeouts/nexus_prebeta_rebaseline_through_v1.3.1-prebeta.md`
 
 Historical closeout leaf docs are intentionally routed through `Docs/closeout_index.md`.
 

--- a/Docs/branch_records/codex_no_active_branch_docs_governance_refinement.md
+++ b/Docs/branch_records/codex_no_active_branch_docs_governance_refinement.md
@@ -19,7 +19,7 @@ This branch also closes the remaining governance gap for non-backlog branches by
 
 - `Merge-ready branch record`
 - historical on merged `main`
-- repo-level sequencing truth remains blocked `No Active Branch` for next implementation-lane selection while FB-041 release debt remains open
+- at this branch's merge time, repo-level sequencing truth was blocked `No Active Branch` for next implementation-lane selection until later FB-041 release packaging cleared the release debt in `v1.3.1-prebeta`
 
 ## Branch Class
 
@@ -79,5 +79,5 @@ This branch also closes the remaining governance gap for non-backlog branches by
 
 - no product or runtime code changes
 - no next implementation workstream selection
-- no FB-041 release-debt clearance
+- this branch did not execute FB-041 release packaging; that happened later through `v1.3.1-prebeta`
 - no release packaging work

--- a/Docs/closeout_index.md
+++ b/Docs/closeout_index.md
@@ -11,12 +11,12 @@ Use `Docs/closeout_guidance.md` for policy and cadence questions.
 
 ## Current Nexus-Era Baseline
 
-### Nexus Pre-Beta Rebaseline Through v1.3.0-prebeta
+### Nexus Pre-Beta Rebaseline Through v1.3.1-prebeta
 
 - scope:
-  - current shared Nexus pre-Beta baseline through the released FB-036 saved-action authoring and callable-group milestone
+  - current shared Nexus pre-Beta baseline through the released FB-041 deterministic callable-group execution milestone
 - file:
-  - `Docs/closeouts/nexus_prebeta_rebaseline_through_v1.3.0-prebeta.md`
+  - `Docs/closeouts/nexus_prebeta_rebaseline_through_v1.3.1-prebeta.md`
 
 ## Historical Jarvis Closeouts
 

--- a/Docs/closeouts/nexus_prebeta_rebaseline_through_v1.3.1-prebeta.md
+++ b/Docs/closeouts/nexus_prebeta_rebaseline_through_v1.3.1-prebeta.md
@@ -1,0 +1,115 @@
+# Nexus Pre-Beta Rebaseline Through v1.3.1-prebeta
+
+## Purpose
+
+This document is the modern Nexus-era rebaseline through `v1.3.1-prebeta`.
+
+Its job is to:
+
+- summarize the current shared pre-Beta baseline
+- capture what is locked versus deferred
+- reduce prompt bloat by replacing repeated lane recaps
+- point back to preserved historical closeouts without rewriting them
+
+## Baseline Scope
+
+This rebaseline covers merged shared truth through the released public prerelease:
+
+- `v1.3.1-prebeta`
+
+It stands on top of the preserved historical closeout line indexed in:
+
+- `Docs/closeout_index.md`
+
+## Material Closed Workstreams In This Baseline
+
+The closed workstreams that materially define the current baseline are:
+
+- `Docs/workstreams/FB-028_history_state_relocation.md`
+- `Docs/workstreams/FB-033_startup_snapshot_harness_follow_through.md`
+- `Docs/workstreams/FB-025_boot_desktop_milestone_taxonomy_clarification.md`
+- `Docs/workstreams/FB-034_recoverable_diagnostics.md`
+- `Docs/workstreams/FB-035_release_context_fallback_hardening.md`
+- `Docs/workstreams/FB-027_interaction_system_baseline.md`
+- `Docs/workstreams/FB-036_saved_action_authoring.md`
+- `Docs/workstreams/FB-041_deterministic_callable_group_execution_layer.md`
+
+## What Is Locked Now
+
+Through `v1.3.1-prebeta`, current shared truth includes:
+
+- launcher-owned historical state is not a live root-logs surface
+- the startup snapshot harness is a bounded dev-only and opt-in debugging surface
+- boot and desktop milestone taxonomy remains clarified without collapsing ownership boundaries
+- one recoverable-operational-incident class is closed and shipped:
+  - repeated identical `launch_failed` for the same action in a still-running session
+- support-report fallback now derives release context from released-canon truth instead of the highest planned prerelease target
+- the manual-reporting boundary remains local and manual only
+- the typed-first desktop interaction baseline is explicit and validator-defended
+- built-in actions and saved actions resolve through one shared action catalog
+- the first bounded interaction capability milestone is released:
+  - first-class URL target support for saved actions without changing exact-match resolution, state-machine boundedness, or input-capture behavior
+- the later bounded FB-027 follow-through is also released:
+  - saved-action inventory and guided access
+  - built-in-vs-saved distinction in choose and confirm
+  - saved-source health visibility for missing, invalid, template-only, and colliding states
+  - directly coupled validator expansion for inventory, origin, and source-state visibility
+- the released FB-036 milestone is part of the locked shared pre-Beta baseline:
+  - bounded custom-task create, edit, and delete flows
+  - explicit trigger modeling with alias-root invocation for newly created tasks
+  - bounded callable-group create, manage, and exact invocation
+  - bounded single-group assignment and inline group quick-create
+  - immediate catalog reload and fail-closed malformed-source blocking for authoring paths
+  - final exact-green interactive proof plus launched-process UI audit for the released authoring baseline
+- the released FB-041 milestone is now part of the locked shared pre-Beta baseline:
+  - deterministic callable-group execution after confirm
+  - stored-order group member execution
+  - stop-on-first-failure semantics
+  - terminal group success or failure propagation
+  - bounded runtime progression markers for group start, per-step progression, and terminal completion or failure
+  - group failure reuse of the existing recoverable launch-failure classification pipeline with structured group-aware context
+  - confirm and result status text aligned to full stored-order group execution
+  - unchanged single-action confirm, dispatch, result, and failure behavior
+
+## What Remains Deferred
+
+This rebaseline does not authorize automatic continuation into:
+
+- curated built-in system actions and Nexus settings expansion
+- taskbar or tray quick-task entry surfaces
+- external trigger and plugin integration architecture
+- monitoring, thermal, or performance HUD surfaces
+- scheduling, branching, or multi-step orchestration beyond deterministic stored-order callable-group execution
+- nested callable groups
+- parallel callable-group execution
+- retries
+- Action Studio behavior
+- voice invocation
+- shutdown exit-confirmation work
+- hotkey cleanup before Beta
+- broader reporting-policy or upload-behavior work
+- broader boot-layer implementation work
+- broader interaction, rebrand, voice, or UI follow-through by inertia
+
+## Forward-Planning Posture After This Baseline
+
+Current merged truth is again between released non-doc implementation lanes.
+
+FB-041 release debt is cleared by `v1.3.1-prebeta`.
+
+The next implementation workstream must be chosen from refreshed backlog, workstream, product-boundary, and release truth on updated `main` through the strict `Branch Readiness` admission flow rather than by continuing FB-036 or FB-041 by inertia.
+
+## Historical Relationship
+
+The preserved historical Jarvis closeout line remains valid historical context.
+
+Use:
+
+- `Docs/closeout_guidance.md` for closeout and rebaseline policy
+- `Docs/closeout_index.md` for historical closeout lookup
+
+This document does not rewrite those historical closeouts.
+
+## Carry-Forward Rule
+
+Future prompts should usually treat this rebaseline plus the retained workstream records as the modern carry-forward baseline through `v1.3.1-prebeta` instead of replaying each closed lane narrative in full.

--- a/Docs/feature_backlog.md
+++ b/Docs/feature_backlog.md
@@ -26,16 +26,7 @@ Historical note:
 
 ## Promoted Canonical Workstreams
 
-### [ID: FB-041] Deterministic callable-group execution layer
-
-Status: Merged unreleased on `main`
-Record State: Promoted
-Priority: High
-Release Stage: pre-Beta
-Target Version: TBD
-Canonical Workstream Doc: Docs/workstreams/FB-041_deterministic_callable_group_execution_layer.md
-Summary: Land the first bounded callable-group follow-through execution layer for deterministic linear member execution in stored order with stop-on-failure, terminal success or failure propagation, and runtime progression markers.
-Why it matters: Released FB-036 intentionally deferred callable-group execution follow-through. FB-041 is now merged unreleased implementation debt on `main`, so it remains the promoted current-truth owner until release-debt handling is complete.
+- none currently
 
 ## Registry Items
 
@@ -150,6 +141,17 @@ Summary: Track future runtime monitoring and HUD surfaces for GPU / CPU thermals
 Why it matters: Monitoring overlays are a separate runtime and status surface and should not be bolted onto the saved-action system without an explicit product boundary.
 
 ## Closed Canonical Workstreams
+
+### [ID: FB-041] Deterministic callable-group execution layer
+
+Status: Released (v1.3.1-prebeta)
+Record State: Closed
+Priority: High
+Release Stage: pre-Beta
+Target Version: v1.3.1-prebeta
+Canonical Workstream Doc: Docs/workstreams/FB-041_deterministic_callable_group_execution_layer.md
+Summary: Released the first bounded callable-group follow-through execution layer for deterministic linear member execution in stored order with stop-on-failure, terminal success or failure propagation, and runtime progression markers.
+Why it matters: FB-041 closes the released FB-036 callable-group execution follow-through by supporting full stored-order group execution without reopening authoring, changing single-action behavior, or widening into scheduling, branching, retries, nested groups, or parallelism.
 
 ### [ID: FB-036] Limited saved-action authoring and type-first custom task UX
 

--- a/Docs/prebeta_roadmap.md
+++ b/Docs/prebeta_roadmap.md
@@ -61,28 +61,27 @@ Use these release-state values when relevant:
 
 Current merged truth indicates:
 
-- latest public prerelease: `v1.3.0-prebeta`
-- latest public release commit: `11eb8ad`
-- merged unreleased non-doc implementation debt currently exists on `main`
-- the latest public released implementation milestone is FB-036 saved-action authoring and callable groups in `v1.3.0-prebeta`
-- that merged unreleased implementation debt is FB-041 deterministic callable-group execution layer
-- no next implementation branch may enter `Branch Readiness` until release-debt handling is complete
+- latest public prerelease: `v1.3.1-prebeta`
+- latest public release commit: `f743281`
+- no merged unreleased non-doc implementation debt currently exists on `main`
+- the latest public released implementation milestone is FB-041 deterministic callable-group execution layer in `v1.3.1-prebeta`
+- no next implementation branch is currently selected
 
-That means the released FB-027 interaction baseline plus the later released FB-036 authoring-and-callable-group milestone remain the latest public shared pre-Beta baseline, while FB-041 is now merged unreleased truth above that baseline.
+That means the released FB-027 interaction baseline, the released FB-036 authoring-and-callable-group milestone, and the released FB-041 deterministic callable-group execution milestone are now part of the current public shared pre-Beta baseline.
 
-## Current Release-Debt Workstream
+## Most Recent Released Workstream Context
 
 ### FB-041 Deterministic Callable-Group Execution Layer
 
-- status: `merged unreleased on main`
+- status: `released`
 - lane type: `implementation`
 - release floor: `patch prerelease`
-- target version: `TBD`
-- release state: `merged unreleased`
+- target version: `v1.3.1-prebeta`
+- release state: `released`
 - canonical workstream doc: `Docs/workstreams/FB-041_deterministic_callable_group_execution_layer.md`
-- sequencing note: the first bounded callable-group execution follow-through lane is now merged to `main`, merged current-state canon is aligned by this governance pass, and release-debt handling still needs to complete before a next implementation branch may begin
+- sequencing note: released deterministic stored-order callable-group execution, stop-on-failure semantics, group-aware failure-path reuse, and confirm/result status alignment while preserving single-action behavior
 
-## Most Recent Released Workstream Context
+## Prior Released Workstream Context
 
 ### FB-036 Saved-Action Authoring And Callable Groups
 
@@ -159,11 +158,11 @@ Current merged truth indicates:
 
 - the released FB-027 baseline remains part of the locked current interaction floor
 - the released FB-036 authoring-and-callable-group milestone is now part of the locked current pre-Beta baseline
+- the released FB-041 deterministic callable-group execution milestone is now part of the locked current pre-Beta baseline
 - the released FB-035 lane is closed
 - the recent released workstreams above remain part of the locked current baseline
-- merged unreleased non-doc implementation debt currently exists on `main`
-- FB-041 is the merged unreleased implementation-debt owner on current merged truth
-- repo state is `No Active Branch` for next-lane execution until release-debt handling is complete
+- no merged unreleased non-doc implementation debt currently exists on `main`
+- repo state has no active implementation branch selected after the FB-041 release
 - if a branch changes release-facing canon, those canon updates must land on that same branch before PR readiness is allowed
 - post-release canon repair is emergency-only when merged canon is already stale or external drift made pre-merge prevention impossible
 - the released FB-027 baseline does not authorize further saved-action authoring, resolution, voice, Action Studio, routines, profiles, hotkey cleanup, or shutdown-confirmation work by inertia
@@ -173,8 +172,7 @@ Current merged truth indicates:
   - FB-039 for external trigger and plugin integration architecture
   - FB-040 for monitoring, thermals, and performance HUD surfaces
 - those candidate lanes must be selected deliberately rather than bundled together as one implicit interaction continuation
-- FB-041 remains the promoted current-truth owner only as the merged-unreleased release-debt record, not as permission to start another execution branch by inertia
-- the next implementation workstream must not be selected or branched until FB-041 release-debt handling is complete
+- the next implementation workstream must be selected deliberately through `Branch Readiness` from updated `main`; FB-041 release does not imply automatic continuation into any candidate lane
 
 Use canonical workstream docs for execution detail.
 Use the backlog for item identity.

--- a/Docs/workstreams/FB-041_deterministic_callable_group_execution_layer.md
+++ b/Docs/workstreams/FB-041_deterministic_callable_group_execution_layer.md
@@ -7,11 +7,11 @@
 
 ## Record State
 
-- `Promoted`
+- `Closed`
 
 ## Status
 
-- `Merged unreleased on main`
+- `Released (v1.3.1-prebeta)`
 
 ## Release Stage
 
@@ -19,13 +19,15 @@
 
 ## Target Version
 
-- `TBD`
+- `v1.3.1-prebeta`
 
 ## Canonical Branch
 
 - `No Active Branch`
 - historical implementation branch:
   - `feature/fb-041-deterministic-callable-group-execution`
+- release packaging branch:
+  - `codex/fb-041-release-debt-packaging`
 
 ## Purpose / Why It Matters
 
@@ -33,50 +35,17 @@ Promote the first bounded callable-group follow-through execution layer above th
 
 This workstream exists so callable groups can move from exact invocation only into deterministic runtime follow-through without reopening FB-036 authoring foundations, widening into automation design, or overlapping the separate future lanes already tracked in FB-037 through FB-040.
 
-## Current Phase
+## Current Release-Truth Note
 
-- Phase: `Release Readiness`
-
-## Phase Status
-
-- `No Active Branch`
-- `FB-041` is the merged-unreleased release-debt owner on updated `main`
-- merged current-state canon is aligned by the governance correction pass; release-debt handling remains outstanding before the repo may legally begin next-lane execution
-
-## Branch Class
-
-- `release packaging`
-
-## Blockers
-
-- `Release Debt`
-
-## Entry Basis
-
-- merged `main` includes the FB-041 implementation merge from PR `#58`
-- latest public prerelease remains `v1.3.0-prebeta`, so FB-041 is merged unreleased implementation debt above the latest public baseline
-- merged current-state canon now reflects FB-041 as the merged-unreleased release-debt owner across backlog, roadmap, and workstream indexing layers
-- no next implementation branch may legally begin until release-debt handling is explicit
-
-## Exit Criteria
-
-- backlog, roadmap, workstreams index, and this workstream doc agree on the same merged-unreleased posture
-- release packaging inputs are explicit and no unresolved blocker remains
-- if a real correctness, canon, regression, or governance issue appears during release review, the repo reopens to the failed earlier phase instead of starting next-lane execution
-
-## Rollback Target
-
-- `PR Readiness`
-
-## Next Legal Phase
-
-- `Release Readiness` on a release packaging or emergency canon repair branch once release-debt handling is explicitly opened
+- FB-041 is released in `v1.3.1-prebeta`
+- the FB-041 release-debt blocker is cleared by the public prerelease
+- this closed workstream record is historical lane truth, not active execution authority
+- no next implementation branch is selected by this release record
+- any future implementation lane must enter through strict `Branch Readiness` from updated `main`
 
 ## Current Branch Truth
 
-- the latest public shared baseline remains the released FB-027 interaction floor plus the released FB-036 authoring-and-callable-group milestone in `v1.3.0-prebeta`
-- `main` now also contains merged unreleased FB-041 callable-group execution follow-through above that public baseline
-- repo state is currently `No Active Branch` for next-lane execution until release-debt handling is complete
+- the latest public shared baseline is the released FB-027 interaction floor plus the released FB-036 authoring-and-callable-group milestone and the released FB-041 deterministic callable-group execution milestone in `v1.3.1-prebeta`
 - exact group invocation still enters through the released chooser and confirm flow, but group follow-through now executes the full stored-order callable group after confirm
 - deterministic callable-group execution now emits bounded runtime markers for:
   - group start
@@ -86,6 +55,40 @@ This workstream exists so callable groups can move from exact invocation only in
 - dispatch now consumes immutable execution intent captured at confirm time rather than ambient overlay group state
 - group failures now reuse the existing recoverable launch-failure classification pipeline with structured group-aware payloads
 - single-action dispatch, confirm text, result text, and failure behavior remain unchanged except where the documented confirm/result group-only clarification exceptions apply
+
+## Release Definition
+
+The public prerelease for this lane is `v1.3.1-prebeta`.
+
+That release means:
+
+- saved callable groups are officially supported for full stored-order member execution after confirm instead of stopping at exact single-member invocation behavior
+- group execution is officially supported as deterministic and stop-on-failure, with bounded runtime progression markers for group start, per-step progression, and terminal completion or failure
+- group failures stay aligned to the existing recoverable launch-failure classification path rather than introducing a separate failure system
+- group confirm and result copy accurately describe full stored-order group execution while single-action behavior remains unchanged
+
+## Release Artifacts
+
+- tag:
+  - `v1.3.1-prebeta`
+- high-level release notes:
+  - deterministic callable-group execution is now supported after confirm
+  - callable-group execution follows persisted stored order and stops on first failure
+  - group failures reuse the existing recoverable launch-failure classification path with group-aware context
+  - group confirm and result status text now accurately describe full stored-order group execution
+  - single-action confirm, dispatch, result, and failure behavior remain unchanged
+- supporting release artifacts:
+  - `Docs/closeouts/nexus_prebeta_rebaseline_through_v1.3.1-prebeta.md`
+  - FB-041 workstream record converted to historical released-lane truth
+  - existing FB-041 validator and interactive evidence references retained as release-supporting proof
+
+## Release Closeout
+
+- released in public prerelease `v1.3.1-prebeta`
+- release-debt state cleared for FB-041
+- backlog, roadmap, workstreams index, closeout index, and Nexus-era rebaseline now treat FB-041 as closed released truth
+- no next implementation lane is selected by this closeout
+- future work must enter through the strict branch-governance admission flow
 
 ## Governance Drift Audit
 
@@ -104,8 +107,8 @@ This workstream exists so callable groups can move from exact invocation only in
   - add the governance validator
   - strengthen current-state claim containment
   - update prompt scaffolds to the exact prompt contract
-- Whether The Drift Blocks Merge: `This governance branch resolves the drift; after merge the remaining blocker is release debt, which still blocks next-lane execution`
-- Whether User Confirmation Is Required: `No for the current approved governance pass`
+- Whether The Drift Blocks Merge: `No; the governance drift was resolved before release, and the FB-041 release-debt blocker is cleared by v1.3.1-prebeta`
+- Whether User Confirmation Is Required: `No; this is historical release evidence for the completed governance pass`
 
 ## Scope
 
@@ -137,7 +140,7 @@ Exception:
 
 - `Docs/workstreams/FB-036_saved_action_authoring.md`
 - `Docs/workstreams/FB-027_interaction_system_baseline.md`
-- `Docs/closeouts/nexus_prebeta_rebaseline_through_v1.3.0-prebeta.md`
+- `Docs/closeouts/nexus_prebeta_rebaseline_through_v1.3.1-prebeta.md`
 - `desktop/interaction_overlay_model.py`
 - `desktop/shared_action_model.py`
 

--- a/Docs/workstreams/index.md
+++ b/Docs/workstreams/index.md
@@ -71,15 +71,13 @@ For an active or recently closed canonical workstream, keep these durable tracea
 ### Active
 
 Active here means the current promoted truth owner.
-That may be:
+That may be an executable branch owner or another explicitly promoted current-truth owner.
 
-- an executable branch owner, or
-- a merged-unreleased release-debt owner while repo state is `No Active Branch`
-
-- `Docs/workstreams/FB-041_deterministic_callable_group_execution_layer.md`
+- none currently
 
 ### Closed
 
+- `Docs/workstreams/FB-041_deterministic_callable_group_execution_layer.md`
 - `Docs/workstreams/FB-036_saved_action_authoring.md`
 - `Docs/workstreams/FB-027_interaction_system_baseline.md`
 - `Docs/workstreams/FB-035_release_context_fallback_hardening.md`

--- a/dev/orin_branch_governance_validation.py
+++ b/dev/orin_branch_governance_validation.py
@@ -324,15 +324,75 @@ def main() -> int:
             f"{relative_path}: docs/governance branch-admission guidance is missing",
         )
 
-    promoted_entries = [
-        entry
-        for entry in _parse_backlog_sections(backlog_text)
-        if entry.get("record_state") == "Promoted"
-    ]
-    require(bool(promoted_entries), "Docs/feature_backlog.md: expected at least one promoted workstream")
-
     active_index_paths = _collect_active_index_paths(index_text)
     closed_index_paths = _collect_closed_index_paths(index_text)
+
+    backlog_entries = _parse_backlog_sections(backlog_text)
+    promoted_entries = [
+        entry
+        for entry in backlog_entries
+        if entry.get("record_state") == "Promoted"
+    ]
+    if not promoted_entries:
+        require(
+            not active_index_paths,
+            "Docs/workstreams/index.md: Active list must be empty when no backlog workstream is Promoted",
+        )
+
+    fb041_entries = [entry for entry in backlog_entries if entry.get("id") == "FB-041"]
+    require(bool(fb041_entries), "Docs/feature_backlog.md: FB-041 backlog entry is missing")
+    if fb041_entries:
+        fb041_entry = fb041_entries[0]
+        fb041_path = fb041_entry["canonical_path"]
+        require(
+            fb041_entry["record_state"] == "Closed",
+            "Docs/feature_backlog.md: FB-041 must be Closed after v1.3.1-prebeta release",
+        )
+        require(
+            _normalize_status(fb041_entry["status"]) == "released",
+            "Docs/feature_backlog.md: FB-041 must be Released after v1.3.1-prebeta release",
+        )
+        require(
+            fb041_path in closed_index_paths,
+            "Docs/workstreams/index.md: FB-041 must be listed under Closed after v1.3.1-prebeta release",
+        )
+        require(
+            fb041_path not in active_index_paths,
+            "Docs/workstreams/index.md: FB-041 must not remain under Active after v1.3.1-prebeta release",
+        )
+
+        if fb041_path:
+            fb041_doc_path = Path(fb041_path)
+            require(
+                (ROOT_DIR / fb041_doc_path).is_file(),
+                f"{fb041_path}: FB-041 workstream doc does not exist",
+            )
+            if (ROOT_DIR / fb041_doc_path).is_file():
+                fb041_text = _read_text(fb041_doc_path)
+                fb041_info = _parse_workstream_doc(fb041_text)
+                require(
+                    fb041_info["record_state"] == "Closed",
+                    f"{fb041_path}: Record State must be Closed after v1.3.1-prebeta release",
+                )
+                require(
+                    _normalize_status(str(fb041_info["status"])) == "released",
+                    f"{fb041_path}: Status must be Released after v1.3.1-prebeta release",
+                )
+
+        fb041_roadmap_section = _roadmap_section_for_id(roadmap_text, "FB-041")
+        require(
+            bool(fb041_roadmap_section),
+            "Docs/prebeta_roadmap.md: FB-041 release section is missing",
+        )
+        if fb041_roadmap_section:
+            require(
+                fb041_path in fb041_roadmap_section,
+                "Docs/prebeta_roadmap.md: FB-041 release section must cite the canonical workstream doc",
+            )
+            require(
+                "release state: `released`" in fb041_roadmap_section,
+                "Docs/prebeta_roadmap.md: FB-041 release state must be `released`",
+            )
 
     for entry in promoted_entries:
         workstream_id = entry["id"]


### PR DESCRIPTION
## Summary

Finalizes the repo-facing release state for FB-041 after publication of v1.3.1-prebeta.

## What Changed

Includes:
- updates current-state canon from merged-unreleased to released
- closes FB-041 in backlog/workstream records
- advances latest public prerelease to v1.3.1-prebeta
- updates closeout/baseline pointers to the v1.3.1-prebeta rebaseline
- refreshes branch-governance validation for the released state

Tag already exists and points to main commit f743281.
This PR brings merged canon into alignment with the published prerelease.

Includes:
- updates current-state canon from merged-unreleased to released
- closes FB-041 in backlog/workstream records
- advances latest public prerelease to v1.3.1-prebeta
- updates closeout/baseline pointers to the v1.3.1-prebeta rebaseline
- refreshes branch-governance validation for the released state
