### PR TITLE
FB-037: Curated built-in actions and PR-readiness canon

### DIFF
--- a/Docs/Main.md
+++ b/Docs/Main.md
@@ -195,8 +195,11 @@ These are reference layers, not active workstream or roadmap owners.
 - do not create duplicate authority by making backlog, roadmap, and workstream docs all carry the same execution story
 - do not treat workstream docs as the owner of repo-wide phase, timeout, stop-loss, proof-authority, validation-helper, or desktop UI audit rules; those belong to `Docs/phase_governance.md`
 - keep historical Jarvis material preserved, but mark it as historical rather than current reality
-- during the normal active-branch-first `pre-Beta` flow, do not default to a standalone docs-only canon lane when a plausible active implementation or release branch should carry the truth updates
-- a planned standalone `docs/governance` branch is future-capable from `No Active Branch`, but only when the branch-class admission rules pass and the branch is genuinely governance, policy, docs, or triage work rather than delayed implementation follow-through
+- during the normal active-branch-first `pre-Beta` flow, governance and canon updates should ride on the active current branch when they are directly required to keep that branch truthful, executable, phase-correct, readiness-correct, validation-correct, closeout-correct, or release-correct
+- active-branch governance or canon updates must stay inside the current branch's approved phase, branch class, and scope; they must not weaken validation, stop conditions, phase authority, or become unrelated documentation churn
+- do not default to a standalone docs-only canon lane when a plausible active implementation or release branch should carry the truth updates
+- a planned standalone `docs/governance` branch is an exception path, not the preferred default; it is future-capable from `No Active Branch`, but only when the branch-class admission rules pass and the branch is genuinely governance, policy, docs, or triage work rather than delayed implementation follow-through
+- standalone governance or docs-style branches are reserved for repo-wide governance work not tightly coupled to one active branch, emergency canon repair, cross-branch truth repair that cannot safely live on one active branch, or governance work that would contaminate or confuse an active implementation or release branch
 - the normal governed branch lifecycle is:
   1. `Branch Readiness`
   2. `Workstream`
@@ -204,25 +207,35 @@ These are reference layers, not active workstream or roadmap owners.
   4. `Live Validation`
   5. `PR Readiness`
   6. `Release Readiness`
+- `Branch Readiness` must plan the whole branch at phase level before Workstream begins, including objective, target end-state, expected seam families and risk classes, validation contract, User Test Summary strategy, later-phase needs, and first seam or seam sequence
+- during `Workstream`, `bounded multi-seam workflow` is the primary model for coherent same-risk seam chains; execute one active seam at a time, validate it, record evidence, and report `continue` or `stop` before the next seam
+- single-seam fallback is required for bug fixes, hotfixes, unclear or high-risk seams, cross-subsystem changes, settings/protocol/launcher/UI-model changes, or any pass where validation cannot support safe continuation
+- `Workstream` completion does not imply PR readiness; the normal next legal phase is `Hardening`, followed by `Live Validation` and then `PR Readiness`
 - `Post-Release Canon Repair` is not a normal phase; it is an emergency-only exception path after merged or released truth already exists
 - before any next implementation branch may enter `Branch Readiness`, the repo-level admission gate from `Docs/phase_governance.md` must pass on updated `main`
 - if repo truth resolves to blocked `No Active Branch`, report the blocking repair path
 - if repo truth resolves to steady-state `No Active Branch`, do not invent a next implementation branch by inertia
 - the normal `PR Readiness` sequence for a branch that changes release-facing canon is:
+  0. clear the hard PR Readiness blockers: `stale-canon`, `post-merge`, `dirty`, `docs-sync`, and `next-workstream`
   1. validate current branch truth
   2. complete the merge-target canon updates on that same branch
   3. run the Governance Drift Audit
-  4. if post-merge truth will admit a next branch, select the next workstream from current canon
-  5. if post-merge truth will admit a next branch, confirm the next workstream has canon-valid record state
-  6. if post-merge truth will admit a next branch, create the fresh successor branch
-  7. if post-merge truth will admit a next branch, keep that successor branch reserved until it is revalidated after merge
-  8. If post-merge truth will resolve to `No Active Branch` because `Release Debt` or another repo-level admission blocker remains open, successor-lane selection and reserved successor-branch creation are waived for that PR-readiness pass.
-  9. when that waiver applies, record the blocked repo state explicitly
-  10. only then allow the current branch to enter PR creation
+  4. clear the stale-canon blocker by proving current-state canon and merge-target canon reflect the branch's true state
+  5. select the next workstream from current canon
+  6. confirm the next workstream is recorded in backlog and roadmap
+  7. confirm the next workstream has canon-valid record state and minimal scope
+  8. confirm no branch exists yet for that next workstream
+  9. defer successor branch creation to `Branch Readiness` after merge and updated-`main` revalidation
+  10. encode the machine-checkable selected-next markers: `Next Workstream: Selected` and `Minimal Scope:` in backlog, plus `## Selected Next Workstream` with `Branch: Not created` in roadmap
+  11. If post-merge truth will resolve to `No Active Branch` because `Release Debt` or another repo-level admission blocker remains open, successor branch creation remains deferred; next-workstream selection is still required unless the user explicitly approves a no-next-workstream steady-state outcome in canon.
+  12. commit all required docs, canon, validator, and branch-truth changes so the worktree is clean and truth is durable in commit history
+  13. run the normal branch governance validator and the PR-readiness gate mode
+  14. only then allow the current branch to report `PR READY: YES` and enter PR creation
 - a standalone post-release canon repair is an emergency-only exception path when merged canon is already stale or when external drift made pre-merge prevention impossible
 - returned `UTS`, screenshot, interactive, PR-review, or release-review evidence must be digested into the authority record before phase advancement is recommended
 - when a slice changes user-visible behavior or another operator-facing path, do not treat `## User Test Summary` as a recap slot; route through `Docs/user_test_summary_guidance.md` and require a real manual checklist unless no meaningful manual test exists
 - when an active desktop workstream has a canonical repo-level `UTS` artifact, do not stop at response text; update that workstream-owned artifact as well unless an explicit exception from `Docs/user_test_summary_guidance.md` applies
+- during bounded multi-seam Workstream execution, update the canonical workstream `UTS` incrementally as user-visible seams land, then refresh the desktop export when the Workstream seam chain is complete and the branch is user-facing
 - for relevant desktop user-facing slices, also export or refresh `C:\Users\anden\OneDrive\Desktop\User Test Summary.txt` unless an explicit exception from `Docs/user_test_summary_guidance.md` applies
 - do not confuse the canonical workstream-owned repo artifact with the required desktop convenience export or with response-level handoff text
 - when a user-visible implementation slice is already validator-green, do not assume that alone is enough to continue; route through `Docs/development_rules.md` and require an explicit hardening or continuation judgment
@@ -231,6 +244,8 @@ These are reference layers, not active workstream or roadmap owners.
 - keep validator results, synthetic/headless validation results, interactive OS-level execution results, simulated reasoning, and manual handoff as separate evidence layers rather than collapsing them into one summary
 - when a pass opens programs, windows, dialogs, temporary documents, helper processes, probe files, or other session-scoped artifacts, route through `Docs/development_rules.md` and require cleanup plus explicit cleanup verification before handoff unless there is an explicit reason to preserve them
 - when a task depends on interactive desktop validation, route through `Docs/development_rules.md` and require explicit time budgets, clean timeout abort behavior, cleanup, and last-progress reporting rather than relying on open-ended waits
+- when a task depends on Live Validation or another interactive desktop helper, route through `Docs/phase_governance.md` and require reuse-first selection from existing helpers before creating new scripts; temporary one-off probes must stay ignored, temporary, and non-closeout-grade unless promoted into documented reusable tooling
+- when a live validation helper has no tighter watchdog, require a `10s` maximum no-progress supervisor with visible progress, clean abort, cleanup, and last confirmed progress reporting
 - when closeout depends on interactive desktop validation, also route through `Docs/phase_governance.md` and require the helper's documented default budget profile to prove green before calling the branch truly green
 - when a branch materially changes user-facing desktop UI, require the post-green live launched-process UI audit before treating closeout as complete; do not reinterpret that as a screenshot requirement for every seam iteration
 - when the user also wants those audit screenshots to render inside the Codex client, use the screenshot-delivery guidance in `Docs/codex_user_guide.md`, which now defaults to small inline PNG preview images backed by preserved original files on disk, rather than assuming local-file image embeds will work

--- a/Docs/Main.md
+++ b/Docs/Main.md
@@ -127,6 +127,7 @@ Rules:
 Use these for promoted work that needs a stable feature-state, branch-local validation/evidence record, active seam trail, durable artifact/reuse history, and closure history:
 
 - `Docs/workstreams/index.md`
+- `Docs/workstreams/FB-037_built_in_actions_and_settings_expansion.md`
 - `Docs/workstreams/FB-036_saved_action_authoring.md`
 - `Docs/workstreams/FB-041_deterministic_callable_group_execution_layer.md`
 - `Docs/workstreams/FB-035_release_context_fallback_hardening.md`

--- a/Docs/codex_modes.md
+++ b/Docs/codex_modes.md
@@ -123,6 +123,7 @@ In Workflow mode, Codex should:
 - make the required changes
 - verify the changed behavior or changed docs
 - report any drift or remaining gaps honestly
+- when the approved Workstream boundary contains a coherent same-risk seam chain, use bounded multi-seam workflow as the primary model while executing one active seam at a time
 - when the approved boundary is continuous validation inside the current workstream, keep iterating until the full gate is green or a hard stop is reached
 
 ### What Codex Must Not Do
@@ -143,6 +144,7 @@ Workflow mode should usually return:
 - a distinct summary of validator results
 - a distinct summary of synthetic or headless validation results and the supporting validation artifacts created or used
 - a distinct summary of interactive OS-level execution results when that path is feasible
+- the existing helper, harness, or shared support reused for interactive validation, or the explicit reason a temporary probe or new helper was necessary
 - session cleanup performed and explicitly verified, including what was closed, stopped, restored, or deleted after the pass
 - any remaining simulated-only findings or reasoning-only gaps that still matter
 - deeper branch-local validation or hardening findings when the slice changes runtime or user-visible behavior
@@ -161,20 +163,28 @@ When the approved phase is `PR Readiness`, the output must also explicitly inclu
 - confirmation that the merge-target canon completeness gate passed
 - confirmation that the Governance Drift Audit ran
 - whether governance drift was found
-- when post-merge truth will admit a next branch:
+- confirmation that stale-canon, post-merge-state, next-workstream, dirty-branch, and docs-sync/drift-audit blockers are clear
+- confirmation that branch truth is committed and durable, not only present in the working tree
+- confirmation that the normal governance validator and the PR-readiness gate mode passed
+- for the selected next workstream:
   - the selected next workstream identity
   - the next workstream `Record State`
-  - the successor branch name
-  - confirmation that the successor branch was created
-  - confirmation that the successor branch is reserved until revalidated after merge
+  - the minimal scope recorded in canon
+  - confirmation that backlog includes `Next Workstream: Selected` and `Minimal Scope:` and roadmap includes `## Selected Next Workstream`
+  - confirmation that no branch exists yet for that next workstream
+  - confirmation that successor branch creation is deferred to `Branch Readiness` after merge and updated-`main` revalidation
 - when post-merge truth will resolve to `No Active Branch` because `Release Debt` or another repo-level admission blocker remains open:
   - repo state `No Active Branch`
   - the blocking admission item
-  - confirmation that successor lock was waived for the pass
+  - confirmation that branch creation remains deferred and no next implementation branch may execute by inertia
 
 Do not report cleanup as complete unless the pass has explicitly checked for leftover apps, windows, dialogs, helper processes, probe files, or other temporary artifacts it created or opened.
 
 Do not report an interactive validation pass as complete or trustworthy if it exceeded its time budgets or sat stalled without a clean abort path.
+
+Do not create a new live-validation script by default.
+For Live Validation, Codex should reuse existing helpers first, then parameterize or extend them, then extract shared support if several helpers need the same watchdog or cleanup behavior.
+Temporary one-off probes are allowed only as ignored exploratory artifacts and must be deleted or promoted into documented reusable tooling before closeout-grade proof is claimed.
 
 ## Workstream And Branch Governance
 
@@ -187,6 +197,23 @@ That means:
 - one branch may host multiple validated slices for one milestone
 - grouped workstreams should not become grab-bags of unrelated ideas
 - lane evaluation should stay milestone-driven rather than slice-driven
+
+### Bounded Multi-Seam Workflow
+
+For coherent Workstream implementation, bounded multi-seam workflow is the primary execution model.
+
+That means:
+
+- Branch Readiness should plan the branch objective, target end-state, expected seam families, risk classes, validation contract, User Test Summary strategy, later-phase needs, and first seam sequence
+- Workstream may execute multiple planned seams in one pass only when they share the same workstream, phase, branch class, risk class, and subsystem family or tightly coupled chain
+- each seam is still analyzed, bounded, implemented, validated, recorded, and judged before the next seam starts
+- the output must report the per-seam validation result and `continue` or `stop` decision
+- a risk-class change, validation failure, scope drift, governance drift, unresolved manual-validation blocker, or branch-truth contradiction stops the workflow
+
+Single-seam fallback is required for bug fixes, hotfixes, unclear or high-risk seams, cross-subsystem work, settings/protocol/launcher/UI-model changes, or any pass where validation cannot support safe continuation.
+
+Completing Workstream seams does not make the branch PR-ready by itself.
+The normal next legal phase is `Hardening`, then `Live Validation`, then `PR Readiness`.
 
 ### Milestone Gate
 
@@ -227,9 +254,11 @@ If repo truth is a steady-state `No Active Branch`, say so explicitly instead of
 
 After a workstream is merged and closed, the next implementation workstream should execute from updated `main` on a fresh branch.
 
-That successor branch may be created during `PR Readiness`, but it must stay reserved until the current branch merges and the successor branch is revalidated against updated `main`.
+During `PR Readiness`, the next workstream must be selected, canon-defined, minimally scoped, and explicitly not branched yet.
 
-If post-merge truth will resolve to `No Active Branch` because `Release Debt` or another repo-level admission blocker remains open, successor-lane selection and reserved successor-branch creation are waived for that PR-readiness pass.
+That successor branch is created only during `Branch Readiness` after the current branch merges and updated `main` is revalidated.
+
+If post-merge truth will resolve to `No Active Branch` because `Release Debt` or another repo-level admission blocker remains open, successor branch creation remains deferred; next-workstream selection is still required unless the user explicitly approves a no-next-workstream steady-state outcome in canon.
 
 If a branch is stale, merged, or identical to `main`, call it out explicitly and stop using it as the base for next-lane planning.
 
@@ -261,6 +290,9 @@ Do not collapse those two cases into one label.
 - `Docs/phase_governance.md` owns repo-wide phase, proof, timeout, seam, stop-loss, validation-helper, and desktop UI audit rules
 - User Test Summary belongs to workstream-owned validation
 - incident patterns are generalized knowledge, not case history
+- governance and canon updates should ride on the active current branch when they are directly required to keep that branch truthful, executable, phase-correct, readiness-correct, validation-correct, closeout-correct, or release-correct
+- standalone governance or docs-style branches are exception paths for repo-wide governance work not tightly coupled to one active branch, emergency canon repair, cross-branch truth repair, or governance work that would contaminate or confuse an active implementation or release branch
+- active-branch governance updates must not weaken validation, stop conditions, phase authority, branch-class authority, or scope control
 
 For desktop workstreams, response-level `## User Test Summary` output and the canonical repo-level `UTS` artifact are related but not interchangeable:
 
@@ -288,6 +320,7 @@ Codex must also:
 - add or create the smallest reliable validation infrastructure when meaningful blind spots remain
 - preserve an evidence trail of the validators, harnesses, helper scripts, fixtures, runtime logs, traces, screenshots, or other validation artifacts actually used
 - clean up test-session side effects such as temporary files, launched apps, helper processes, probe documents, or altered local state unless there is an intentional reason to preserve them
+- enforce visible progress and a no-progress supervisor for live validation; if no tighter helper-specific watchdog is active, `10s` without meaningful progress must stop the run and report the last confirmed progress point
 - use synthetic or headless validators and harnesses as supporting proof rather than the final gate when a real desktop session is feasible
 - launch and exercise the real desktop or runtime path through an interactive OS-level session when feasible
 - explicitly distinguish validator results, synthetic or headless validation results, simulated reasoning, interactive OS-level execution results, and manual user-test handoff

--- a/Docs/codex_user_guide.md
+++ b/Docs/codex_user_guide.md
@@ -74,6 +74,11 @@ For governed closeout recovery, also include:
 - `Validation Contract: <summary or authority reference>` when validation governance matters
 - `Timeout Contract: <summary or authority reference>` when interactive/manual timing governance matters
 
+For bounded multi-seam Workstream execution, also include:
+
+- `Seam Sequence: <ordered seam list>`
+- `Per-Seam Gate: validate, record evidence, and report continue-or-stop before the next seam`
+
 ## What Codex Should Do Automatically
 
 Brief prompts do not waive source-of-truth reading.
@@ -101,6 +106,9 @@ For meaningful interactive desktop hardening or closeout work, that baseline als
 
 - using `Docs/phase_governance.md` for the repo-wide validation helper contract and proof hierarchy
 - using `Docs/development_rules.md` for evidence, cleanup, and hardening expectations
+- reusing existing live-validation helpers before creating new scripts, or recording why reuse is unsafe
+- treating one-off live-validation probes as temporary ignored artifacts that must be deleted or promoted into documented reusable tooling before closeout-grade proof
+- requiring visible helper progress and a no-progress supervisor; if no tighter helper-specific watchdog is active, `10s` without meaningful progress must abort the run, clean up, and report the last confirmed progress point
 - planning the post-green live launched-process UI audit when meaningful user-facing desktop UI changed
 
 ## Codex Client Screenshot Delivery
@@ -207,6 +215,7 @@ Useful execution add-ons:
 Execution-phase discipline such as:
 
 - bounded patching
+- bounded multi-seam workflow
 - minimal isolated change
 - smallest coherent execution slice
 - narrow fix pass
@@ -214,6 +223,21 @@ Execution-phase discipline such as:
 belongs here, after analysis and scope selection are already complete.
 
 ## Prompt Recipes
+
+### Active-Branch Governance Or Canon Update
+
+Use:
+
+- `Workflow mode on current branch: docs-only governance or canon refinement`
+
+Use this when:
+
+- the active branch owns the affected truth
+- the change is directly required to keep that branch truthful, executable, phase-correct, readiness-correct, validation-correct, closeout-correct, or release-correct
+- the prompt names the exact canonical phase and current branch class
+- the update can stay docs-only and inside the active branch's approved scope, validation rules, and stop conditions
+
+Do not use this recipe for unrelated governance cleanup, broad docs churn, product/runtime changes, or work that would contaminate or confuse the active implementation or release branch.
 
 ### Deep Analysis Of The Next Move
 
@@ -271,6 +295,7 @@ Use this only when:
 - the branch purpose is genuinely governance, docs, policy, roadmap, backlog, or triage work
 - the branch is not being used to avoid canon sync that belongs on an active implementation or release branch
 - the branch-class admission rules from `Docs/phase_governance.md` pass
+- the work is repo-wide governance not coupled to one active branch, emergency canon repair, cross-branch truth repair, or governance work that would contaminate or confuse an active implementation or release branch
 
 During `pre-Beta`, this path remains non-default and explicitly justified.
 In later Beta, public, or steady-state repo operation, it may become a normal maintenance path.
@@ -286,6 +311,31 @@ Examples:
 
 - `continue on current branch: finish the approved validator follow-through`
 - `Workflow mode on current branch: execute Phase 2 of canon reconstruction`
+
+### Bounded Multi-Seam Workstream Execution
+
+Use:
+
+- `Workflow mode on current branch: execute bounded multi-seam Workstream sequence`
+
+Required add-ons:
+
+- `Phase: Workstream`
+- `Seam Sequence: [ordered seam list]`
+- `validate after each seam`
+- `report continue-or-stop after each seam`
+- `stop on validation failure, regression, scope drift, risk-class change, governance drift, unresolved manual-validation blocker, or branch-truth inconsistency`
+
+Use this when:
+
+- the seams are in the same workstream, same phase, same branch class, same risk class, and same subsystem family or tightly coupled chain
+- the operator wants Codex to keep moving through a coherent seam sequence without a new prompt after every seam
+- per-seam validation and evidence recording remain mandatory
+
+Do not use this recipe for bug fixes, hotfixes, unclear or high-risk seams, cross-subsystem changes, settings/protocol/launcher/UI-model changes, or any pass where validation cannot support safe continuation.
+
+When the sequence completes, the normal next phase is `Hardening`.
+Do not prompt Codex to treat Workstream completion as direct `PR Readiness`.
 
 ### Run A Narrow Fix Pass
 
@@ -327,6 +377,7 @@ Required add-ons:
 
 - `Phase: Hardening`
 - `use the documented validation timeout profile`
+- `reuse existing validation helpers first`
 - `do not widen scope`
 - `do not stop between seam iterations unless blocker, truth drift, stop-loss, or required canon sync appears`
 - `continue until the full gate is green or a hard stop is hit`
@@ -334,6 +385,7 @@ Required add-ons:
 Helpful add-ons:
 
 - `target no-progress 3s`
+- `fallback maximum no-progress 10s when no tighter helper watchdog exists`
 - `target transition 3s`
 - `target normal seam 60s`
 
@@ -364,6 +416,10 @@ After a workstream is closed, released, merged, or otherwise no longer the right
 
 Prompting should reflect that reality.
 
+PR Readiness selects and minimally scopes the next workstream in canon, but it must also prove no branch exists yet for that next workstream.
+Use machine-checkable markers: `Next Workstream: Selected` and `Minimal Scope:` in the backlog entry, plus `## Selected Next Workstream` and `Branch: Not created` in the roadmap.
+Create the fresh branch only during the next `Branch Readiness` pass after the current branch merges and updated `main` is revalidated.
+
 Do not ask Codex to keep planning from an old lane branch when live repo truth shows that branch is stale, merged, or identical to `main`.
 If repo truth is a steady-state `No Active Branch`, it is also valid for the truthful next move to be no branch at all until a new approved need exists.
 
@@ -387,6 +443,7 @@ The key distinction is prompt length, not analysis depth.
 - add control language only when it materially protects truth or scope
 - use `Analyze for drift` before merge, release, or major canon carry-forward decisions
 - use evidence-digestion language when returned validation evidence should control the next move, rather than implying that phase advancement is automatic
+- in `PR Readiness`, require five hard blocker checks before accepting `PR READY: YES`: `stale-canon`, `post-merge`, `next-workstream`, `dirty`, and `docs-sync`
 - route through `Docs/Main.md` whenever authority is unclear
 - treat local unmerged overlays as reference material until revalidated against updated `origin/main`
 

--- a/Docs/development_rules.md
+++ b/Docs/development_rules.md
@@ -148,6 +148,9 @@ Default checkpoint:
 
 - branch-level lane evaluation
 
+Branch Readiness must establish the branch-level execution plan before Workstream begins.
+That plan must name the branch objective, target end-state, expected seam families and risk classes, validation contract, User Test Summary strategy, later-phase needs, and the first Workstream seam or initial seam sequence.
+
 Stay inside the active grouped lane until one of these is true:
 
 - the milestone threshold is satisfied
@@ -158,7 +161,8 @@ Stay inside the active grouped lane until one of these is true:
 After a lane is closed or merged:
 
 - the next implementation workstream must execute from updated `main` on a fresh branch
-- the successor branch may be created during `PR Readiness`, but it remains reserved and may not be used for execution until the current branch merges and the successor branch is revalidated against updated `main`
+- the next workstream must be selected, canon-defined, minimally scoped, and explicitly not branched during `PR Readiness`
+- the successor branch is created only during `Branch Readiness` after the current branch merges and updated `main` is revalidated
 
 If a branch becomes:
 
@@ -182,8 +186,10 @@ Explicitly approved non-implementation branches may still begin from `No Active 
 - their branch-class admission rules from `Docs/phase_governance.md` pass
 - their branch authority record is explicit
 
-Active-branch-first remains the normal rule.
-Do not use a standalone `docs/governance` branch to carry routine canon work that belongs on an already-active implementation or release branch.
+Active-branch-first remains the normal rule for tightly coupled canon and governance work.
+When a governance or canon update is directly required to keep the active branch truthful, executable, phase-correct, readiness-correct, validation-correct, closeout-correct, or release-correct, carry that update on the active branch inside its current phase and branch class.
+That allowance does not permit unrelated governance churn, product scope expansion, validation weakening, stop-condition weakening, or phase-authority bypass.
+Do not use a standalone `docs/governance` branch to carry routine canon or governance work that belongs on an already-active implementation or release branch.
 
 For active promoted work, the canonical workstream doc is the single authoritative owner of:
 
@@ -206,23 +212,41 @@ Supporting canon must stay aligned with live truth.
 
 That means:
 
-- directly supporting canon may be updated on the active implementation branch when that branch changes the truth
+- PR Readiness hard blocker shorthand is `stale-canon`, `post-merge`, `dirty`, `docs-sync`, and `next-workstream`
+- directly supporting canon and tightly coupled governance may be updated on the active implementation or release branch when that branch changes or depends on the truth
 - no PR-ready without canon-ready:
   - a branch is not PR-ready if merging it would leave `main` canon-stale
+- no PR-ready with stale canon:
+  - current-state canon and merge-target canon must already reflect the branch's true state and the state that will be true after merge
 - when a branch closes a workstream, changes released milestone posture, changes the current rebaseline, changes closeout-index routing, changes backlog or roadmap release posture, changes workstream-index release posture, or changes `Docs/Main.md` baseline routing, the required release-facing canon updates must already be on that branch before PR creation is allowed
-- no PR-ready without successor branch created:
-  - If post-merge truth will resolve to `No Active Branch` because `Release Debt` or another repo-level admission blocker remains open, successor-lane selection and reserved successor-branch creation are waived for that PR-readiness pass.
+- no PR-ready with `Next Workstream Undefined`:
+  - If post-merge truth will resolve to `No Active Branch` because `Release Debt` or another repo-level admission blocker remains open, successor branch creation remains deferred; next-workstream selection is still required unless the user explicitly approves a no-next-workstream steady-state outcome in canon.
   - the next workstream must be selected from canon
+  - that workstream must be recorded in `Docs/feature_backlog.md` and `Docs/prebeta_roadmap.md`
   - that workstream must have canon-valid `Record State`
-  - a fresh successor branch must already be created using an approved naming family such as `feature/<lane>`, `fix/<issue>`, or `docs/<lane>`
-  - that successor branch must remain reserved until the current branch merges and the successor branch is revalidated against updated `main`
-  - when that waiver applies, the branch must instead record `No Active Branch` plus the blocking admission item explicitly in merged current-state canon
+  - that workstream must have minimal scope defined before PR green
+  - no branch may exist yet for that next workstream
+  - the selected backlog entry must include `Next Workstream: Selected` and `Minimal Scope:`
+  - `Docs/prebeta_roadmap.md` must include `## Selected Next Workstream` with the same workstream id, `Record State`, `Minimal Scope:`, and branch status such as `Branch: Not created`
+  - successor branch creation is deferred to `Branch Readiness` after the current branch merges and updated `main` is revalidated
+  - when release debt or another admission blocker applies, the branch must also record `No Active Branch` plus the blocking admission item explicitly in merged current-state canon
+- no PR-ready with unresolved post-merge planning:
+  - if post-merge truth needs `No Active Branch` handling, release-debt handling, next-workstream planning, next-workstream canon sync, minimal scope, or branch-creation deferral, that handling must already be complete inside PR Readiness
+- no PR-ready with a dirty branch:
+  - the worktree must be clean before `PR READY: YES`
+  - required docs changes must be committed
+  - required canon state must not exist only in the working tree
+  - branch truth must be durable in commit history
+- no PR-ready without docs-sync and drift-audit completion:
+  - docs sync, Governance Drift Audit, validator alignment, and required post-merge wording must be complete and mutually consistent
+  - run the branch governance validator and its PR-readiness gate mode before reporting `PR READY: YES`
 - post-release canon repair is emergency-only:
   - use it only when canon drift already exists on updated `main` and could not be prevented before merge or release
 - standalone `docs/governance` branches are future-capable but tightly gated:
   - they may begin from `No Active Branch` when the branch-class admission rules pass
   - they remain non-default during `pre-Beta`
   - they must not be used to avoid active-branch canon duties or required release-debt follow-through
+- standalone governance or docs-style branches are reserved for repo-wide governance work not tightly coupled to one active branch, emergency canon repair, cross-branch truth repair that cannot safely live on one active branch, or governance work that would contaminate or confuse an active implementation or release branch
 - do not default to a standalone docs-only post-release branch for routine canon completion
 - do not use canon sync as an excuse for broad unrelated documentation churn
 
@@ -258,7 +282,8 @@ that weakness must be classified as `Governance Drift`.
 If governance drift is discovered:
 
 - stop normal progression immediately
-- either fix it inside the approved governance or docs boundary, or
+- if the drift is directly coupled to the active branch's truth, phase, readiness, validation, closeout, or release state, fix it inside the approved docs or governance boundary on that active branch after the boundary is explicit
+- otherwise, either fix it inside an approved standalone governance or docs boundary, or
 - produce the exact required canon delta and wait for user confirmation
 
 Do not defer known governance weaknesses silently to a later branch.
@@ -282,7 +307,25 @@ and keep that validator green before calling the branch ready.
 - minimal isolated changes means the minimal coherent change set needed to close that approved subproblem
 - grouped workstreams are allowed during `pre-Beta` when they remain coherent by subsystem and end-state
 - a grouped branch may carry multiple validated slices when they all belong to the same milestone
+- `bounded multi-seam workflow` is the primary Workstream execution model for coherent same-risk seam chains
 - unrelated ideas must still be split out even if they look convenient to batch
+
+Bounded multi-seam workflow means:
+
+- multiple seams may execute in sequence within one approved Workstream pass
+- each seam still has one active owner, exact boundary, explicit non-includes, validation gate, and continue-or-stop decision
+- every seam must remain in the same workstream, same phase, same branch class, same risk class, and same subsystem family or tightly coupled chain
+
+Stop the workflow immediately if validation fails, regression appears, scope drifts, risk class changes, governance drift appears, manual validation becomes blocking, or branch truth no longer matches the authority record.
+
+Use single-seam fallback for:
+
+- bug fixes
+- hotfixes
+- unclear or high-risk seams
+- cross-subsystem changes
+- settings, protocol, launcher-policy, or UI-model changes
+- any pass where validation cannot support safe continuation
 
 Use the smallest safe slice for:
 
@@ -312,6 +355,10 @@ Codex must not allow stalled validation runs, harnesses, or desktop exercises to
 
 When the branch is in governed closeout recovery, `Docs/phase_governance.md` is the controlling timeout and stop-loss authority unless the active workstream doc explicitly documents a tighter contract.
 
+Interactive validation is reuse-first.
+Before creating a new live-validation helper, Codex must inspect the existing repo helper surface and use, parameterize, extend, or extract shared support from existing helpers when that is safe.
+Temporary one-off probes may be used only under ignored evidence roots, may not become closeout-grade proof by inertia, and must be deleted after the pass unless deliberately promoted into documented reusable tooling.
+
 When an interactive validation pass is relevant, it must use:
 
 - a full-run hard timeout
@@ -331,6 +378,10 @@ That means:
 - live re-resolution of windows, dialogs, overlays, and controls across close/open seams
 - seam classification before product code is changed during validation hardening
 
+If no tighter helper-specific watchdog is active, `10s` without meaningful progress is the maximum allowed no-progress interval for live validation.
+Meaningful progress means a new runtime marker, step-log entry, scenario transition, UI readback, screenshot/proof artifact, process-state observation, cleanup confirmation, or explicit last-progress update.
+If that interval is exceeded, Codex must abort the run, clean up session state, report the last confirmed progress point, and classify the stall before patching anything.
+
 When the approved boundary is a continuous `Hardening` pass on the current branch, Codex should keep iterating through seams without waiting for a new user prompt after every rerun unless:
 
 - a blocker appears
@@ -347,6 +398,7 @@ If a timeout or freeze is detected, Codex must:
 - perform the required session cleanup
 - explicitly report the timeout or stall condition
 - explicitly report the last confirmed meaningful progress point
+- route helper or harness repair back through `Hardening` unless the authority record explicitly allows validation-only support edits in the current phase
 
 For hardened desktop helpers, the working target is not just eventual completion.
 The working target is also responsiveness:
@@ -435,6 +487,16 @@ If no meaningful manual test exists for the change, Codex must say so explicitly
 For active desktop workstreams, the default canonical repo-level `UTS` artifact is the `## User Test Summary` section in the relevant canonical workstream doc unless that doc explicitly declares a different repo path.
 
 When that artifact exists and supporting docs are in scope on the active branch, Codex must update it as part of the same slice by default.
+
+For bounded multi-seam Workstream execution, User Test Summary handling is incremental plus final:
+
+- update the canonical workstream `## User Test Summary` as user-visible or operator-facing seams land
+- when the Workstream seam chain is complete, refresh the desktop export if the branch is user-facing
+- digest returned user evidence in `Live Validation` before recommending phase advancement
+- route returned evidence back to `Workstream` for in-scope user-facing branch work, to `Hardening` for defects or validation gaps, or to backlog/defer handling for new feature requests
+
+Completing a User Test Summary update does not move the branch directly from `Workstream` to `PR Readiness`.
+The normal next phase after Workstream completion remains `Hardening`.
 
 Response-only `## User Test Summary` output does not satisfy the workstream-owned validation layer when the canonical repo artifact remains stale.
 

--- a/Docs/feature_backlog.md
+++ b/Docs/feature_backlog.md
@@ -28,7 +28,7 @@ Historical note:
 
 ### [ID: FB-037] Curated built-in system actions and Nexus settings expansion
 
-Status: Branch Readiness
+Status: Workstream
 Record State: Promoted
 Priority: High
 Release Stage: pre-Beta

--- a/Docs/feature_backlog.md
+++ b/Docs/feature_backlog.md
@@ -26,7 +26,16 @@ Historical note:
 
 ## Promoted Canonical Workstreams
 
-- none currently
+### [ID: FB-037] Curated built-in system actions and Nexus settings expansion
+
+Status: Branch Readiness
+Record State: Promoted
+Priority: High
+Release Stage: pre-Beta
+Target Version: TBD
+Canonical Workstream Doc: Docs/workstreams/FB-037_built_in_actions_and_settings_expansion.md
+Summary: Admit the curated built-in system actions and Nexus settings expansion lane for bounded planning and later implementation under the shared action model.
+Why it matters: Standard product actions should feel native and inspectable under the shared action model instead of being pushed into user-defined saved actions as ad hoc customization. Common Windows and Nexus-owned actions should ship as first-class built-ins, while saved actions remain the seam for personal or non-standard tasks.
 
 ## Registry Items
 
@@ -99,16 +108,6 @@ Release Stage: pre-Beta
 Target Version: TBD
 Summary: Track the broader Nexus-era vision and source-of-truth migration above the current phase-one canon foundation rebuild.
 Why it matters: The repo still needs deeper identity and wording normalization after the foundation layer is rebuilt.
-
-### [ID: FB-037] Curated built-in system actions and Nexus settings expansion
-
-Status: Deferred
-Record State: Registry-only
-Priority: High
-Release Stage: pre-Beta
-Target Version: TBD
-Summary: Track future curated built-in actions for standard Windows, system, vendor-utility, and Nexus-owned surfaces such as Sound settings, graphics settings, NVIDIA / AMD utilities, and Nexus settings.
-Why it matters: Standard product actions should feel native and inspectable under the shared action model instead of being pushed into user-defined saved actions as ad hoc customization. Common Windows and Nexus-owned actions should ship as first-class built-ins, while saved actions remain the seam for personal or non-standard tasks.
 
 ### [ID: FB-038] Taskbar / tray quick-task UX and Create Custom Task surface
 

--- a/Docs/feature_backlog.md
+++ b/Docs/feature_backlog.md
@@ -28,13 +28,14 @@ Historical note:
 
 ### [ID: FB-037] Curated built-in system actions and Nexus settings expansion
 
-Status: Workstream
+Status: Merged unreleased on main
 Record State: Promoted
+Blocker: Release Debt
 Priority: High
 Release Stage: pre-Beta
 Target Version: TBD
 Canonical Workstream Doc: Docs/workstreams/FB-037_built_in_actions_and_settings_expansion.md
-Summary: Admit the curated built-in system actions and Nexus settings expansion lane for bounded planning and later implementation under the shared action model.
+Summary: Completed and merge-target-ready curated Windows utility built-in catalog expansion under the shared action model; after merge, FB-037 is merged-unreleased implementation debt and blocks next implementation admission until release packaging clears Release Debt.
 Why it matters: Standard product actions should feel native and inspectable under the shared action model instead of being pushed into user-defined saved actions as ad hoc customization. Common Windows and Nexus-owned actions should ship as first-class built-ins, while saved actions remain the seam for personal or non-standard tasks.
 
 ## Registry Items
@@ -113,9 +114,11 @@ Why it matters: The repo still needs deeper identity and wording normalization a
 
 Status: Deferred
 Record State: Registry-only
+Next Workstream: Selected
 Priority: Medium
 Release Stage: pre-Beta
 Target Version: TBD
+Minimal Scope: Branch Readiness admission and planning for the shell-facing quick-task entry surface, initially limited to defining the smallest safe taskbar/tray or Create Custom Task UX seam above the released interaction, authoring, callable-group execution, and built-in catalog baselines; no branch exists yet and no implementation is authorized until FB-037 release debt is cleared.
 Summary: Track future taskbar or tray quick-access UX, including a Create Custom Task affordance, as a deliberate shell-facing entry surface into the shared action model.
 Why it matters: Taskbar and tray interaction affect entry, discoverability, and user trust, so they should be planned as an explicit UX lane instead of piggybacking on overlay or authoring work.
 

--- a/Docs/incident_patterns.md
+++ b/Docs/incident_patterns.md
@@ -15,6 +15,22 @@ Use:
 Add material here only when the lesson has generalized beyond one lane.
 Branch-local "what worked" notes should stay in the canonical workstream doc first and only be distilled here once the pattern is broad enough to help future branches outside that lane.
 
+## Pattern: PR Readiness Green Must Require Durable Process Truth
+
+- symptom:
+  PR Readiness can appear green while required canon sync, post-merge state handling, or docs changes still exist only in the working tree
+- layer:
+  branch governance and merge-target canon
+- root-cause pattern:
+  validation proves branch behavior, but process blockers are not named strongly enough as pre-merge gates
+- fix pattern:
+  require PR Readiness to clear stale canon, post-merge-state handling, next-workstream selection with minimal scope and no branch created yet, dirty branch / durable commit state, and docs-sync / Governance Drift Audit blockers before reporting `PR READY: YES`
+- validation pattern:
+  run the normal branch governance validator plus the PR-readiness gate mode; the gate must fail while the worktree is dirty, while required post-merge truth is not encoded, or while the next workstream is undefined, unscoped, or already branched
+- source references:
+  - `Docs/phase_governance.md`
+  - `dev/orin_branch_governance_validation.py`
+
 ## Pattern: Released-Canon Fallback Must Not Use The Highest Planned Prerelease
 
 - symptom:

--- a/Docs/orin_task_template.md
+++ b/Docs/orin_task_template.md
@@ -56,6 +56,9 @@ Validation Contract:
 Timeout Contract:
 [fill in only when interactive timing governance matters]
 
+Seam Sequence:
+[fill in when a Workstream pass may execute more than one seam]
+
 Repo state:
 [Active Branch / No Active Branch]
 
@@ -67,7 +70,11 @@ If the task is phase-sensitive and the exact `Phase` field is missing, stop and 
 If repo state is blocked `No Active Branch`, implementation is blocked and the task should resolve the blocking repair path instead of starting implementation.
 If repo state is steady-state `No Active Branch`, do not start implementation by inertia.
 An explicitly approved `docs/governance`, `release packaging`, or `emergency canon repair` branch may still proceed only when the branch-class admission rules from `C:\Nexus Desktop AI\Docs\phase_governance.md` allow it.
+If a governance or canon update is directly required to keep the active current branch truthful, executable, phase-correct, readiness-correct, validation-correct, closeout-correct, or release-correct, keep that docs-only update on the active branch inside the current phase and branch class.
+Use a separate governance or docs-style branch only for repo-wide uncoupled governance work, emergency canon repair, cross-branch truth repair, or governance work that would contaminate or confuse an active implementation or release branch.
 Add `Validation Contract`, `Timeout Contract`, and `Current active seam` when the governed task needs them.
+Add `Seam Sequence` when the Workstream prompt may use bounded multi-seam workflow.
+If `Seam Sequence` is present, Codex must execute one active seam at a time, validate after each seam, and report a continue-or-stop decision before starting the next seam.
 
 Default expectation:
 
@@ -144,6 +151,7 @@ Use this section when the branch matters to the task:
 - milestone value: [why this branch or docs program is worth completing]
 - same-branch follow-through: [dependent work that still belongs on this branch before readiness]
 - branch posture: [fresh branch from updated main / continue approved active branch / docs/governance branch from No Active Branch / release packaging branch / emergency canon repair branch / No Active Branch]
+- branch-level plan: [objective, target end-state, expected seam families and risk classes, validation contract, User Test Summary strategy, later-phase needs, and first seam or seam sequence]
 
 If a lane was already closed, merged, or released, the next workstream should start from updated `main` on a fresh branch.
 
@@ -204,6 +212,9 @@ After analysis is complete and execution scope is approved, follow these discipl
 - verify exact failure path or behavior before changing logic
 - no blind iteration
 - one coherent approved subproblem per revision
+- use bounded multi-seam workflow as the primary Workstream model when the approved seams are same-workstream, same-phase, same-risk, and same-subsystem-family or tightly coupled
+- execute exactly one active seam at a time and validate, record, and decide continue-or-stop before the next seam
+- use single-seam fallback for bug fixes, hotfixes, unclear or high-risk seams, cross-subsystem work, settings/protocol/launcher/UI-model changes, or any pass where validation cannot support safe continuation
 - preserve architecture boundaries
 - keep source-of-truth docs aligned with actual implemented state
 - production behavior must remain unchanged unless explicitly in scope
@@ -255,22 +266,29 @@ If an execution task is too broad for one approved pass, explain the cleaner exe
 2. Explain the branch or workstream posture.
 3. Explain the exact current phase, branch class, and blockers.
 4. Explain the next legal phase or say explicitly that repo state is `No Active Branch`.
-5. Explain the validation plan.
+5. If in `Branch Readiness`, explain the whole-branch execution plan before Workstream admission.
+6. If in `Workstream`, explain whether bounded multi-seam workflow is safe; if it is, list the seam sequence, per-seam gates, and stop conditions.
+7. If in `PR Readiness`, explicitly plan the stale-canon check, post-merge-state handling, next-workstream selection/canon/minimal-scope/no-branch-exists check, required `Next Workstream: Selected`, `Minimal Scope:`, `## Selected Next Workstream`, and `Branch: Not created` markers, dirty-branch/durable-commit check, docs-sync/drift-audit check, normal governance validator, and PR-readiness gate mode.
+8. Explain the validation plan.
 
 If the task includes interactive validation, the validation plan should also state:
 
+- existing helper or harness that will be reused first, or the exact reason reuse is unsafe
+- whether any temporary one-off probe is being used and how it will be deleted or promoted before closeout-grade proof
 - full-run hard timeout
 - no-progress timeout
 - scenario timeout when relevant
 - transition timeout when relevant
+- visible progress markers or step-log updates that prove the run is not stalled
 - how timeout or freeze will be reported and cleaned up
 
 ### During Execution
 
 1. Perform only the approved execution work.
-2. Verify the result directly.
-3. Clean up session-scoped side effects from the pass unless there is an explicit reason to preserve them.
-4. Report what changed, what was verified, and what was cleaned up or intentionally left in place.
+2. For bounded multi-seam workflow, perform exactly one seam, verify it, record evidence, and decide `continue` or `stop` before starting the next seam.
+3. Stop the workflow immediately on validation failure, regression, scope drift, risk-class change, governance drift, unresolved manual-validation blocker, or branch-truth inconsistency.
+4. Clean up session-scoped side effects from the pass unless there is an explicit reason to preserve them.
+5. Report what changed, what was verified, the per-seam continue-or-stop decisions, and what was cleaned up or intentionally left in place.
 
 ## Verification Requirements
 
@@ -286,10 +304,12 @@ If applicable, also verify:
 - failure path
 - artifact cleanup
 - session cleanup and teardown
+- existing-helper reuse or documented justification for any temporary probe
 - cleanup verification, including that no test-opened app window, helper process, or temporary probe file was left behind
 - no regressions in locked behavior
 - no drift outside the allowed surfaces
 - interactive validation time budgets and timeout behavior when the pass depends on a real desktop or harness run
+- no-progress supervision, using the tighter helper-specific watchdog when present or a `10s` maximum no-progress interval when no tighter watchdog exists
 
 Session cleanup and teardown includes, when relevant:
 
@@ -306,6 +326,7 @@ If an interactive run times out or freezes, the output must also state:
 - which time budget tripped
 - the last confirmed meaningful progress point
 - what cleanup was performed before handoff
+- whether the issue is classified as product defect, harness defect, environment issue, or canon / contract drift
 
 If the slice changes user-visible behavior, runtime interaction, UX flow, prompts, startup behavior, voice behavior, or another manual operator-facing path, the final output must include a `## User Test Summary` section as a concrete manual checklist.
 
@@ -324,6 +345,9 @@ If no meaningful manual test exists, the output must still include `## User Test
 If a canonical repo-level `UTS` artifact exists for the active desktop workstream, the execution pass must update that artifact as well rather than stopping at response text.
 
 By default, that artifact is the `## User Test Summary` section in the relevant canonical workstream doc unless that doc explicitly declares a different repo path.
+
+For bounded multi-seam Workstream execution, update the canonical workstream `UTS` incrementally as user-visible seams land.
+When the Workstream seam chain is complete, refresh the desktop export if the branch is user-facing.
 
 If the artifact is not updated, the final output must explain why the update was skipped.
 
@@ -397,4 +421,5 @@ K. `## User Test Summary` manual checklist when manual validation is relevant
 - Do not reopen closed version behavior without explicit approval.
 - Do not smuggle in policy or authority changes outside the approved task.
 - Do not modify backlog status or add backlog items unless the task explicitly authorizes backlog updates.
+- Do not force tightly coupled governance or canon updates onto a separate docs/governance branch when the active branch owns the affected truth and the update can stay inside its current phase, branch class, validation rules, and stop conditions.
 - Do not force a docs-only canon repair onto a hypothetical implementation branch when live truth and `C:\Nexus Desktop AI\Docs\phase_governance.md` justify an explicitly approved standalone docs/governance branch.

--- a/Docs/phase_governance.md
+++ b/Docs/phase_governance.md
@@ -34,10 +34,12 @@ Add these fields when relevant:
 
 - `Branch Class: <implementation / docs/governance / emergency canon repair / release packaging>`
 - `Active Seam: <seam name>`
+- `Seam Sequence: <ordered seam list>` when a Workstream pass may execute more than one seam
 - `Validation Contract: <summary or authority reference>`
 - `Timeout Contract: <summary or authority reference>`
 
 If `Phase` is missing or is not one of the exact canonical phase names below, execution is blocked and only truth-validation or analysis may continue.
+If `Seam Sequence` is present, the pass must still execute only one active seam at a time and must report a validation-backed continue-or-stop decision before starting the next seam.
 
 ## Canonical Phase Enum
 
@@ -156,8 +158,13 @@ The default named blockers are:
 - `Workstream Phase Authority Missing`
 - `Branch Base Invalid`
 - `Merged Canon Drift`
+- `Stale Canon`
 - `Phase Exit Unmet`
+- `Next Workstream Undefined`
 - `Successor Lock Missing`
+- `Post-Merge State Unresolved`
+- `Dirty Branch`
+- `Docs Sync Incomplete`
 - `Release Debt`
 - `Governance Drift`
 - `Current-State Claim Drift`
@@ -205,9 +212,12 @@ Branch admission is class-sensitive.
 
 - the full repo-level admission gate must pass before the branch may enter `Branch Readiness`
 - the active promoted workstream doc is the default authority record
+- docs-only governance or canon refinements may ride on the active implementation branch when they are directly required to keep that branch truthful, executable, phase-correct, readiness-correct, validation-correct, closeout-correct, or release-correct
+- those refinements do not change the branch class; they must stay inside the current phase, remain explicit in scope, preserve validation and stop conditions, and avoid unrelated governance churn
 
 `docs/governance`
 
+- is an exception path, not the preferred default while an active implementation or release branch owns the affected truth
 - may begin from updated `main` while repo sequencing truth is `No Active Branch` only when:
   - no active implementation branch exists
   - the branch purpose is genuine governance, docs, roadmap, backlog, triage, policy, or prompt-scaffolding maintenance
@@ -217,6 +227,7 @@ Branch admission is class-sensitive.
 - during `pre-Beta`, active-branch-first remains the default and standalone `docs/governance` branches are non-default
 - in later Beta, public, or project steady-state operation, this branch class may legitimately begin from `No Active Branch` when the same admission rules still hold
 - if `Release Debt` remains open, the branch must leave that blocker explicit and must not claim the debt is cleared unless that is the approved scope
+- standalone governance or docs-style branches are reserved for repo-wide governance work not tightly coupled to one active branch, emergency canon repair, cross-branch truth repair that cannot safely live on one active branch, or governance work that would contaminate or confuse an active implementation or release branch
 
 `release packaging`
 
@@ -260,30 +271,59 @@ If any required merge-target canon update is missing, the branch remains blocked
 
 Rule:
 
-- a branch is not `PR Readiness`-complete unless the next workstream is selected, canon-valid, and a fresh successor branch is created
+- a branch is not `PR Readiness`-complete unless the next workstream is selected, canon-defined, assigned a valid record state, minimally scoped, and explicitly not branched yet
 
 Exception:
 
-- If post-merge truth will resolve to `No Active Branch` because `Release Debt` or another repo-level admission blocker remains open, successor-lane selection and reserved successor-branch creation are waived for that PR-readiness pass.
+- If post-merge truth will resolve to `No Active Branch` because `Release Debt` or another repo-level admission blocker remains open, successor branch creation remains deferred; next-workstream selection is still required unless the user explicitly approves a no-next-workstream steady-state outcome in canon.
 
 This gate requires all of the following before PR creation is allowed:
 
 - the next workstream identity is selected from current canon
-- that workstream has canon-valid `Record State`
-- a fresh successor branch is created using an approved naming family such as:
-  - `feature/<lane>`
-  - `fix/<issue>`
-  - `docs/<lane>`
-- the successor branch is explicitly treated as reserved
-- execution on the successor branch must not begin until the current branch merges and the successor branch is revalidated against updated `main`
+- that workstream exists in `Docs/feature_backlog.md`
+- that workstream is recorded in `Docs/prebeta_roadmap.md`
+- that workstream has a canon-valid `Record State`
+- that workstream has minimal scope defined before PR green
+- no branch has been created for that next workstream yet
+- successor branch creation is deferred to `Branch Readiness` after the current branch merges and updated `main` is revalidated
+
+Machine-checkable canon markers:
+
+- the selected backlog entry must include `Next Workstream: Selected`
+- the selected backlog entry must include `Minimal Scope:`
+- the roadmap must include `## Selected Next Workstream`
+- the roadmap selected-next section must include the same workstream id, its `Record State`, `Minimal Scope:`, and branch status such as `Branch: Not created`
 
 When the exception applies, the branch must instead:
 
 - make the post-merge `No Active Branch` state explicit in current-state canon
 - name the blocking admission item explicitly
-- avoid selecting or branching the next implementation lane by inertia
+- keep the selected next workstream as canon planning only
+- avoid creating or executing the next implementation branch by inertia
 
-If the next workstream is not selected, its record state is not canon-valid, or the successor branch has not been created, the branch is blocked by `Successor Lock Missing`.
+If the next workstream is not selected, is not recorded in backlog and roadmap, lacks valid record state, or lacks minimal scope, the branch is blocked by `Next Workstream Undefined`.
+If a successor branch is created before `Branch Readiness`, the branch is blocked by `Successor Lock Missing`.
+
+### PR Readiness Hard Blocker Gates
+
+PR Readiness must not report green while any pre-merge process blocker remains unresolved.
+
+Hard blockers:
+
+- canonical shorthand: `stale-canon`, `post-merge`, `dirty`, `docs-sync`, `next-workstream`
+- `Stale Canon`:
+  current-state canon and merge-target canon must already reflect the branch's true state and the state that will be true after merge
+- `Post-Merge State Unresolved`:
+  post-merge truth must already encode either the `No Active Branch` / `Release Debt` path or the successor-workstream planning, canon sync, and branch-creation deferral required when post-merge truth will admit another branch
+- `Next Workstream Undefined`:
+  PR Readiness cannot be green until the next workstream exists in canon, is recorded in backlog and roadmap, has a valid record state, has minimal scope defined, and has no branch created yet
+- `Dirty Branch`:
+  PR Readiness cannot be green while the worktree is dirty, required docs changes are uncommitted, required canon exists only in the working tree, or branch truth is not durable in commit history
+- `Docs Sync Incomplete`:
+  docs sync, Governance Drift Audit, validator alignment, and any required post-merge state wording must be complete and mutually consistent
+
+The PR-readiness validator gate must be run in its PR-specific mode before reporting `PR READY: YES`.
+If the normal governance validator passes but the PR-specific gate reports dirty worktree or unresolved PR blockers, the result is not PR-ready.
 
 ### Governance Drift Audit
 
@@ -314,7 +354,8 @@ If governance drift is discovered in any earlier phase:
 
 - stop normal progression immediately
 - classify it as `Governance Drift`
-- either fix it inside the approved governance or docs boundary, or
+- if the drift is directly coupled to the active branch's truth, phase, readiness, validation, closeout, or release state, fix it inside the approved docs or governance boundary on that active branch after the boundary is explicit
+- otherwise, either fix it inside an approved standalone governance or docs boundary, or
 - produce the exact required canon delta and wait for user confirmation
 
 Do not defer known governance weaknesses silently to a later branch.
@@ -374,6 +415,11 @@ That validator should verify at minimum:
 - stale merge-era wording does not remain in active current-state owners
 - Governance Drift Audit output exists before `Release Readiness`
 - unresolved blockers prevent phase advancement
+- active-branch governance and canon updates remain the primary path when tightly coupled to the active branch's truth, phase, readiness, validation, closeout, or release state
+- standalone governance or docs-style branches remain exception paths for repo-wide uncoupled governance work, emergency canon repair, cross-branch truth repair, or contamination-risk cases
+- the canonical `bounded multi-seam workflow` contract is present in governance and operator scaffolds
+- prompt scaffolds teach `Seam Sequence`, per-seam validation, and continue-or-stop decisions for multi-seam Workstream execution
+- docs do not teach direct `Workstream` -> `PR Readiness` as the default path
 
 A governance or current-state canon branch is not complete until that validator is green.
 
@@ -444,6 +490,22 @@ That contract is:
 - windows, dialogs, overlays, and controls should be re-resolved live across close/open seams instead of reusing stale references
 - validation seams must be classified as `product defect`, `harness defect`, `environment issue`, or `canon / contract drift` before product code is changed
 
+## Live Validation Reuse-First Rule
+
+Before creating a new live-validation helper, script, or harness, Codex must inventory existing repo helpers and choose the smallest safe reuse path.
+
+Preferred order:
+
+1. use an existing helper unchanged when it already covers the needed path
+2. parameterize or extend an existing helper when the validation belongs to the same desktop/runtime helper family
+3. extract shared helper support when multiple helpers need the same watchdog, progress, cleanup, or UIAutomation behavior
+4. create a new helper only when reuse would contaminate the helper boundary, blur workstream truth, or make validation less reliable
+
+One-off probes are allowed only as temporary exploratory evidence under an ignored evidence root such as `dev/logs/...`.
+They must not be used as closeout-grade proof, must not be left behind as de facto reusable tooling, and must either be deleted after the pass or deliberately promoted into a documented reusable helper with workstream artifact-history notes.
+
+If a Live Validation pass needs helper or harness changes before it can produce trustworthy evidence, the branch must reopen to `Hardening` unless the active authority record explicitly allows validation-only support edits in `Live Validation`.
+
 Closeout-grade proof has one extra rule:
 
 - the default budget profile of the validation helper must itself prove green before branch closeout can be claimed
@@ -461,14 +523,61 @@ Validation seams should be classified before they are fixed:
 
 Do not treat a seam as a product defect merely because the interactive harness failed first.
 
-## Single-Seam Iteration Rule
+## Bounded Multi-Seam Workflow Rule
 
-- only one active seam may be fixed at a time during governed recovery
-- rerun the full governed gate immediately after that seam fix
-- if a new seam appears, log it before selecting it as the next active seam
+The primary Workstream execution model is `bounded multi-seam workflow`.
 
-Single-seam ownership does not require a new operator prompt after every rerun.
-It means one seam is active at a time, even when a longer continuous validation pass is allowed.
+A bounded multi-seam workflow is an ordered sequence of seams executed inside one approved Workstream boundary.
+It is allowed only when every seam in the sequence stays within:
+
+- the same workstream
+- the same normal phase
+- the same branch class
+- the same risk class
+- the same subsystem family or a tightly coupled implementation chain
+
+Multi-seam does not mean batch execution.
+It means Codex may continue across a planned seam sequence without requiring a new operator prompt after every seam, but only while it executes exactly one active seam at a time.
+
+Before each seam, Codex must state:
+
+- the seam name
+- the exact boundary
+- the explicit non-includes
+- the validation gate required for that seam
+
+After each seam, Codex must:
+
+- run the required validation for that seam
+- update the active workstream evidence when branch-local truth changed
+- update the canonical workstream `User Test Summary` when the seam changes user-visible or operator-facing behavior
+- decide and report `continue` or `stop`
+
+Continuation is allowed only when:
+
+- validation passes
+- no regression is detected
+- no scope drift is detected
+- no risk-class change is detected
+- no governance drift is detected
+- no unresolved manual-validation blocker is present
+- branch truth remains consistent with the authority record
+
+If any continuation condition fails, the whole workflow stops immediately and the next safe move must be reported from the blocking truth.
+
+## Single-Seam Fallback Rule
+
+Single-seam execution remains required for:
+
+- bug fixes
+- hotfixes
+- unclear or high-risk seams
+- cross-subsystem changes
+- settings, protocol, launcher-policy, or UI-model changes
+- any pass where validation cannot support safe continuation
+
+Single-seam fallback means only one active seam may be selected for that pass.
+It does not authorize phase skipping or a direct readiness claim.
 
 ## Continuous Validation Loop Rule
 
@@ -526,6 +635,10 @@ Additional repo-wide rule:
 
 - when hardening proves that a tighter and faster default helper profile is stable, that profile should replace the older relaxed default before closeout-grade proof is claimed
 - if a seam keeps breaching the documented `3s` or `60s` targets, treat that as validation-helper or process debt and redesign the proof path instead of silently letting the run sit longer
+- every interactive helper or live-validation run must emit visible progress before and during execution, including scenario start, meaningful step progress, scenario result, and last-confirmed-progress evidence
+- if a helper does not already enforce a tighter watchdog, `10s` is the maximum allowed no-progress interval before the run must self-abort, clean up, report the last confirmed progress point, and classify the stall
+- long-running interactive commands must not hide behind only the shell/tool outer timeout; they must be supervised by a watchdog, monitor job, child process, or equivalent path that can abort and clean up blocked UIAutomation, app launch, screenshot, focus, source-write, or cleanup operations
+- Codex should poll or surface helper progress during live validation instead of leaving the operator with a silent long-running command
 
 ## Truth-Drift Enforcement Rule
 
@@ -563,12 +676,15 @@ The canonical rule is narrower:
 
 ## Phase Transition Rule
 
-- `Branch Readiness` -> `Workstream` only after branch base, branch class, authority record, and execution boundary are explicit
-- `Workstream` -> `Hardening` when the changed branch truth must be pressure-tested or stabilized before closeout
+- `Branch Readiness` -> `Workstream` only after branch base, branch class, authority record, branch objective, target end-state, expected seam families and risk classes, validation contract, User Test Summary strategy, later-phase expectations, and first Workstream seam or initial seam sequence are explicit
+- `Workstream` -> `Hardening` only after the approved same-risk Workstream seam sequence is complete, direct validation is green, User Test Summary obligations are current for user-facing changes, and no same-slice correctness gap remains
 - `Hardening` -> `Live Validation` only after repo-side hardening proof is sufficient for interactive or manual closeout work
 - `Live Validation` -> `PR Readiness` only after branch-local proof is sufficient for closeout and returned evidence has been digested into the authority record
-- `PR Readiness` -> `Release Readiness` only after merge-target canon completeness passes, the Governance Drift Audit passes, and either successor lock passes or successor lock is explicitly waived because post-merge truth resolves to `No Active Branch` due to `Release Debt` or another repo-level admission blocker
+- `PR Readiness` -> `Release Readiness` only after merge-target canon completeness passes, the Governance Drift Audit passes, the next-workstream selection gate passes, and branch creation remains deferred to `Branch Readiness`
 - `Release Readiness` -> `Post-Release Canon Repair` only as an emergency repair path after merged or released truth already exists and canon drift escaped the earlier gates
+
+There is no default direct `Workstream` -> `PR Readiness` transition.
+If Workstream appears complete, the next normal phase is `Hardening` unless an explicit authority-record waiver says otherwise.
 
 Later phases must not paper over missing earlier-phase requirements.
 If a later phase discovers an earlier-phase defect, reopen the branch to the failed earlier phase.
@@ -584,6 +700,7 @@ Purpose:
 - set up or confirm the promoted workstream authority record or branch authority record
 - align branch-start canon
 - lock execution, validation, and timeout boundaries
+- plan the whole branch at phase level before implementation begins
 
 Allowed:
 
@@ -592,6 +709,7 @@ Allowed:
 - branch-start canon sync
 - workstream promotion, branch-record setup, or authority setup
 - execution-boundary definition
+- branch-level execution planning
 
 Forbidden:
 
@@ -605,6 +723,11 @@ Required evidence:
 - correct execution base
 - explicit branch class
 - explicit phase block in the authority record
+- branch objective and target end-state
+- expected seam families and risk classes
+- validation contract and User Test Summary strategy
+- expected Hardening, Live Validation, PR Readiness, and Release Readiness needs
+- first Workstream seam or initial seam sequence
 
 Exit:
 
@@ -613,6 +736,7 @@ Exit:
 - exact phase state is recorded
 - branch-start canon is coherent
 - execution boundary is explicit
+- branch-level execution plan is explicit enough to enter Workstream without inventing the lane shape mid-execution
 
 ### Workstream
 
@@ -620,28 +744,36 @@ Purpose:
 
 - execute the approved bounded implementation or bounded governance/docs work
 - run normal repo-side regression validation inside that boundary
+- use bounded multi-seam workflow as the primary model when a coherent same-risk seam chain is safe
 
 Allowed:
 
 - bounded code or docs changes
 - direct verification inside the approved scope
+- one active seam at a time within an approved multi-seam sequence
+- incremental workstream evidence and User Test Summary updates when branch-local truth changes
 
 Forbidden:
 
 - silent scope expansion
 - hidden hardening or closure claims
 - PR or release packaging
+- batching multiple seams without per-seam validation and continue-or-stop gates
+- crossing risk class, subsystem family, or phase boundaries under a multi-seam prompt
 
 Required evidence:
 
 - approved execution boundary
 - direct verification of the changed behavior or docs
+- seam sequence when multiple seams may execute in one pass
+- per-seam validation results and continue-or-stop decisions
 
 Exit:
 
 - approved scope is implemented
 - direct verification is complete
 - no unresolved same-slice correctness gaps remain
+- Workstream evidence and User Test Summary obligations are current for user-facing changes
 
 ### Hardening
 
@@ -714,6 +846,7 @@ Exit:
 Purpose:
 
 - determine whether the branch is ready to become a merge candidate without leaving merged canon stale and, when post-merge truth will admit a next branch, with the next lane already locked
+- determine whether the branch is ready to become a merge candidate without leaving merged canon stale and with the next workstream selected, canon-defined, minimally scoped, and explicitly not branched yet
 
 Allowed:
 
@@ -721,7 +854,8 @@ Allowed:
 - merge-target canon sync
 - final drift checks
 - next-workstream confirmation
-- successor-branch creation
+- successor-branch absence verification
+- Branch Readiness branch-creation deferral
 - Governance Drift Audit
 - PR material preparation
 
@@ -736,8 +870,12 @@ Required evidence:
 
 - branch-local proof complete
 - merge-target canon completeness gate passed
-- successor lane lock gate passed, or successor lock explicitly waived because post-merge truth resolves to `No Active Branch` due to `Release Debt` or another repo-level admission blocker
+- next workstream selected, canon-defined, assigned valid record state, minimally scoped, and explicitly not branched yet
+- successor branch creation deferred to `Branch Readiness`
+- post-merge truth fully encoded before merge
 - Governance Drift Audit completed
+- docs sync complete and validator-aligned
+- clean worktree with required branch truth durable in commit history
 - approved non-backlog branches merge with historical or removed branch-authority truth rather than lingering as active branch owners on `main`
 - no active seam
 - no unresolved blocker that should have been repaired on the current branch before merge

--- a/Docs/prebeta_roadmap.md
+++ b/Docs/prebeta_roadmap.md
@@ -65,7 +65,7 @@ Current merged truth indicates:
 - latest public release commit: `f743281`
 - no merged unreleased non-doc implementation debt currently exists on `main`
 - the latest public released implementation milestone is FB-041 deterministic callable-group execution layer in `v1.3.1-prebeta`
-- the active implementation workstream is FB-037 in `Branch Readiness`
+- the active implementation workstream is FB-037 in `Workstream`
 
 That means the released FB-027 interaction baseline, the released FB-036 authoring-and-callable-group milestone, and the released FB-041 deterministic callable-group execution milestone are now part of the current public shared pre-Beta baseline.
 
@@ -73,13 +73,13 @@ That means the released FB-027 interaction baseline, the released FB-036 authori
 
 ### FB-037 Curated Built-In System Actions And Nexus Settings Expansion
 
-- status: `Branch Readiness`
+- status: `Workstream`
 - lane type: `implementation`
 - release floor: `minor prerelease`
 - target version: `TBD`
 - release state: `active delta`
 - canonical workstream doc: `Docs/workstreams/FB-037_built_in_actions_and_settings_expansion.md`
-- sequencing note: admitted for Branch Readiness only; implementation must not begin until the workstream doc, boundary, validation contract, and phase exit criteria allow transition into `Workstream`
+- sequencing note: admitted into `Workstream` for first seam selection; implementation must not begin until the first seam is explicitly selected and bounded
 
 ## Most Recent Released Workstream Context
 
@@ -174,7 +174,7 @@ Current merged truth indicates:
 - the released FB-035 lane is closed
 - the recent released workstreams above remain part of the locked current baseline
 - no merged unreleased non-doc implementation debt currently exists on `main`
-- FB-037 is the active implementation workstream in `Branch Readiness`
+- FB-037 is the active implementation workstream in `Workstream`
 - if a branch changes release-facing canon, those canon updates must land on that same branch before PR readiness is allowed
 - post-release canon repair is emergency-only when merged canon is already stale or external drift made pre-merge prevention impossible
 - the released FB-027 baseline does not authorize further saved-action authoring, resolution, voice, Action Studio, routines, profiles, hotkey cleanup, or shutdown-confirmation work by inertia

--- a/Docs/prebeta_roadmap.md
+++ b/Docs/prebeta_roadmap.md
@@ -63,23 +63,41 @@ Current merged truth indicates:
 
 - latest public prerelease: `v1.3.1-prebeta`
 - latest public release commit: `f743281`
-- no merged unreleased non-doc implementation debt currently exists on `main`
+- merged unreleased non-doc implementation debt exists after this branch merges: FB-037 curated built-in system actions and Nexus settings expansion
 - the latest public released implementation milestone is FB-041 deterministic callable-group execution layer in `v1.3.1-prebeta`
-- the active implementation workstream is FB-037 in `Workstream`
+- current phase after this branch merges: `Release Readiness`
+- phase status after this branch merges: `No Active Branch`
+- blocker after this branch merges: `Release Debt` (FB-037)
+- next concern after this branch merges: release packaging for FB-037
 
 That means the released FB-027 interaction baseline, the released FB-036 authoring-and-callable-group milestone, and the released FB-041 deterministic callable-group execution milestone are now part of the current public shared pre-Beta baseline.
 
-## Current Active Workstream
+## Current Release Debt Owner
 
 ### FB-037 Curated Built-In System Actions And Nexus Settings Expansion
 
-- status: `Workstream`
+- status: `merged unreleased`
 - lane type: `implementation`
 - release floor: `minor prerelease`
 - target version: `TBD`
-- release state: `active delta`
+- release state: `merged unreleased`
+- current phase after merge: `Release Readiness`
+- phase status after merge: `No Active Branch`
+- blocker after merge: `Release Debt` (FB-037)
+- next concern after merge: release packaging
 - canonical workstream doc: `Docs/workstreams/FB-037_built_in_actions_and_settings_expansion.md`
-- sequencing note: admitted into `Workstream` for first seam selection; implementation must not begin until the first seam is explicitly selected and bounded
+- sequencing note: Workstream same-risk built-in catalog seams remain complete; helper-only Hardening cleared the reusable-helper cleanup no-progress and missing-manifest gap; Live Validation then passed with manifest-backed evidence across built-in execution, saved-action override, authoring collision rejection, mixed environments, and repeated execution; successor-lane lock is waived because post-merge truth resolves to `No Active Branch` due to FB-037 release debt
+
+## Selected Next Workstream
+
+### FB-038 Taskbar / Tray Quick-Task UX And Create Custom Task Surface
+
+- selection state: `selected next workstream`
+- Record State: `Registry-only`
+- Branch: Not created
+- sequence: after FB-037 release packaging clears `Release Debt`
+- Minimal Scope: Branch Readiness admission and planning for the shell-facing quick-task entry surface, initially limited to defining the smallest safe taskbar/tray or Create Custom Task UX seam above the released FB-027 interaction baseline, FB-036 authoring baseline, FB-041 callable-group execution baseline, and FB-037 built-in catalog baseline.
+- branch creation rule: defer branch creation to `Branch Readiness` after FB-037 release debt is cleared and updated `main` is revalidated
 
 ## Most Recent Released Workstream Context
 
@@ -173,13 +191,15 @@ Current merged truth indicates:
 - the released FB-041 deterministic callable-group execution milestone is now part of the locked current pre-Beta baseline
 - the released FB-035 lane is closed
 - the recent released workstreams above remain part of the locked current baseline
-- no merged unreleased non-doc implementation debt currently exists on `main`
-- FB-037 is the active implementation workstream in `Workstream`
+- merged unreleased non-doc implementation debt exists after this branch merges: FB-037
+- no active implementation workstream remains selected after this branch merges
+- post-merge repo truth resolves to `Release Readiness` with phase status `No Active Branch` and blocker `Release Debt` (FB-037)
+- successor-lane lock is waived for this PR Readiness pass because release debt blocks next implementation admission
 - if a branch changes release-facing canon, those canon updates must land on that same branch before PR readiness is allowed
 - post-release canon repair is emergency-only when merged canon is already stale or external drift made pre-merge prevention impossible
 - the released FB-027 baseline does not authorize further saved-action authoring, resolution, voice, Action Studio, routines, profiles, hotkey cleanup, or shutdown-confirmation work by inertia
 - remaining future candidate spaces now explicitly recorded in the backlog include:
-  - FB-038 for taskbar or tray quick-task UX including Create Custom Task
+  - FB-038 for taskbar or tray quick-task UX including Create Custom Task, selected as the next implementation workstream after FB-037 release packaging clears release debt
   - FB-039 for external trigger and plugin integration architecture
   - FB-040 for monitoring, thermals, and performance HUD surfaces
 - those candidate lanes must be selected deliberately rather than bundled together as one implicit interaction continuation

--- a/Docs/prebeta_roadmap.md
+++ b/Docs/prebeta_roadmap.md
@@ -65,9 +65,21 @@ Current merged truth indicates:
 - latest public release commit: `f743281`
 - no merged unreleased non-doc implementation debt currently exists on `main`
 - the latest public released implementation milestone is FB-041 deterministic callable-group execution layer in `v1.3.1-prebeta`
-- no next implementation branch is currently selected
+- the active implementation workstream is FB-037 in `Branch Readiness`
 
 That means the released FB-027 interaction baseline, the released FB-036 authoring-and-callable-group milestone, and the released FB-041 deterministic callable-group execution milestone are now part of the current public shared pre-Beta baseline.
+
+## Current Active Workstream
+
+### FB-037 Curated Built-In System Actions And Nexus Settings Expansion
+
+- status: `Branch Readiness`
+- lane type: `implementation`
+- release floor: `minor prerelease`
+- target version: `TBD`
+- release state: `active delta`
+- canonical workstream doc: `Docs/workstreams/FB-037_built_in_actions_and_settings_expansion.md`
+- sequencing note: admitted for Branch Readiness only; implementation must not begin until the workstream doc, boundary, validation contract, and phase exit criteria allow transition into `Workstream`
 
 ## Most Recent Released Workstream Context
 
@@ -162,17 +174,16 @@ Current merged truth indicates:
 - the released FB-035 lane is closed
 - the recent released workstreams above remain part of the locked current baseline
 - no merged unreleased non-doc implementation debt currently exists on `main`
-- repo state has no active implementation branch selected after the FB-041 release
+- FB-037 is the active implementation workstream in `Branch Readiness`
 - if a branch changes release-facing canon, those canon updates must land on that same branch before PR readiness is allowed
 - post-release canon repair is emergency-only when merged canon is already stale or external drift made pre-merge prevention impossible
 - the released FB-027 baseline does not authorize further saved-action authoring, resolution, voice, Action Studio, routines, profiles, hotkey cleanup, or shutdown-confirmation work by inertia
-- future candidate spaces now explicitly recorded in the backlog include:
-  - FB-037 for curated built-in system actions and Nexus settings expansion
+- remaining future candidate spaces now explicitly recorded in the backlog include:
   - FB-038 for taskbar or tray quick-task UX including Create Custom Task
   - FB-039 for external trigger and plugin integration architecture
   - FB-040 for monitoring, thermals, and performance HUD surfaces
 - those candidate lanes must be selected deliberately rather than bundled together as one implicit interaction continuation
-- the next implementation workstream must be selected deliberately through `Branch Readiness` from updated `main`; FB-041 release does not imply automatic continuation into any candidate lane
+- FB-037 Branch Readiness does not imply automatic continuation into any remaining candidate lane
 
 Use canonical workstream docs for execution detail.
 Use the backlog for item identity.

--- a/Docs/workstreams/FB-037_built_in_actions_and_settings_expansion.md
+++ b/Docs/workstreams/FB-037_built_in_actions_and_settings_expansion.md
@@ -11,7 +11,7 @@
 
 ## Status
 
-- `Workstream`
+- `Merged unreleased on main`
 
 ## Release Stage
 
@@ -33,15 +33,34 @@ This workstream exists so common Windows, vendor utility, and Nexus-owned destin
 
 ## Current Phase
 
-- Phase: `Workstream`
+- Phase: `Release Readiness`
 
 ## Phase Status
 
-- `Active Branch`
-- Workstream phase is open on `feature/fb-037-built-in-actions-and-settings-expansion`
+- `No Active Branch`
+- after this branch merges, FB-037 is merged-unreleased implementation release debt and no implementation branch remains active
+- Release Readiness is the governing post-merge phase until release packaging clears `Release Debt` for FB-037
+- successor-lane lock is waived because post-merge repo truth resolves to `No Active Branch` due to `Release Debt` (FB-037)
+- historical implementation branch:
+  - `feature/fb-037-built-in-actions-and-settings-expansion`
+- PR Readiness on the implementation branch passed after Live Validation evidence was digested and merge-target canon was corrected for post-merge truth
+- prior Hardening repaired and verified the reusable live-validation helper/process path before the first Live Validation attempt
 - Branch Readiness setup is durably checkpointed in commit `1cc1a93`
-- no implementation seam has been selected yet
-- no product or runtime code changes are authorized until the first Workstream seam is selected and bounded
+- first four implementation seams are selected and implemented:
+  `catalog-only Task Manager built-in action`, `catalog-only Calculator built-in action`, `catalog-only Notepad built-in action`, and `catalog-only Paint built-in action`
+- product/runtime changes are limited to the existing shared-action catalog and exact resolver precedence needed for saved-action fallback safety
+- branch-local docs-only governance refinement is allowed only to keep this active implementation branch truthful, phase-correct, and aligned with live source-of-truth; it does not authorize product/runtime scope expansion
+- this branch exposed repo-wide multi-seam workflow drift, and the bounded docs/governance repair is carried on this active branch because it directly controls FB-037 Workstream execution truth
+- Workstream exit criteria are satisfied under the bounded multi-seam model
+- Live Validation exposed process drift: a one-off interactive validation probe did not use the strongest existing watchdog/progress pattern and did not self-abort before operator-visible stall
+- the completed Hardening seam remained limited to governance alignment plus reusable live-validation helper/process repair; no new product features, built-ins, target kinds, launcher behavior, UI model changes, settings/protocol behavior, or result/confirm copy changes were introduced
+- the first formal FB-037 Live Validation run passed Task Manager and Calculator built-in evidence, reached correct Notepad confirm and launch markers, but failed to capture a visible Notepad launch window before timeout
+- the targeted helper Hardening pass added process/window probes, failure manifests, cleanup metadata, framed-window handling, focus-verified input handling, submit markers, and bounded submit retries
+- the latest submit-reliability validation proved Task Manager, Calculator, and Notepad all reached `COMMAND_CONFIRM_READY` on the first submit attempt; the remaining failure moved back to Notepad visible-window evidence and Task Manager cleanup
+- the later Live Validation attempt at `dev\logs\launcher_live_window_audit\20260420_105902` progressed through built-in scenarios but violated the no-progress cleanup contract during Notepad cleanup and did not generate `manifest.json`
+- helper-only Hardening validation later passed at `dev\logs\launcher_live_window_audit\20260420_111616\manifest.json` with manifest-backed cleanup classification and no helper cleanup failures
+- closeout-grade Live Validation later passed at `dev\logs\launcher_live_window_audit\20260420_112713\manifest.json` with `19` passed scenarios, `0` scenario failures, `36` captures, and complete cleanup classification
+- no additional same-risk Workstream seams remain; settings/protocol behavior, target-kind expansion, launcher-policy work, UI-semantics work, and default-group expansion require a different risk class and remain out of scope unless explicitly reopened later
 
 ## Branch Class
 
@@ -49,7 +68,7 @@ This workstream exists so common Windows, vendor utility, and Nexus-owned destin
 
 ## Blockers
 
-- no active blockers
+- `Release Debt` (FB-037)
 
 ## Entry Basis
 
@@ -61,29 +80,54 @@ This workstream exists so common Windows, vendor utility, and Nexus-owned destin
 - Branch Readiness setup was committed in `1cc1a93`
 - Branch Readiness validation passed with `python dev/orin_branch_governance_validation.py`
 - `git diff --check` passed after the Branch Readiness checkpoint
+- Workstream exited after the approved same-risk built-in catalog seam chain completed and no same-risk seams remained without changing subsystem or risk class
+- Hardening pressure-tested the completed seam chain and preserved the earlier Live Validation failures as historical evidence, not active blockers
+- Hardening repaired the reusable live-validation helper for progress reporting, failure manifests, process/window probes, focus-verified submit behavior, process-only launch classification, and cleanup outcome classification
+- previous reusable helper evidence passed with `powershell -NoProfile -ExecutionPolicy Bypass -File dev\orin_launcher_live_window_audit.ps1 -Fb037Validation`
+- previous helper evidence path: `dev\logs\launcher_live_window_audit\20260420_103951`
+- subsequent Live Validation evidence path: `dev\logs\launcher_live_window_audit\20260420_105902`
+- subsequent Live Validation result: `FAIL`
+- subsequent failure basis: the helper passed several built-in scenarios but left a cleanup no-progress gap greater than `10s` during Notepad cleanup and did not generate `manifest.json`
+- final helper-only Hardening evidence path: `dev\logs\launcher_live_window_audit\20260420_111616`
+- final helper manifest status: `PASS`
+- final helper scenario result: `19` passed scenarios, `0` failed scenarios
+- final cleanup summary: cleanup success count `5`, OS-blocked cleanup count `0`, helper-failure cleanup count `0`, baseline-skipped count `14`
+- repo-side governance validation passed before this phase transition with `python dev/orin_branch_governance_validation.py`
+- PR Readiness canon correction recorded the post-merge `No Active Branch` state and waived successor-lane lock because FB-037 release debt blocks next implementation admission
 
 ## Exit Criteria
 
-- first implementation seam is selected and explicitly bounded
-- selected seam stays inside curated built-in system actions and Nexus settings expansion
-- implementation for the selected seam is complete
-- direct repo-side validation for the selected seam is green
-- shared action model, saved-action, callable-group, and interaction baseline regressions are checked as relevant
-- no unresolved same-slice correctness gap remains before transition to `Hardening`
+- release packaging for FB-037 is opened on an approved release-packaging branch or otherwise explicitly authorized
+- target public prerelease for FB-037 is selected by release packaging
+- FB-037 release notes and release-state transitions are prepared before clearing `Release Debt`
+- release debt remains explicit until FB-037 is actually released
+- no next implementation branch is admitted while FB-037 release debt remains unresolved
 
 ## Rollback Target
 
-- `Branch Readiness`
+- `PR Readiness`
 
 ## Next Legal Phase
 
-- `Hardening`
+- `Release Readiness`
+
+## Post-Merge State
+
+- Phase (post-merge): `Release Readiness`
+- Phase Status (post-merge): `No Active Branch`
+- Blocker: `Release Debt` (FB-037)
+- Next Legal Phase: `Release Readiness` (release packaging)
+- Successor lane lock: waived because repo truth resolves to `No Active Branch` due to FB-037 release debt
+- Record State: `Promoted` until release packaging marks FB-037 released and closes the workstream
+- Next concern: release packaging; no next implementation lane may begin until release debt is cleared or explicitly waived by canon
+- This workstream must not be treated as an active implementation branch owner after merge
 
 ## Bounded Objective
 
-Define and later implement a curated set of built-in actions for standard Windows, vendor utility, and Nexus-owned surfaces that belong in the product catalog rather than user-authored saved actions.
+Define and implement a curated set of built-in actions for standard Windows, vendor utility, and Nexus-owned surfaces that belong in the product catalog rather than user-authored saved actions.
 
-The first Workstream-phase slice must begin by inventorying candidate built-ins, locating the shared action catalog boundaries, and choosing the smallest safe built-in action expansion seam before product code changes.
+Workstream execution must use bounded multi-seam workflow where the seams stay in the same risk class and subsystem family.
+Each built-in catalog seam must be selected, bounded, implemented, validated, recorded, and judged before the next seam starts.
 
 ## Explicit Non-Goals
 
@@ -119,13 +163,23 @@ Branch Readiness validation is docs/governance-only and must prove:
 - no product or runtime code changed
 - governance validation passes
 
-Future Workstream-phase validation must be defined before implementation begins and must preserve:
+Workstream-phase validation must preserve:
 
 - shared action model compatibility
 - built-in versus saved action source distinction
 - exact-match resolution expectations
 - saved-action and callable-group regression behavior
 - failure classification and result-surface boundaries from the released baseline
+- per-seam validation and continue-or-stop decisions when bounded multi-seam workflow is used
+
+Hardening-phase validation must prove the completed same-risk catalog seam chain remains stable as one branch:
+
+- shared action catalog integrity and built-in metadata remain valid
+- saved-action source precedence still overrides built-in phrase collisions
+- create/edit authoring collision protection remains bounded
+- confirm/result flow remains unchanged for built-ins and saved-action overrides
+- callable-group execution and failure semantics remain unchanged
+- governance and current-state canon remain aligned
 
 ## Branch Readiness Progress
 
@@ -134,14 +188,219 @@ Future Workstream-phase validation must be defined before implementation begins 
 - created this canonical workstream record
 - recorded Branch Readiness phase authority, scope, non-goals, reuse baseline, and validation contract
 - checkpointed Branch Readiness setup in commit `1cc1a93`
-- advanced phase authority to `Workstream` for first seam selection only
+- advanced phase authority to `Workstream` for bounded seam selection and implementation
 
 ## Workstream Progress
 
-- no implementation seam has been selected yet
-- no product or runtime code changes have been made for FB-037
-- next Workstream move is first seam analysis and selection
+- Seam 1 complete:
+  `catalog-only Task Manager built-in action`
+- added `open_task_manager` as one built-in `app` action targeting `taskmgr.exe`
+- kept the existing `CommandAction` schema, supported target kinds, launch path, UI flow, confirm flow, and result flow unchanged
+- preserved saved-action precedence by allowing saved-action phrase collisions with built-ins to load and resolve as saved actions
+- kept built-in ID collisions protected
+- kept saved-vs-saved exact phrase overlaps as explicit ambiguity candidates
+- kept FB-036 authoring create/edit built-in phrase collision rejection intact so the authoring UI path is not widened by this seam
+- repo-side validation:
+  - `python dev/orin_shared_action_baseline_validation.py` passed
+  - `python dev/orin_saved_action_source_validation.py` passed
+  - `python dev/orin_saved_action_authoring_validation.py` passed
+  - `python dev/orin_interaction_baseline_validation.py` passed
+- Seam 2 complete:
+  `catalog-only Calculator built-in action`
+- added `open_calculator` as one built-in `app` action targeting `calc.exe`
+- reused the existing `CommandAction` schema, supported `app` target kind, launch path, UI flow, confirm flow, and result flow
+- preserved saved-action precedence so a saved action matching `calculator`, `open calculator`, or `launch calculator` resolves instead of the built-in
+- kept FB-036 authoring create/edit built-in phrase collision rejection intact; source-loaded saved actions still retain override authority
+- kept callable-group execution, failure classification, result text, Nexus settings, shell arguments, and target-kind support unchanged
+- repo-side validation:
+  - `python dev/orin_shared_action_baseline_validation.py` passed
+  - `python dev/orin_saved_action_source_validation.py` passed
+  - `python dev/orin_saved_action_authoring_validation.py` passed
+  - `python dev/orin_interaction_baseline_validation.py` passed
+  - `python dev/orin_callable_group_execution_validation.py` passed
+  - `python dev/orin_branch_governance_validation.py` passed
+- same-phase Seam 2 hardening checkpoint passed with targeted proof for catalog ordering, exact-match boundaries, saved-action override precedence, confirm/result continuity, and authoring collision protection
+- Seam 3 complete:
+  `catalog-only Notepad built-in action`
+- added `open_notepad` as one built-in `app` action targeting `notepad.exe`
+- reused the existing `CommandAction` schema, supported `app` target kind, launch path, UI flow, confirm flow, and result flow
+- preserved saved-action precedence so a saved action matching `notepad`, `open notepad`, or `launch notepad` resolves instead of the built-in
+- kept FB-036 authoring create/edit built-in phrase collision rejection intact; source-loaded saved actions still retain override authority
+- kept callable-group execution, failure classification, result text, Nexus settings, shell arguments, and target-kind support unchanged
+- repo-side validation:
+  - `python dev/orin_shared_action_baseline_validation.py` passed
+  - `python dev/orin_saved_action_source_validation.py` passed
+  - `python dev/orin_saved_action_authoring_validation.py` passed
+  - `python dev/orin_interaction_baseline_validation.py` passed
+  - `python dev/orin_callable_group_execution_validation.py` passed
+  - `python dev/orin_branch_governance_validation.py` passed
+- same-phase Seam 3 hardening checkpoint passed with targeted proof for catalog ordering, exact-match boundaries, saved-action override precedence, create/edit authoring collision protection, confirm/result continuity, target-kind boundaries, and default-group boundaries
+- Seam 4 complete:
+  `catalog-only Paint built-in action`
+- added `open_paint` as one built-in `app` action targeting `mspaint.exe`
+- reused the existing `CommandAction` schema, supported `app` target kind, launch path, UI flow, confirm flow, and result flow
+- preserved saved-action precedence so a saved action matching `paint`, `open paint`, or `launch paint` resolves instead of the built-in
+- kept FB-036 authoring create/edit built-in phrase collision rejection intact; source-loaded saved actions still retain override authority
+- kept callable-group execution, failure classification, result text, Nexus settings, shell arguments, target-kind support, launcher policy, and UI semantics unchanged
+- repo-side validation:
+  - `python dev/orin_shared_action_baseline_validation.py` passed
+  - `python dev/orin_saved_action_source_validation.py` passed
+  - `python dev/orin_saved_action_authoring_validation.py` passed
+  - `python dev/orin_interaction_baseline_validation.py` passed
+  - `python dev/orin_callable_group_execution_validation.py` passed
+  - `python dev/orin_branch_governance_validation.py` passed
+  - `git diff --check` passed with CRLF normalization warnings only
+- all currently safe same-risk Workstream implementation seams are complete; settings/protocol behavior, target-kind expansion, launcher-policy work, UI-semantics work, and default-group expansion remain out of scope unless a later phase-valid prompt explicitly reclassifies the risk
+- branch-coupled governance refinement complete:
+  `bounded multi-seam workflow` is now formalized as the primary Workstream model while preserving one active seam at a time, per-seam validation, continue-or-stop gates, single-seam fallback, and the normal `Workstream` -> `Hardening` -> `Live Validation` -> `PR Readiness` phase path
+- repo-side governance validation:
+  - `python dev/orin_branch_governance_validation.py` must pass after the multi-seam governance repair
+  - `git diff --check` must pass after the multi-seam governance repair
+- Workstream exit complete:
+  - all approved same-risk catalog seams are complete and validated
+  - no same-risk Workstream seams remain without changing subsystem or risk class
+  - phase authority transitioned from `Workstream` to `Hardening`
+
+## Hardening Progress
+
+- Initial Hardening pressure-tested the completed built-in catalog seam chain
+- Hardening did not add new built-ins, settings/protocol behavior, target kinds, launcher-policy behavior, UI-model changes, or default-group expansion
+- Initial Hardening validation passed:
+  - `python dev/orin_shared_action_baseline_validation.py`
+  - `python dev/orin_saved_action_source_validation.py`
+  - `python dev/orin_saved_action_authoring_validation.py`
+  - `python dev/orin_interaction_baseline_validation.py`
+  - `python dev/orin_callable_group_execution_validation.py`
+  - `python dev/orin_branch_governance_validation.py`
+  - `git diff --check`
+  - inline four-built-in cross-seam pressure probe
+- Live Validation later exposed process drift in the interactive helper path: the attempted validation used a one-off probe pattern without sufficient reusable-helper discipline, visible progress, or no-progress self-abort
+- reopened Hardening completed the governance alignment plus reusable live-validation helper/process repair
+- `dev/orin_launcher_live_window_audit.ps1` now records visible step progress, writes a step log, reports the last confirmed progress point, and enforces a `10s` no-progress supervisor by default
+- helper repair validation passed with `powershell -NoProfile -ExecutionPolicy Bypass -File dev\orin_launcher_live_window_audit.ps1 -TimeoutSeconds 8 -NoProgressTimeoutSeconds 10`
+- targeted evidence/cleanup reliability validation passed with `powershell -NoProfile -ExecutionPolicy Bypass -File dev\orin_launcher_live_window_audit.ps1 -Fb037Validation`
+- latest reusable helper artifact path: `dev\logs\launcher_live_window_audit\20260420_103951`
+- latest reusable helper manifest status: `PASS`
+- latest reusable helper cleanup classification is explicit: cleanup success count `1`, OS-blocked cleanup count `0`, helper-failure cleanup count `0`, and baseline-skipped count `14`
+- phase authority transitioned from `Hardening` to `Live Validation` after helper repair validation, evidence/cleanup validation, and governance validation passed
+- later Live Validation run `dev\logs\launcher_live_window_audit\20260420_105902` reopened Hardening because cleanup created a no-progress gap greater than `10s` after Notepad launch evidence and the run was aborted before `manifest.json` was generated
+- helper-only Hardening repaired cleanup watchdog coverage, manifest-before-cleanup failure handling, final manifest refresh, Win32 visible-window probe acceptance, cleanup progress markers, and already-exited cleanup classification
+- final helper-only Hardening validation passed:
+  `powershell -NoProfile -ExecutionPolicy Bypass -File dev\orin_launcher_live_window_audit.ps1 -Fb037Validation`
+- final helper evidence path:
+  `dev\logs\launcher_live_window_audit\20260420_111616`
+- final helper manifest status:
+  `PASS`
+- final helper cleanup classification:
+  cleanup success count `5`, OS-blocked cleanup count `0`, helper-failure cleanup count `0`, baseline-skipped count `14`
+- Live Validation closeout evidence path: `dev\logs\launcher_live_window_audit\20260420_112713`
+- Live Validation closeout manifest status: `PASS`
+- Live Validation closeout scenario result: `19` passed scenarios, `0` failed scenarios
+- Live Validation closeout artifact summary: `manifest.json`, `step_log.txt`, `36` screenshots/probes, and per-scenario launch evidence were generated
+- Live Validation closeout cleanup classification: cleanup success count `20`, OS-blocked cleanup count `14`, helper-failure cleanup count `0`, baseline-skipped count `0`
+- environment-specific behavior classification:
+  - Task Manager launched correctly and visible launched-window evidence was captured; Windows denied forced Task Manager termination during cleanup, which is classified as OS-blocked cleanup rather than helper or product failure
+  - Notepad resolved and launched correctly under runtime markers; this environment exposed Notepad process-only/no-visible-window evidence, so the helper preserved launch probes and classified the launch as `process_launched_no_visible_window`
+
+## Live Validation Progress
+
+- Live Validation was formally opened for real interactive usage checks of the completed built-in catalog seam chain
+- first FB-037 live helper run:
+  `powershell -NoProfile -ExecutionPolicy Bypass -File dev\orin_launcher_live_window_audit.ps1 -Fb037Validation -TimeoutSeconds 8 -NoProgressTimeoutSeconds 10`
+- result: `FAIL`
+- preserved evidence path:
+  `dev\logs\launcher_live_window_audit\20260420_094357`
+- Task Manager built-in evidence passed:
+  correct confirm marker, launch marker, result screenshot, and launched-window screenshot were captured for `open_task_manager`
+- Calculator built-in evidence passed:
+  correct confirm marker, launch marker, result screenshot, and launched-window screenshot were captured for `open_calculator`
+- Notepad built-in partial evidence:
+  correct confirm marker and launch marker were captured for `open_notepad`, and confirm/result screenshots were written
+- Notepad failure:
+  the helper timed out while waiting for a visible window matching `*Notepad*`; no manifest was generated because the run stopped before scenario completion
+- targeted Hardening rerun after process/window-probe and failure-manifest changes:
+  `dev\logs\launcher_live_window_audit\20260420_095824`
+- result: `FAIL`
+- Task Manager evidence passed and `manifest.json` was generated on failure
+- Calculator failure:
+  the helper detected `CalculatorApp` process state but no visible process-owned top-level window; the manifest classified the probe instead of timing out silently
+- targeted Hardening reruns after framed-window and submit-path changes:
+  `dev\logs\launcher_live_window_audit\20260420_100012` and `dev\logs\launcher_live_window_audit\20260420_100155`
+- result: `FAIL`
+- helper submit failure:
+  the runtime observed overlay text changes for `open task manager`, but the helper did not produce the expected `COMMAND_CONFIRM_READY|action_id=open_task_manager` marker
+- targeted Hardening rerun after focus-verified submit repair:
+  `dev\logs\launcher_live_window_audit\20260420_101109`
+- result: `FAIL`
+- submit reliability result:
+  Task Manager, Calculator, and Notepad each reached the expected `COMMAND_CONFIRM_READY` marker on the first submit attempt, with explicit `input focused`, `text set`, `submit attempted`, and `submit confirmed` step-log markers
+- remaining helper failure:
+  Notepad launched according to runtime markers but did not expose a visible document window before the `10s` no-progress watchdog; the manifest records the two Notepad processes and hidden window probe
+- remaining cleanup failure:
+  Task Manager remained open after helper cleanup because Windows denied process termination; the pass also verified that normal close, Alt+F4, `WM_CLOSE`, and `taskkill` could not close the instance from the current process context
+- targeted Hardening rerun after evidence/cleanup reliability repair:
+  `dev\logs\launcher_live_window_audit\20260420_103951`
+- result: `PASS`
+- evidence/cleanup reliability result:
+  the reusable helper completed the FB-037 validation profile, generated `manifest.json`, wrote `step_log.txt`, preserved confirm/result screenshots, preserved launch probes for process-only launches, and classified cleanup outcomes without helper failure
+- second Live Validation attempt:
+  `dev\logs\launcher_live_window_audit\20260420_105902`
+- result: `FAIL`
+- runtime/product result:
+  built-in scenarios progressed through Task Manager, Calculator, Notepad, and Paint evidence without a product contradiction before the run was stopped
+- helper failure:
+  cleanup after Notepad created a no-progress gap greater than the `10s` contract and the aborted run did not generate `manifest.json`
+- the earlier interrupted attempt remains non-closeout-grade evidence
+- interrupted or partial interactive evidence is not closeout-grade proof and does not advance the phase by implication
+- closeout-grade Live Validation run:
+  `powershell -NoProfile -ExecutionPolicy Bypass -File dev\orin_launcher_live_window_audit.ps1 -Fb037Validation`
+- closeout-grade evidence path:
+  `dev\logs\launcher_live_window_audit\20260420_112713`
+- result: `PASS`
+- scenario summary:
+  `19` passed scenarios, `0` scenario failures
+- artifact summary:
+  `manifest.json`, `step_log.txt`, `36` screenshots/probes, confirm captures, result captures, launched-window captures where visible-window evidence was available, and launch probes where process-only evidence was the observed environment behavior
+- required Live Validation focus completed:
+  - built-in execution for Task Manager, Calculator, Notepad, and Paint
+  - saved-action override behavior for the same phrase families
+  - authoring collision rejection for built-in phrases
+  - mixed built-in plus saved-action source behavior
+  - repeated execution without resolution drift or state leakage
+- environment-specific classifications:
+  - Task Manager cleanup produced OS-blocked termination outcomes while preserving successful launch evidence and no helper cleanup failure
+  - Notepad produced process-only/no-visible-window launch evidence in this environment; runtime markers and launch probes remained consistent with successful execution
+- no product/runtime contradiction, confirm/result divergence, saved-action override failure, or helper evidence gap remained after the run
+- phase authority advanced from `Live Validation` to `PR Readiness` during the implementation branch, and PR Readiness correction later encoded the post-merge `Release Readiness` / `No Active Branch` release-debt state
+
+## Governance Drift Audit
+
+- Governance Drift Found: Yes, already resolved on this active branch
+- Drift Type: Workstream execution-flow governance, active-branch governance placement, and Live Validation helper/process discipline
+- Why Current Canon Failed To Prevent It: Earlier canon still carried one-seam-per-pass habits, left ambiguity around whether branch-coupled governance fixes belonged on a separate docs branch, and did not make reusable Live Validation helpers plus no-progress monitoring explicit enough to prevent operator-visible stalls
+- Required Canon Changes: Already applied on this branch across repo-wide governance docs, prompt scaffolds, the branch governance validator, and this authority record; no additional canon delta is required by the closeout-grade Live Validation evidence
+- Whether The Drift Blocks Merge: No, because the drift was corrected before PR Readiness and the remaining PR gate is ordinary merge-target canon/package review
+- Whether User Confirmation Is Required: No further confirmation is required for the already-applied governance repairs; any new governance expansion found during PR Readiness must stop and request confirmation before implementation
+- Missing blocker check: no missing blocker remains after adding reusable-helper timeout, active-branch governance, and bounded multi-seam rules
+- Weak phase entry or exit rule check: no unresolved weakness remains for the current FB-037 phase path
+- Weak source-of-truth ownership rule check: active workstream authority remains the phase owner; backlog and roadmap only mirror current state
+- Stale prompt scaffolding or example check: branch-coupled prompt scaffolds were updated earlier on this branch for multi-seam and active-branch governance rules
+- Missing validator requirement check: the branch governance validator now enforces the PR Readiness Governance Drift Audit presence requirement and still guards canonical phase/state drift
 
 ## User Test Summary
 
-No manual user test is required for this phase-transition pass because no product, runtime, UI, or user-visible behavior changed.
+Seams 1, 2, 3, and 4 add user-visible built-in catalog actions without changing UI structure.
+
+Live Validation evidence captured:
+
+- evidence path: `dev\logs\launcher_live_window_audit\20260420_112713`
+- `manifest.json`: generated and `PASS`
+- `step_log.txt`: generated with visible progress through cleanup completion
+- built-in execution passed for `open task manager`, `open calculator`, `open notepad`, and `open paint`
+- saved-action override passed for `task manager`, `calculator`, `notepad`, and `paint`; saved actions won and built-ins did not execute for those override scenarios
+- authoring boundary passed for create collisions on `task manager`, `calculator`, `notepad`, and `paint`, plus edit collision on `task manager`
+- mixed environment passed for built-in Task Manager, saved Calculator, built-in Notepad, and saved Paint
+- repeated execution passed for Notepad without resolution drift or state leakage
+- Task Manager launched with visible-window evidence; cleanup termination was OS-blocked by Windows and classified as environmental cleanup behavior, not a product or helper failure
+- Notepad launched with runtime markers and process-only/no-visible-window probe evidence in this environment; the helper preserved probe artifacts and classified the launch without treating it as a product contradiction
+- confirm and result surfaces used the existing flow and did not require UI copy or model changes

--- a/Docs/workstreams/FB-037_built_in_actions_and_settings_expansion.md
+++ b/Docs/workstreams/FB-037_built_in_actions_and_settings_expansion.md
@@ -1,0 +1,134 @@
+# FB-037 Curated Built-In System Actions And Nexus Settings Expansion
+
+## ID And Title
+
+- ID: `FB-037`
+- Title: `Curated built-in system actions and Nexus settings expansion`
+
+## Record State
+
+- `Promoted`
+
+## Status
+
+- `Branch Readiness`
+
+## Release Stage
+
+- `pre-Beta`
+
+## Target Version
+
+- `TBD`
+
+## Canonical Branch
+
+- `feature/fb-037-built-in-actions-and-settings-expansion`
+
+## Purpose / Why It Matters
+
+Promote the curated built-in system actions and Nexus settings expansion lane above the released shared action, saved-action authoring, callable-group authoring, and deterministic callable-group execution baseline.
+
+This workstream exists so common Windows, vendor utility, and Nexus-owned destinations can become deliberate first-class built-in actions under the shared action model instead of being left to ad hoc saved-action customization.
+
+## Current Phase
+
+- Phase: `Branch Readiness`
+
+## Phase Status
+
+- `Active Branch`
+- Branch Readiness admission is open on `feature/fb-037-built-in-actions-and-settings-expansion`
+- no implementation seam has been selected yet
+- no product or runtime code changes are authorized in Branch Readiness
+
+## Branch Class
+
+- `implementation`
+
+## Blockers
+
+- no active blockers
+
+## Entry Basis
+
+- updated `main` is aligned with `origin/main`
+- FB-041 is released in `v1.3.1-prebeta` and no longer blocks next-lane admission
+- no active promoted workstream exists before this admission
+- FB-037 was `Registry-only` on merged canon before this Branch Readiness pass
+- this branch was created fresh from updated `main`
+
+## Exit Criteria
+
+- backlog, roadmap, workstreams index, and this workstream doc agree that FB-037 is promoted and in `Branch Readiness`
+- bounded objective and explicit non-goals are recorded before implementation begins
+- reuse baseline and validation contract are recorded
+- no product or runtime implementation has started during Branch Readiness
+- no unresolved blocker prevents transition to `Workstream`
+
+## Rollback Target
+
+- `Branch Readiness`
+
+## Next Legal Phase
+
+- `Workstream`
+
+## Bounded Objective
+
+Define and later implement a curated set of built-in actions for standard Windows, vendor utility, and Nexus-owned surfaces that belong in the product catalog rather than user-authored saved actions.
+
+The first Workstream-phase slice must begin by inventorying candidate built-ins, locating the shared action catalog boundaries, and choosing the smallest safe built-in action expansion seam before product code changes.
+
+## Explicit Non-Goals
+
+- no implementation during Branch Readiness
+- no product or runtime code changes during Branch Readiness
+- no saved-action authoring redesign
+- no callable-group execution changes
+- no scheduling, branching, retries, nested groups, or parallelism
+- no taskbar, tray, plugin, external trigger, monitoring, thermal, or performance HUD work
+- no Action Studio behavior
+- no voice invocation changes
+- no broad UI redesign
+- no implicit promotion of FB-038, FB-039, or FB-040
+
+## Reuse Baseline
+
+- `Docs/closeouts/nexus_prebeta_rebaseline_through_v1.3.1-prebeta.md`
+- `Docs/workstreams/FB-041_deterministic_callable_group_execution_layer.md`
+- `Docs/workstreams/FB-036_saved_action_authoring.md`
+- `Docs/workstreams/FB-027_interaction_system_baseline.md`
+- `desktop/shared_action_model.py`
+- `desktop/interaction_overlay_model.py`
+
+## Validation Contract
+
+Branch Readiness validation is docs/governance-only and must prove:
+
+- FB-037 is promoted exactly once
+- FB-037 has a canonical workstream doc
+- the active phase block uses the canonical phase enum
+- the branch class is `implementation`
+- FB-041 released truth remains unchanged
+- no product or runtime code changed
+- governance validation passes
+
+Future Workstream-phase validation must be defined before implementation begins and must preserve:
+
+- shared action model compatibility
+- built-in versus saved action source distinction
+- exact-match resolution expectations
+- saved-action and callable-group regression behavior
+- failure classification and result-surface boundaries from the released baseline
+
+## Branch Readiness Progress
+
+- created fresh branch `feature/fb-037-built-in-actions-and-settings-expansion` from updated `main`
+- promoted FB-037 from `Registry-only` to `Promoted`
+- created this canonical workstream record
+- recorded Branch Readiness phase authority, scope, non-goals, reuse baseline, and validation contract
+
+## User Test Summary
+
+No manual user test is required for this Branch Readiness pass because no product, runtime, UI, or user-visible behavior changed.

--- a/Docs/workstreams/FB-037_built_in_actions_and_settings_expansion.md
+++ b/Docs/workstreams/FB-037_built_in_actions_and_settings_expansion.md
@@ -11,7 +11,7 @@
 
 ## Status
 
-- `Branch Readiness`
+- `Workstream`
 
 ## Release Stage
 
@@ -33,14 +33,15 @@ This workstream exists so common Windows, vendor utility, and Nexus-owned destin
 
 ## Current Phase
 
-- Phase: `Branch Readiness`
+- Phase: `Workstream`
 
 ## Phase Status
 
 - `Active Branch`
-- Branch Readiness admission is open on `feature/fb-037-built-in-actions-and-settings-expansion`
+- Workstream phase is open on `feature/fb-037-built-in-actions-and-settings-expansion`
+- Branch Readiness setup is durably checkpointed in commit `1cc1a93`
 - no implementation seam has been selected yet
-- no product or runtime code changes are authorized in Branch Readiness
+- no product or runtime code changes are authorized until the first Workstream seam is selected and bounded
 
 ## Branch Class
 
@@ -57,14 +58,18 @@ This workstream exists so common Windows, vendor utility, and Nexus-owned destin
 - no active promoted workstream exists before this admission
 - FB-037 was `Registry-only` on merged canon before this Branch Readiness pass
 - this branch was created fresh from updated `main`
+- Branch Readiness setup was committed in `1cc1a93`
+- Branch Readiness validation passed with `python dev/orin_branch_governance_validation.py`
+- `git diff --check` passed after the Branch Readiness checkpoint
 
 ## Exit Criteria
 
-- backlog, roadmap, workstreams index, and this workstream doc agree that FB-037 is promoted and in `Branch Readiness`
-- bounded objective and explicit non-goals are recorded before implementation begins
-- reuse baseline and validation contract are recorded
-- no product or runtime implementation has started during Branch Readiness
-- no unresolved blocker prevents transition to `Workstream`
+- first implementation seam is selected and explicitly bounded
+- selected seam stays inside curated built-in system actions and Nexus settings expansion
+- implementation for the selected seam is complete
+- direct repo-side validation for the selected seam is green
+- shared action model, saved-action, callable-group, and interaction baseline regressions are checked as relevant
+- no unresolved same-slice correctness gap remains before transition to `Hardening`
 
 ## Rollback Target
 
@@ -72,7 +77,7 @@ This workstream exists so common Windows, vendor utility, and Nexus-owned destin
 
 ## Next Legal Phase
 
-- `Workstream`
+- `Hardening`
 
 ## Bounded Objective
 
@@ -128,7 +133,15 @@ Future Workstream-phase validation must be defined before implementation begins 
 - promoted FB-037 from `Registry-only` to `Promoted`
 - created this canonical workstream record
 - recorded Branch Readiness phase authority, scope, non-goals, reuse baseline, and validation contract
+- checkpointed Branch Readiness setup in commit `1cc1a93`
+- advanced phase authority to `Workstream` for first seam selection only
+
+## Workstream Progress
+
+- no implementation seam has been selected yet
+- no product or runtime code changes have been made for FB-037
+- next Workstream move is first seam analysis and selection
 
 ## User Test Summary
 
-No manual user test is required for this Branch Readiness pass because no product, runtime, UI, or user-visible behavior changed.
+No manual user test is required for this phase-transition pass because no product, runtime, UI, or user-visible behavior changed.

--- a/Docs/workstreams/index.md
+++ b/Docs/workstreams/index.md
@@ -73,6 +73,13 @@ For an active or recently closed canonical workstream, keep these durable tracea
 Active here means the current promoted truth owner.
 That may be an executable branch owner or another explicitly promoted current-truth owner.
 
+- None
+
+### Merged / Release Debt Owners
+
+Merged / Release Debt Owners are promoted implementation workstreams whose implementation branch is merge-target complete but whose public release packaging has not yet cleared release debt.
+These records are not active implementation branch owners after merge.
+
 - `Docs/workstreams/FB-037_built_in_actions_and_settings_expansion.md`
 
 ### Closed

--- a/Docs/workstreams/index.md
+++ b/Docs/workstreams/index.md
@@ -73,7 +73,7 @@ For an active or recently closed canonical workstream, keep these durable tracea
 Active here means the current promoted truth owner.
 That may be an executable branch owner or another explicitly promoted current-truth owner.
 
-- none currently
+- `Docs/workstreams/FB-037_built_in_actions_and_settings_expansion.md`
 
 ### Closed
 

--- a/desktop/saved_action_authoring.py
+++ b/desktop/saved_action_authoring.py
@@ -14,6 +14,7 @@ from .shared_action_model import (
     CommandGroup,
     DEFAULT_COMMAND_ACTIONS,
     SUPPORTED_ACTION_TARGET_KINDS,
+    build_saved_action_callable_phrases,
     build_default_command_action_catalog,
     coerce_saved_command_action_record,
     coerce_saved_command_actions_from_records,
@@ -427,6 +428,34 @@ def _available_actions_for_state(
     return (*DEFAULT_COMMAND_ACTIONS, *(saved_actions or state.existing_actions))
 
 
+def _normalized_action_phrases(action: CommandAction) -> set[str]:
+    return {
+        normalized
+        for normalized in (
+            normalize_command_text(phrase)
+            for phrase in build_saved_action_callable_phrases(
+                action.title,
+                action.aliases,
+                invocation_mode=action.invocation_mode,
+                trigger_mode=action.trigger_mode,
+                custom_triggers=action.custom_triggers,
+            )
+        )
+        if normalized
+    }
+
+
+def _reject_builtin_phrase_collision_for_authoring(action: CommandAction):
+    built_in_phrases: set[str] = set()
+    for built_in_action in DEFAULT_COMMAND_ACTIONS:
+        built_in_phrases.update(_normalized_action_phrases(built_in_action))
+
+    if _normalized_action_phrases(action) & built_in_phrases:
+        raise SavedActionDraftValidationError(
+            "Saved action title, alias, or trigger phrase collides with an existing built-in action."
+        )
+
+
 def _load_saved_action_authoring_state(
     source_path: str | Path | None = None,
 ) -> SavedActionAuthoringState:
@@ -581,6 +610,7 @@ def _build_saved_action_record_for_create(
         record["custom_triggers"] = list(custom_triggers)
 
     try:
+        _reject_builtin_phrase_collision_for_authoring(coerce_saved_command_action_record(record))
         coerce_saved_command_actions_from_records((*state.existing_records, record))
     except ValueError as exc:
         raise SavedActionDraftValidationError(str(exc)) from exc
@@ -852,6 +882,7 @@ def update_saved_action_from_draft(
     updated_records = list(deepcopy(state.existing_records))
     updated_records[index] = record
     try:
+        _reject_builtin_phrase_collision_for_authoring(coerce_saved_command_action_record(record))
         updated_actions = coerce_saved_command_actions_from_records(updated_records)
     except ValueError as exc:
         raise SavedActionDraftValidationError(str(exc)) from exc

--- a/desktop/shared_action_model.py
+++ b/desktop/shared_action_model.py
@@ -66,6 +66,34 @@ DEFAULT_COMMAND_ACTIONS = (
         aliases=("open windows explorer", "open file explorer", "windows explorer"),
     ),
     CommandAction(
+        id="open_task_manager",
+        title="Open Task Manager",
+        target_kind="app",
+        target="taskmgr.exe",
+        aliases=("open task manager", "task manager", "launch task manager"),
+    ),
+    CommandAction(
+        id="open_calculator",
+        title="Open Calculator",
+        target_kind="app",
+        target="calc.exe",
+        aliases=("open calculator", "calculator", "launch calculator"),
+    ),
+    CommandAction(
+        id="open_notepad",
+        title="Open Notepad",
+        target_kind="app",
+        target="notepad.exe",
+        aliases=("open notepad", "notepad", "launch notepad"),
+    ),
+    CommandAction(
+        id="open_paint",
+        title="Open Paint",
+        target_kind="app",
+        target="mspaint.exe",
+        aliases=("open paint", "paint", "launch paint"),
+    ),
+    CommandAction(
         id="open_saved_actions_file",
         title="Open Saved Actions File",
         target_kind="file",
@@ -456,14 +484,6 @@ def _build_default_command_groups() -> tuple[CommandGroup, ...]:
 DEFAULT_COMMAND_GROUPS = _build_default_command_groups()
 
 
-LEGACY_SAVED_ACTIONS_ACCESS_ACTION_PHRASES = frozenset(
-    normalized_phrase
-    for action in DEFAULT_COMMAND_ACTIONS
-    if action.id in LEGACY_SAVED_ACTIONS_ACCESS_ACTION_IDS
-    for normalized_phrase in _normalized_action_phrases(action)
-)
-
-
 def _require_saved_action_string(record: dict, field_name: str) -> str:
     value = record.get(field_name)
     if not isinstance(value, str):
@@ -701,33 +721,20 @@ def _build_saved_group_access_guidance() -> str:
 
 def _load_saved_command_actions_from_records(records: Iterable[object]) -> tuple[CommandAction, ...]:
     built_in_ids = {action.id.casefold() for action in DEFAULT_COMMAND_ACTIONS}
-    built_in_phrases: set[str] = set()
-    for action in DEFAULT_COMMAND_ACTIONS:
-        built_in_phrases.update(_normalized_action_phrases(action))
 
     seen_saved_ids: set[str] = set()
     saved_actions: list[CommandAction] = []
     for record in records:
         action = _command_action_from_saved_record(record)
         normalized_id = action.id.casefold()
-        normalized_phrases = _normalized_action_phrases(action)
         if normalized_id in seen_saved_ids:
             raise ValueError("Saved action id collides with another saved action.")
 
-        built_in_phrase_collisions = normalized_phrases & built_in_phrases
-        if normalized_id in built_in_ids or built_in_phrase_collisions:
+        if normalized_id in built_in_ids:
             # Preserve backward compatibility for users who already added these
             # same file/folder helpers manually before they became built-ins.
-            incompatible_id_collision = (
-                normalized_id in built_in_ids
-                and normalized_id not in LEGACY_SAVED_ACTIONS_ACCESS_ACTION_IDS
-            )
-            incompatible_phrase_collision = bool(
-                built_in_phrase_collisions
-                - LEGACY_SAVED_ACTIONS_ACCESS_ACTION_PHRASES
-            )
-            if incompatible_id_collision or incompatible_phrase_collision:
-                raise ValueError("Saved action title, alias, or trigger phrase collides with an existing action.")
+            if normalized_id not in LEGACY_SAVED_ACTIONS_ACCESS_ACTION_IDS:
+                raise ValueError("Saved action id collides with an existing action.")
             continue
 
         seen_saved_ids.add(normalized_id)
@@ -1087,15 +1094,15 @@ def resolve_command_actions(text: str, actions=DEFAULT_COMMAND_ACTIONS):
 
     matches = []
     for action in actions:
-        candidates = build_saved_action_callable_phrases(
-            action.title,
-            action.aliases,
-            invocation_mode=action.invocation_mode,
-            trigger_mode=action.trigger_mode,
-            custom_triggers=action.custom_triggers,
-        )
-        if any(normalize_command_text(candidate) == normalized for candidate in candidates):
+        if normalized in _normalized_action_phrases(action):
             matches.append(action)
+    saved_matches = [
+        action
+        for action in matches
+        if (action.origin or "").strip().casefold() == "saved"
+    ]
+    if saved_matches:
+        return saved_matches
     return matches
 
 

--- a/dev/orin_branch_governance_validation.py
+++ b/dev/orin_branch_governance_validation.py
@@ -1,4 +1,5 @@
 import re
+import subprocess
 import sys
 from pathlib import Path
 
@@ -112,7 +113,113 @@ DOCS_GOVERNANCE_ADMISSION_DOCS = (
     Path("Docs/codex_user_guide.md"),
 )
 
+MULTI_SEAM_CONTRACT_DOCS = (
+    Path("Docs/phase_governance.md"),
+    Path("Docs/development_rules.md"),
+    Path("Docs/codex_modes.md"),
+    Path("Docs/Main.md"),
+    Path("Docs/orin_task_template.md"),
+    Path("Docs/codex_user_guide.md"),
+)
+
+MULTI_SEAM_CONTRACT_PHRASE = "bounded multi-seam workflow"
+
+MULTI_SEAM_PROMPT_DOCS = (
+    Path("Docs/orin_task_template.md"),
+    Path("Docs/codex_user_guide.md"),
+)
+
+MULTI_SEAM_PROMPT_PHRASES = (
+    "Seam Sequence",
+    "continue-or-stop",
+)
+
+WORKSTREAM_TO_PR_DEFAULT_GUARD_DOCS = (
+    Path("Docs/phase_governance.md"),
+    Path("Docs/codex_modes.md"),
+    Path("Docs/codex_user_guide.md"),
+)
+
+WORKSTREAM_TO_PR_DEFAULT_GUARD_PHRASES = (
+    "There is no default direct `Workstream` -> `PR Readiness` transition.",
+    "The normal next legal phase is `Hardening`, then `Live Validation`, then `PR Readiness`.",
+    "Do not prompt Codex to treat Workstream completion as direct `PR Readiness`.",
+)
+
+LIVE_VALIDATION_REUSE_DOCS = (
+    Path("Docs/phase_governance.md"),
+    Path("Docs/development_rules.md"),
+    Path("Docs/codex_modes.md"),
+    Path("Docs/Main.md"),
+    Path("Docs/orin_task_template.md"),
+    Path("Docs/codex_user_guide.md"),
+)
+
+LIVE_VALIDATION_REUSE_PHRASES = (
+    "reuse",
+    "existing",
+    "one-off",
+)
+
+LIVE_VALIDATION_STALL_DOCS = (
+    Path("Docs/phase_governance.md"),
+    Path("Docs/development_rules.md"),
+    Path("Docs/codex_modes.md"),
+    Path("Docs/Main.md"),
+    Path("Docs/orin_task_template.md"),
+    Path("Docs/codex_user_guide.md"),
+)
+
+LIVE_VALIDATION_STALL_PHRASES = (
+    "10s",
+    "no-progress",
+    "last confirmed",
+)
+
+LIVE_VALIDATION_HELPER_CONTRACTS = {
+    Path("dev/orin_launcher_live_window_audit.ps1"): (
+        "NoProgressTimeoutSeconds",
+        "Fb037Validation",
+        "Write-AuditStep",
+        "Last confirmed progress",
+        "step_log",
+        "failure_message",
+        "cleanup_notes",
+    ),
+}
+
+PR_READINESS_BLOCKER_DOCS = (
+    Path("Docs/phase_governance.md"),
+    Path("Docs/development_rules.md"),
+    Path("Docs/Main.md"),
+    Path("Docs/codex_modes.md"),
+    Path("Docs/orin_task_template.md"),
+    Path("Docs/codex_user_guide.md"),
+)
+
+PR_READINESS_BLOCKER_PHRASES = (
+    "stale-canon",
+    "post-merge",
+    "dirty",
+    "docs-sync",
+    "next-workstream",
+)
+
 BRANCH_RECORD_INDEX = Path("Docs/branch_records/index.md")
+
+NEXT_WORKSTREAM_SELECTION_MARKER = "Next Workstream: Selected"
+NEXT_WORKSTREAM_MINIMAL_SCOPE_LABEL = "Minimal Scope:"
+NEXT_WORKSTREAM_BRANCH_NOT_CREATED_PHRASES = (
+    "Branch: Not created",
+    "Branch: Deferred to Branch Readiness",
+    "No branch created",
+    "not branched",
+)
+
+VALID_NEXT_WORKSTREAM_RECORD_STATES = (
+    "Registry-only",
+    "Promoted",
+)
 
 REQUIRED_BRANCH_RECORD_HEADINGS = (
     "## Current Phase",
@@ -229,6 +336,11 @@ def _collect_closed_index_paths(text: str) -> set[str]:
     return set(re.findall(r"Docs/workstreams/[A-Za-z0-9._-]+\.md", closed_section))
 
 
+def _collect_release_debt_index_paths(text: str) -> set[str]:
+    release_debt_section = _subsection(text, "Merged / Release Debt Owners")
+    return set(re.findall(r"Docs/workstreams/[A-Za-z0-9._-]+\.md", release_debt_section))
+
+
 def _collect_branch_record_paths(text: str, heading_prefix: str) -> set[str]:
     section = _subsection(text, heading_prefix)
     return set(re.findall(r"Docs/branch_records/[A-Za-z0-9._-]+\.md", section))
@@ -243,7 +355,163 @@ def _phase_index(phase_name: str) -> int:
     return PHASES.index(phase_name)
 
 
+def _git_status_porcelain() -> str:
+    completed = subprocess.run(
+        ("git", "status", "--porcelain"),
+        cwd=ROOT_DIR,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        check=False,
+    )
+    if completed.returncode != 0:
+        return f"__GIT_STATUS_ERROR__ {completed.stderr.strip()}"
+    return completed.stdout.strip()
+
+
+def _git_branch_names() -> tuple[list[str], str]:
+    names: list[str] = []
+    errors: list[str] = []
+    for args in (
+        ("git", "branch", "--format=%(refname:short)"),
+        ("git", "branch", "-r", "--format=%(refname:short)"),
+    ):
+        completed = subprocess.run(
+            args,
+            cwd=ROOT_DIR,
+            text=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            check=False,
+        )
+        if completed.returncode != 0:
+            errors.append(completed.stderr.strip())
+            continue
+        names.extend(line.strip() for line in completed.stdout.splitlines() if line.strip())
+    return sorted(set(names)), "; ".join(error for error in errors if error)
+
+
+def _selected_next_workstream_entries(backlog_entries: list[dict[str, str]]) -> list[dict[str, str]]:
+    return [
+        entry
+        for entry in backlog_entries
+        if re.search(rf"^{re.escape(NEXT_WORKSTREAM_SELECTION_MARKER)}\s*$", entry["block"], flags=re.M)
+    ]
+
+
+def _next_workstream_roadmap_section(roadmap_text: str) -> str:
+    return _section(roadmap_text, "Selected Next Workstream")
+
+
+def _branch_names_for_workstream(branch_names: list[str], workstream_id: str) -> list[str]:
+    canonical = workstream_id.casefold()
+    compact = canonical.replace("-", "")
+    return [
+        branch_name
+        for branch_name in branch_names
+        if canonical in branch_name.casefold() or compact in branch_name.casefold().replace("-", "")
+    ]
+
+
+def _run_next_workstream_gate(require, backlog_entries: list[dict[str, str]], roadmap_text: str) -> None:
+    selected_entries = _selected_next_workstream_entries(backlog_entries)
+    require(
+        len(selected_entries) == 1,
+        (
+            "PR readiness gate: Next Workstream Undefined blocker is active; exactly one backlog "
+            f"entry must declare '{NEXT_WORKSTREAM_SELECTION_MARKER}' before PR READY: YES"
+        ),
+    )
+    if len(selected_entries) != 1:
+        return
+
+    selected = selected_entries[0]
+    selected_id = selected["id"]
+    selected_record_state = selected["record_state"]
+    selected_block = selected["block"]
+    selected_scope = _extract_colon_value(selected_block, "Minimal Scope")
+    roadmap_section = _next_workstream_roadmap_section(roadmap_text)
+
+    require(
+        selected_record_state in VALID_NEXT_WORKSTREAM_RECORD_STATES,
+        (
+            "PR readiness gate: Next Workstream Undefined blocker is active; "
+            f"{selected_id} has invalid Record State '{selected_record_state}'"
+        ),
+    )
+    require(
+        bool(selected_scope),
+        (
+            "PR readiness gate: Next Workstream Undefined blocker is active; "
+            f"{selected_id} must define '{NEXT_WORKSTREAM_MINIMAL_SCOPE_LABEL}' in Docs/feature_backlog.md"
+        ),
+    )
+    require(
+        bool(roadmap_section),
+        (
+            "PR readiness gate: Next Workstream Undefined blocker is active; "
+            "Docs/prebeta_roadmap.md must contain a 'Selected Next Workstream' section"
+        ),
+    )
+    if roadmap_section:
+        require(
+            selected_id in roadmap_section,
+            (
+                "PR readiness gate: Next Workstream Undefined blocker is active; "
+                f"Docs/prebeta_roadmap.md selected-next section does not name {selected_id}"
+            ),
+        )
+        require(
+            selected_record_state in roadmap_section,
+            (
+                "PR readiness gate: Next Workstream Undefined blocker is active; "
+                f"Docs/prebeta_roadmap.md selected-next section does not record {selected_id} Record State"
+            ),
+        )
+        require(
+            NEXT_WORKSTREAM_MINIMAL_SCOPE_LABEL.casefold() in roadmap_section.casefold(),
+            (
+                "PR readiness gate: Next Workstream Undefined blocker is active; "
+                "Docs/prebeta_roadmap.md selected-next section must define Minimal Scope"
+            ),
+        )
+        require(
+            any(phrase.casefold() in roadmap_section.casefold() for phrase in NEXT_WORKSTREAM_BRANCH_NOT_CREATED_PHRASES),
+            (
+                "PR readiness gate: Successor Lock Missing blocker is active; "
+                "Docs/prebeta_roadmap.md must record that no branch exists yet for the selected next workstream"
+            ),
+        )
+
+    branch_names, branch_error = _git_branch_names()
+    require(
+        not branch_error,
+        f"PR readiness gate: could not inspect branch names for selected next workstream: {branch_error}",
+    )
+    matching_branches = _branch_names_for_workstream(branch_names, selected_id)
+    require(
+        not matching_branches,
+        (
+            "PR readiness gate: Successor Lock Missing blocker is active; "
+            f"{selected_id} already has branch(es): {', '.join(matching_branches)}"
+        ),
+    )
+
+
+def _run_pr_readiness_gate(require, backlog_entries: list[dict[str, str]], roadmap_text: str) -> None:
+    status_output = _git_status_porcelain()
+    require(
+        not status_output,
+        (
+            "PR readiness gate: Dirty Branch blocker is active; worktree must be clean "
+            "and required branch truth must be durable in commit history before PR READY: YES"
+        ),
+    )
+    _run_next_workstream_gate(require, backlog_entries, roadmap_text)
+
+
 def main() -> int:
+    pr_readiness_gate = "--pr-readiness-gate" in sys.argv[1:]
     errors: list[str] = []
     checks = 0
 
@@ -324,10 +592,70 @@ def main() -> int:
             f"{relative_path}: docs/governance branch-admission guidance is missing",
         )
 
+    for relative_path in MULTI_SEAM_CONTRACT_DOCS:
+        text = _read_text(relative_path)
+        require(
+            MULTI_SEAM_CONTRACT_PHRASE in text,
+            f"{relative_path}: canonical bounded multi-seam workflow contract is missing",
+        )
+
+    for relative_path in MULTI_SEAM_PROMPT_DOCS:
+        text = _read_text(relative_path)
+        for required_phrase in MULTI_SEAM_PROMPT_PHRASES:
+            require(
+                required_phrase in text,
+                f"{relative_path}: multi-seam prompt scaffold is missing '{required_phrase}'",
+            )
+
+    for relative_path, guard_phrase in zip(WORKSTREAM_TO_PR_DEFAULT_GUARD_DOCS, WORKSTREAM_TO_PR_DEFAULT_GUARD_PHRASES):
+        text = _read_text(relative_path)
+        require(
+            guard_phrase in text,
+            f"{relative_path}: direct Workstream-to-PR default guard is missing",
+        )
+
+    for relative_path in LIVE_VALIDATION_REUSE_DOCS:
+        text = _read_text(relative_path)
+        lower_text = text.casefold()
+        for required_phrase in LIVE_VALIDATION_REUSE_PHRASES:
+            require(
+                required_phrase in lower_text,
+                f"{relative_path}: Live Validation reuse-first helper guidance is missing '{required_phrase}'",
+            )
+
+    for relative_path in LIVE_VALIDATION_STALL_DOCS:
+        text = _read_text(relative_path)
+        lower_text = text.casefold()
+        for required_phrase in LIVE_VALIDATION_STALL_PHRASES:
+            require(
+                required_phrase in lower_text,
+                f"{relative_path}: Live Validation no-progress/stall guidance is missing '{required_phrase}'",
+            )
+
+    for relative_path, required_phrases in LIVE_VALIDATION_HELPER_CONTRACTS.items():
+        text = _read_text(relative_path)
+        for required_phrase in required_phrases:
+            require(
+                required_phrase in text,
+                f"{relative_path}: reusable Live Validation helper is missing '{required_phrase}'",
+            )
+
+    for relative_path in PR_READINESS_BLOCKER_DOCS:
+        text = _read_text(relative_path).casefold()
+        for required_phrase in PR_READINESS_BLOCKER_PHRASES:
+            require(
+                required_phrase in text,
+                f"{relative_path}: PR Readiness blocker guidance is missing '{required_phrase}'",
+            )
+
     active_index_paths = _collect_active_index_paths(index_text)
     closed_index_paths = _collect_closed_index_paths(index_text)
+    release_debt_index_paths = _collect_release_debt_index_paths(index_text)
 
     backlog_entries = _parse_backlog_sections(backlog_text)
+    if pr_readiness_gate:
+        _run_pr_readiness_gate(require, backlog_entries, roadmap_text)
+
     promoted_entries = [
         entry
         for entry in backlog_entries
@@ -478,6 +806,21 @@ def main() -> int:
                 f"{canonical_path}: Governance Drift Audit is missing 'Governance Drift Found:'",
             )
 
+        if current_phase == "PR Readiness":
+            post_merge_state = _section(workstream_text, "Post-Merge State")
+            require(
+                bool(post_merge_state),
+                f"{canonical_path}: PR Readiness requires a Post-Merge State section",
+            )
+            require(
+                ("No Active Branch" in post_merge_state)
+                or ("successor" in post_merge_state.casefold()),
+                (
+                    f"{canonical_path}: PR Readiness Post-Merge State must encode either "
+                    "No Active Branch handling or successor-branch handling"
+                ),
+            )
+
         phase_status_section = _section(workstream_text, "Phase Status")
         if (
             _normalize_status(str(workstream_info["status"])) == "merged unreleased"
@@ -499,10 +842,27 @@ def main() -> int:
                 ),
             )
 
-        require(
-            canonical_path in active_index_paths,
-            f"Docs/workstreams/index.md: promoted workstream {canonical_path} is missing from the Active list",
-        )
+        normalized_workstream_status = _normalize_status(str(workstream_info["status"]))
+        if normalized_workstream_status == "merged unreleased":
+            require(
+                canonical_path in release_debt_index_paths,
+                (
+                    f"Docs/workstreams/index.md: promoted merged-unreleased workstream "
+                    f"{canonical_path} is missing from the Merged / Release Debt Owners list"
+                ),
+            )
+            require(
+                canonical_path not in active_index_paths,
+                (
+                    f"Docs/workstreams/index.md: promoted merged-unreleased workstream "
+                    f"{canonical_path} must not remain under Active"
+                ),
+            )
+        else:
+            require(
+                canonical_path in active_index_paths,
+                f"Docs/workstreams/index.md: promoted workstream {canonical_path} is missing from the Active list",
+            )
         require(
             canonical_path not in closed_index_paths,
             f"Docs/workstreams/index.md: promoted workstream {canonical_path} is incorrectly listed under Closed",

--- a/dev/orin_interaction_baseline_validation.py
+++ b/dev/orin_interaction_baseline_validation.py
@@ -17,6 +17,7 @@ from desktop.interaction_overlay_model import CommandOverlayModel
 from desktop.shared_action_model import (
     CommandAction,
     CommandActionCatalog,
+    DEFAULT_COMMAND_ACTIONS,
     SavedActionInventoryState,
     build_default_command_action_catalog,
 )
@@ -317,6 +318,418 @@ def _test_url_saved_action_confirm_result_flow():
         renderer_mod.launch_command_action = original_launch
 
 
+def _test_task_manager_builtin_confirm_result_flow():
+    window = _make_window()
+    launches = []
+    original_launch = renderer_mod.launch_command_action
+    renderer_mod.launch_command_action = lambda action: launches.append(
+        (action.id, action.target_kind, action.target)
+    )
+    try:
+        window.open_command_overlay()
+        _type_request(window, "task manager")
+        window.handle_overlay_submit_requested()
+
+        _assert(window._command_model.phase == "confirm", "the Task Manager built-in should reach confirm")
+        pending_action = window._command_panel.last_payload.get("pending_action") or {}
+        _assert(
+            pending_action.get("id") == "open_task_manager",
+            "Task Manager confirm should bind the new built-in action",
+        )
+        _assert(
+            pending_action.get("origin") == "built_in" and pending_action.get("origin_label") == "Built-in",
+            "Task Manager confirm should preserve built-in origin detail",
+        )
+        _assert(
+            pending_action.get("target_kind") == "app" and pending_action.get("target") == "taskmgr.exe",
+            "Task Manager confirm should preserve the existing app launch target",
+        )
+
+        window.handle_overlay_submit_requested()
+
+        _assert(
+            launches == [("open_task_manager", "app", "taskmgr.exe")],
+            "Task Manager confirm submit should use the existing launch path exactly once",
+        )
+        _assert(window._command_model.phase == "result", "Task Manager launch should enter result phase")
+        _assert(
+            window._command_model.status_kind == "launch_requested",
+            "Task Manager launch should preserve the existing launch_requested result behavior",
+        )
+    finally:
+        renderer_mod.launch_command_action = original_launch
+
+
+def _test_calculator_builtin_confirm_result_flow():
+    window = _make_window()
+    launches = []
+    original_launch = renderer_mod.launch_command_action
+    renderer_mod.launch_command_action = lambda action: launches.append(
+        (action.id, action.target_kind, action.target)
+    )
+    try:
+        window.open_command_overlay()
+        _type_request(window, "calculator")
+        window.handle_overlay_submit_requested()
+
+        _assert(window._command_model.phase == "confirm", "the Calculator built-in should reach confirm")
+        pending_action = window._command_panel.last_payload.get("pending_action") or {}
+        _assert(
+            pending_action.get("id") == "open_calculator",
+            "Calculator confirm should bind the new built-in action",
+        )
+        _assert(
+            pending_action.get("origin") == "built_in" and pending_action.get("origin_label") == "Built-in",
+            "Calculator confirm should preserve built-in origin detail",
+        )
+        _assert(
+            pending_action.get("target_kind") == "app" and pending_action.get("target") == "calc.exe",
+            "Calculator confirm should preserve the existing app launch target",
+        )
+
+        window.handle_overlay_submit_requested()
+
+        _assert(
+            launches == [("open_calculator", "app", "calc.exe")],
+            "Calculator confirm submit should use the existing launch path exactly once",
+        )
+        _assert(window._command_model.phase == "result", "Calculator launch should enter result phase")
+        _assert(
+            window._command_model.status_kind == "launch_requested",
+            "Calculator launch should preserve the existing launch_requested result behavior",
+        )
+    finally:
+        renderer_mod.launch_command_action = original_launch
+
+
+def _test_notepad_builtin_confirm_result_flow():
+    window = _make_window()
+    launches = []
+    original_launch = renderer_mod.launch_command_action
+    renderer_mod.launch_command_action = lambda action: launches.append(
+        (action.id, action.target_kind, action.target)
+    )
+    try:
+        window.open_command_overlay()
+        _type_request(window, "notepad")
+        window.handle_overlay_submit_requested()
+
+        _assert(window._command_model.phase == "confirm", "the Notepad built-in should reach confirm")
+        pending_action = window._command_panel.last_payload.get("pending_action") or {}
+        _assert(
+            pending_action.get("id") == "open_notepad",
+            "Notepad confirm should bind the new built-in action",
+        )
+        _assert(
+            pending_action.get("origin") == "built_in" and pending_action.get("origin_label") == "Built-in",
+            "Notepad confirm should preserve built-in origin detail",
+        )
+        _assert(
+            pending_action.get("target_kind") == "app" and pending_action.get("target") == "notepad.exe",
+            "Notepad confirm should preserve the existing app launch target",
+        )
+
+        window.handle_overlay_submit_requested()
+
+        _assert(
+            launches == [("open_notepad", "app", "notepad.exe")],
+            "Notepad confirm submit should use the existing launch path exactly once",
+        )
+        _assert(window._command_model.phase == "result", "Notepad launch should enter result phase")
+        _assert(
+            window._command_model.status_kind == "launch_requested",
+            "Notepad launch should preserve the existing launch_requested result behavior",
+        )
+    finally:
+        renderer_mod.launch_command_action = original_launch
+
+
+def _test_paint_builtin_confirm_result_flow():
+    window = _make_window()
+    launches = []
+    original_launch = renderer_mod.launch_command_action
+    renderer_mod.launch_command_action = lambda action: launches.append(
+        (action.id, action.target_kind, action.target)
+    )
+    try:
+        window.open_command_overlay()
+        _type_request(window, "paint")
+        window.handle_overlay_submit_requested()
+
+        _assert(window._command_model.phase == "confirm", "the Paint built-in should reach confirm")
+        pending_action = window._command_panel.last_payload.get("pending_action") or {}
+        _assert(
+            pending_action.get("id") == "open_paint",
+            "Paint confirm should bind the new built-in action",
+        )
+        _assert(
+            pending_action.get("origin") == "built_in" and pending_action.get("origin_label") == "Built-in",
+            "Paint confirm should preserve built-in origin detail",
+        )
+        _assert(
+            pending_action.get("target_kind") == "app" and pending_action.get("target") == "mspaint.exe",
+            "Paint confirm should preserve the existing app launch target",
+        )
+
+        window.handle_overlay_submit_requested()
+
+        _assert(
+            launches == [("open_paint", "app", "mspaint.exe")],
+            "Paint confirm submit should use the existing launch path exactly once",
+        )
+        _assert(window._command_model.phase == "result", "Paint launch should enter result phase")
+        _assert(
+            window._command_model.status_kind == "launch_requested",
+            "Paint launch should preserve the existing launch_requested result behavior",
+        )
+    finally:
+        renderer_mod.launch_command_action = original_launch
+
+
+def _test_saved_action_phrase_collision_wins_in_confirm_flow():
+    saved_action = CommandAction(
+        id="personal_task_manager",
+        title="Task Manager",
+        target_kind="url",
+        target="https://example.com/task-manager",
+        aliases=("open task manager", "launch task manager"),
+        origin="saved",
+    )
+    action_catalog = CommandActionCatalog(
+        (*DEFAULT_COMMAND_ACTIONS, saved_action),
+        saved_action_inventory=SavedActionInventoryState(
+            visible=True,
+            status_kind="loaded",
+            status_text="1 saved action loaded from the current source.",
+            guidance_text='Use "Open Saved Actions File" or "Open Saved Actions Folder" to inspect the source.',
+            path=r"C:\Users\Test\AppData\Local\Nexus Desktop AI\saved_actions.json",
+            actions=(saved_action,),
+        ),
+    )
+    window = _make_window(action_catalog=action_catalog)
+    launches = []
+    original_launch = renderer_mod.launch_command_action
+    renderer_mod.launch_command_action = lambda action: launches.append(
+        (action.id, action.origin, action.target_kind, action.target)
+    )
+    try:
+        window.open_command_overlay()
+        _type_request(window, "task manager")
+        window.handle_overlay_submit_requested()
+
+        _assert(
+            window._command_model.phase == "confirm",
+            "a saved action colliding with a built-in phrase should reach confirm without ambiguity",
+        )
+        pending_action = window._command_panel.last_payload.get("pending_action") or {}
+        _assert(
+            pending_action.get("id") == "personal_task_manager",
+            "saved action should resolve instead of the Task Manager built-in",
+        )
+        _assert(
+            pending_action.get("origin") == "saved" and pending_action.get("origin_label") == "Saved",
+            "saved phrase override should preserve saved origin detail in confirm",
+        )
+
+        window.handle_overlay_submit_requested()
+
+        _assert(
+            launches == [(
+                "personal_task_manager",
+                "saved",
+                "url",
+                "https://example.com/task-manager",
+            )],
+            "saved phrase override should execute the saved action through the existing confirm flow",
+        )
+        _assert(window._command_model.phase == "result", "saved phrase override should enter result phase")
+    finally:
+        renderer_mod.launch_command_action = original_launch
+
+
+def _test_calculator_saved_action_phrase_collision_wins_in_confirm_flow():
+    saved_action = CommandAction(
+        id="personal_calculator",
+        title="Calculator",
+        target_kind="url",
+        target="https://example.com/calculator",
+        aliases=("open calculator", "launch calculator"),
+        origin="saved",
+    )
+    action_catalog = CommandActionCatalog(
+        (*DEFAULT_COMMAND_ACTIONS, saved_action),
+        saved_action_inventory=SavedActionInventoryState(
+            visible=True,
+            status_kind="loaded",
+            status_text="1 saved action loaded from the current source.",
+            guidance_text='Use "Open Saved Actions File" or "Open Saved Actions Folder" to inspect the source.',
+            path=r"C:\Users\Test\AppData\Local\Nexus Desktop AI\saved_actions.json",
+            actions=(saved_action,),
+        ),
+    )
+    window = _make_window(action_catalog=action_catalog)
+    launches = []
+    original_launch = renderer_mod.launch_command_action
+    renderer_mod.launch_command_action = lambda action: launches.append(
+        (action.id, action.origin, action.target_kind, action.target)
+    )
+    try:
+        window.open_command_overlay()
+        _type_request(window, "calculator")
+        window.handle_overlay_submit_requested()
+
+        _assert(
+            window._command_model.phase == "confirm",
+            "a saved Calculator action colliding with a built-in phrase should reach confirm without ambiguity",
+        )
+        pending_action = window._command_panel.last_payload.get("pending_action") or {}
+        _assert(
+            pending_action.get("id") == "personal_calculator",
+            "saved Calculator action should resolve instead of the Calculator built-in",
+        )
+        _assert(
+            pending_action.get("origin") == "saved" and pending_action.get("origin_label") == "Saved",
+            "Calculator saved phrase override should preserve saved origin detail in confirm",
+        )
+
+        window.handle_overlay_submit_requested()
+
+        _assert(
+            launches == [(
+                "personal_calculator",
+                "saved",
+                "url",
+                "https://example.com/calculator",
+            )],
+            "Calculator saved phrase override should execute the saved action through the existing confirm flow",
+        )
+        _assert(window._command_model.phase == "result", "Calculator saved phrase override should enter result phase")
+    finally:
+        renderer_mod.launch_command_action = original_launch
+
+
+def _test_notepad_saved_action_phrase_collision_wins_in_confirm_flow():
+    saved_action = CommandAction(
+        id="personal_notepad",
+        title="Notepad",
+        target_kind="url",
+        target="https://example.com/notepad",
+        aliases=("open notepad", "launch notepad"),
+        origin="saved",
+    )
+    action_catalog = CommandActionCatalog(
+        (*DEFAULT_COMMAND_ACTIONS, saved_action),
+        saved_action_inventory=SavedActionInventoryState(
+            visible=True,
+            status_kind="loaded",
+            status_text="1 saved action loaded from the current source.",
+            guidance_text='Use "Open Saved Actions File" or "Open Saved Actions Folder" to inspect the source.',
+            path=r"C:\Users\Test\AppData\Local\Nexus Desktop AI\saved_actions.json",
+            actions=(saved_action,),
+        ),
+    )
+    window = _make_window(action_catalog=action_catalog)
+    launches = []
+    original_launch = renderer_mod.launch_command_action
+    renderer_mod.launch_command_action = lambda action: launches.append(
+        (action.id, action.origin, action.target_kind, action.target)
+    )
+    try:
+        window.open_command_overlay()
+        _type_request(window, "notepad")
+        window.handle_overlay_submit_requested()
+
+        _assert(
+            window._command_model.phase == "confirm",
+            "a saved Notepad action colliding with a built-in phrase should reach confirm without ambiguity",
+        )
+        pending_action = window._command_panel.last_payload.get("pending_action") or {}
+        _assert(
+            pending_action.get("id") == "personal_notepad",
+            "saved Notepad action should resolve instead of the Notepad built-in",
+        )
+        _assert(
+            pending_action.get("origin") == "saved" and pending_action.get("origin_label") == "Saved",
+            "Notepad saved phrase override should preserve saved origin detail in confirm",
+        )
+
+        window.handle_overlay_submit_requested()
+
+        _assert(
+            launches == [(
+                "personal_notepad",
+                "saved",
+                "url",
+                "https://example.com/notepad",
+            )],
+            "Notepad saved phrase override should execute the saved action through the existing confirm flow",
+        )
+        _assert(window._command_model.phase == "result", "Notepad saved phrase override should enter result phase")
+    finally:
+        renderer_mod.launch_command_action = original_launch
+
+
+def _test_paint_saved_action_phrase_collision_wins_in_confirm_flow():
+    saved_action = CommandAction(
+        id="personal_paint",
+        title="Paint",
+        target_kind="url",
+        target="https://example.com/paint",
+        aliases=("open paint", "launch paint"),
+        origin="saved",
+    )
+    action_catalog = CommandActionCatalog(
+        (*DEFAULT_COMMAND_ACTIONS, saved_action),
+        saved_action_inventory=SavedActionInventoryState(
+            visible=True,
+            status_kind="loaded",
+            status_text="1 saved action loaded from the current source.",
+            guidance_text='Use "Open Saved Actions File" or "Open Saved Actions Folder" to inspect the source.',
+            path=r"C:\Users\Test\AppData\Local\Nexus Desktop AI\saved_actions.json",
+            actions=(saved_action,),
+        ),
+    )
+    window = _make_window(action_catalog=action_catalog)
+    launches = []
+    original_launch = renderer_mod.launch_command_action
+    renderer_mod.launch_command_action = lambda action: launches.append(
+        (action.id, action.origin, action.target_kind, action.target)
+    )
+    try:
+        window.open_command_overlay()
+        _type_request(window, "paint")
+        window.handle_overlay_submit_requested()
+
+        _assert(
+            window._command_model.phase == "confirm",
+            "a saved Paint action colliding with a built-in phrase should reach confirm without ambiguity",
+        )
+        pending_action = window._command_panel.last_payload.get("pending_action") or {}
+        _assert(
+            pending_action.get("id") == "personal_paint",
+            "saved Paint action should resolve instead of the Paint built-in",
+        )
+        _assert(
+            pending_action.get("origin") == "saved" and pending_action.get("origin_label") == "Saved",
+            "Paint saved phrase override should preserve saved origin detail in confirm",
+        )
+
+        window.handle_overlay_submit_requested()
+
+        _assert(
+            launches == [(
+                "personal_paint",
+                "saved",
+                "url",
+                "https://example.com/paint",
+            )],
+            "Paint saved phrase override should execute the saved action through the existing confirm flow",
+        )
+        _assert(window._command_model.phase == "result", "Paint saved phrase override should enter result phase")
+    finally:
+        renderer_mod.launch_command_action = original_launch
+
+
 def _test_trigger_generated_saved_action_phrases_stay_exact_and_bounded():
     action_catalog = CommandActionCatalog(
         (
@@ -455,6 +868,14 @@ def main():
         ("choose-confirm-result baseline flow", _test_typed_first_choose_confirm_result_flow),
         ("result close and reopen is clean", _test_result_close_and_reopen_is_clean),
         ("url saved action confirm-result flow", _test_url_saved_action_confirm_result_flow),
+        ("task manager built-in confirm-result flow", _test_task_manager_builtin_confirm_result_flow),
+        ("calculator built-in confirm-result flow", _test_calculator_builtin_confirm_result_flow),
+        ("notepad built-in confirm-result flow", _test_notepad_builtin_confirm_result_flow),
+        ("paint built-in confirm-result flow", _test_paint_builtin_confirm_result_flow),
+        ("saved action phrase collision wins in confirm flow", _test_saved_action_phrase_collision_wins_in_confirm_flow),
+        ("calculator saved action phrase collision wins in confirm flow", _test_calculator_saved_action_phrase_collision_wins_in_confirm_flow),
+        ("notepad saved action phrase collision wins in confirm flow", _test_notepad_saved_action_phrase_collision_wins_in_confirm_flow),
+        ("paint saved action phrase collision wins in confirm flow", _test_paint_saved_action_phrase_collision_wins_in_confirm_flow),
         ("trigger-generated saved action phrases stay exact and bounded", _test_trigger_generated_saved_action_phrases_stay_exact_and_bounded),
         ("entry payload surfaces saved-action inventory guidance", _test_entry_payload_surfaces_saved_action_inventory_guidance),
         ("catalog reload seam surfaces new saved actions", _test_catalog_reload_seam_surfaces_new_saved_actions_without_phase_change),

--- a/dev/orin_launcher_live_window_audit.ps1
+++ b/dev/orin_launcher_live_window_audit.ps1
@@ -1,5 +1,7 @@
 param(
-    [int]$TimeoutSeconds = 8
+    [int]$TimeoutSeconds = 8,
+    [int]$NoProgressTimeoutSeconds = 10,
+    [switch]$Fb037Validation
 )
 
 Set-StrictMode -Version Latest
@@ -12,10 +14,29 @@ Add-Type -AssemblyName System.Drawing
 
 $source = @"
 using System;
+using System.Collections.Generic;
 using System.Runtime.InteropServices;
+using System.Text;
 
 public static class CodexLiveAuditWin32
 {
+    public struct Point
+    {
+        public int X;
+        public int Y;
+    }
+
+    public sealed class WindowInfo
+    {
+        public IntPtr Handle { get; set; }
+        public int ProcessId { get; set; }
+        public string Title { get; set; }
+        public string ClassName { get; set; }
+        public bool IsVisible { get; set; }
+    }
+
+    private delegate bool EnumWindowsProc(IntPtr hWnd, IntPtr lParam);
+
     [DllImport("user32.dll")]
     public static extern void keybd_event(byte bVk, byte bScan, uint dwFlags, UIntPtr dwExtraInfo);
 
@@ -30,6 +51,82 @@ public static class CodexLiveAuditWin32
 
     [DllImport("user32.dll")]
     public static extern void mouse_event(uint dwFlags, uint dx, uint dy, uint dwData, UIntPtr dwExtraInfo);
+
+    [DllImport("user32.dll", SetLastError=true)]
+    public static extern bool ScreenToClient(IntPtr hWnd, ref Point lpPoint);
+
+    [DllImport("user32.dll", SetLastError=true)]
+    public static extern IntPtr SendMessage(IntPtr hWnd, uint Msg, IntPtr wParam, IntPtr lParam);
+
+    [DllImport("user32.dll")]
+    private static extern bool EnumWindows(EnumWindowsProc lpEnumFunc, IntPtr lParam);
+
+    [DllImport("user32.dll")]
+    private static extern bool IsWindowVisible(IntPtr hWnd);
+
+    [DllImport("user32.dll")]
+    private static extern uint GetWindowThreadProcessId(IntPtr hWnd, out uint processId);
+
+    [DllImport("user32.dll", CharSet=CharSet.Unicode)]
+    private static extern int GetWindowText(IntPtr hWnd, StringBuilder lpString, int nMaxCount);
+
+    [DllImport("user32.dll", CharSet=CharSet.Unicode)]
+    private static extern int GetClassName(IntPtr hWnd, StringBuilder lpClassName, int nMaxCount);
+
+    public static WindowInfo[] GetTopLevelWindows()
+    {
+        var windows = new List<WindowInfo>();
+        EnumWindows(delegate(IntPtr hWnd, IntPtr lParam)
+        {
+            uint processId;
+            GetWindowThreadProcessId(hWnd, out processId);
+            var title = new StringBuilder(512);
+            var className = new StringBuilder(256);
+            GetWindowText(hWnd, title, title.Capacity);
+            GetClassName(hWnd, className, className.Capacity);
+            windows.Add(new WindowInfo
+            {
+                Handle = hWnd,
+                ProcessId = (int)processId,
+                Title = title.ToString(),
+                ClassName = className.ToString(),
+                IsVisible = IsWindowVisible(hWnd)
+            });
+            return true;
+        }, IntPtr.Zero);
+        return windows.ToArray();
+    }
+
+    public static void SendWindowClick(IntPtr hWnd, int screenX, int screenY, bool rightButton)
+    {
+        const uint WM_LBUTTONDOWN = 0x0201;
+        const uint WM_LBUTTONUP = 0x0202;
+        const uint WM_RBUTTONDOWN = 0x0204;
+        const uint WM_RBUTTONUP = 0x0205;
+        const int MK_LBUTTON = 0x0001;
+        const int MK_RBUTTON = 0x0002;
+
+        var point = new Point { X = screenX, Y = screenY };
+        ScreenToClient(hWnd, ref point);
+        int lParam = ((point.Y & 0xffff) << 16) | (point.X & 0xffff);
+        if (rightButton)
+        {
+            SendMessage(hWnd, WM_RBUTTONDOWN, (IntPtr)MK_RBUTTON, (IntPtr)lParam);
+            SendMessage(hWnd, WM_RBUTTONUP, IntPtr.Zero, (IntPtr)lParam);
+            return;
+        }
+
+        SendMessage(hWnd, WM_LBUTTONDOWN, (IntPtr)MK_LBUTTON, (IntPtr)lParam);
+        SendMessage(hWnd, WM_LBUTTONUP, IntPtr.Zero, (IntPtr)lParam);
+    }
+
+    public static void SendWindowKey(IntPtr hWnd, int virtualKey)
+    {
+        const uint WM_KEYDOWN = 0x0100;
+        const uint WM_KEYUP = 0x0101;
+        SendMessage(hWnd, WM_KEYDOWN, (IntPtr)virtualKey, (IntPtr)0x00000001);
+        SendMessage(hWnd, WM_KEYUP, (IntPtr)virtualKey, (IntPtr)unchecked((int)0xC0000001));
+    }
 }
 "@
 
@@ -39,6 +136,7 @@ $RootDir = Split-Path -Parent $PSScriptRoot
 $Stamp = Get-Date -Format "yyyyMMdd_HHmmss"
 $OutputDir = Join-Path $RootDir "dev\logs\launcher_live_window_audit\$Stamp"
 $ManifestPath = Join-Path $OutputDir "manifest.json"
+$StepLogPath = Join-Path $OutputDir "step_log.txt"
 $SourcePath = Join-Path $env:LOCALAPPDATA "Nexus Desktop AI\saved_actions.json"
 $SourceBackupPath = Join-Path $OutputDir "saved_actions.backup.json"
 $LauncherPath = Join-Path $RootDir "desktop\orin_desktop_launcher.pyw"
@@ -47,13 +145,52 @@ $AuditRuntimeLogPath = Join-Path $OutputDir "audit_runtime.log"
 New-Item -ItemType Directory -Force -Path $OutputDir | Out-Null
 
 $script:Captures = New-Object System.Collections.Generic.List[object]
+$script:ScenarioResults = New-Object System.Collections.Generic.List[object]
+$script:CleanupNotes = New-Object System.Collections.Generic.List[object]
 $script:AuditStartedAt = Get-Date
+$script:LastProgressAt = $script:AuditStartedAt
+$script:LastProgressPoint = "audit_start"
+$script:ManifestStatus = "ABORTED"
+$script:ManifestFailureMessage = "Run ended before a final manifest status was recorded."
 $script:AuditRuntimeProcess = $null
+$script:Fb037ManagedProcessNames = @("notepad", "mspaint", "calc", "CalculatorApp", "taskmgr")
 $script:BaselinePythonPids = @(
     Get-CimInstance Win32_Process |
         Where-Object { $_.Name -in @("python.exe", "pythonw.exe") } |
         Select-Object -ExpandProperty ProcessId
 )
+$script:BaselineAppPids = @(
+    foreach ($name in $script:Fb037ManagedProcessNames) {
+        Get-Process -Name $name -ErrorAction SilentlyContinue |
+            Select-Object -ExpandProperty Id
+    }
+)
+
+function Write-AuditStep {
+    param(
+        [string]$Stage,
+        [string]$Message,
+        [switch]$DoesNotCountAsProgress
+    )
+
+    $timestamp = (Get-Date).ToString("o")
+    $line = "$timestamp [$Stage] $Message"
+    Add-Content -LiteralPath $StepLogPath -Value $line -Encoding utf8
+    Write-Host $line
+
+    if (-not $DoesNotCountAsProgress) {
+        $script:LastProgressAt = Get-Date
+        $script:LastProgressPoint = "$Stage :: $Message"
+    }
+}
+
+function Assert-NoProgressBudget {
+    param([string]$Activity)
+
+    if ($NoProgressTimeoutSeconds -gt 0 -and (Get-Date) -ge $script:LastProgressAt.AddSeconds($NoProgressTimeoutSeconds)) {
+        throw "No-progress watchdog exceeded during $Activity. Last confirmed progress: $($script:LastProgressPoint)."
+    }
+}
 
 function Add-Capture {
     param(
@@ -74,16 +211,23 @@ function Wait-Until {
         [int]$TimeoutSeconds = $TimeoutSeconds
     )
 
+    Write-AuditStep -Stage "WAIT" -Message "waiting for $Description"
     $deadline = (Get-Date).AddSeconds($TimeoutSeconds)
     while ((Get-Date) -lt $deadline) {
         $result = & $Condition
         if ($result) {
+            Write-AuditStep -Stage "WAIT" -Message "satisfied $Description"
             return $result
         }
+
+        if ($NoProgressTimeoutSeconds -gt 0 -and (Get-Date) -ge $script:LastProgressAt.AddSeconds($NoProgressTimeoutSeconds)) {
+            throw "No-progress watchdog exceeded while waiting for $Description. Last confirmed progress: $($script:LastProgressPoint)."
+        }
+
         Start-Sleep -Milliseconds 120
     }
 
-    throw "Timed out waiting for $Description."
+    throw "Timed out waiting for $Description. Last confirmed progress: $($script:LastProgressPoint)."
 }
 
 function Find-ElementByAutomationIdDirect {
@@ -138,6 +282,120 @@ function Get-ElementControlTypeNameSafe {
     } catch {
         return ""
     }
+}
+
+function Get-ElementStateSummary {
+    param(
+        [System.Windows.Automation.AutomationElement]$Element
+    )
+
+    if (-not $Element) {
+        return "missing"
+    }
+
+    try {
+        $rect = $Element.Current.BoundingRectangle
+        return (
+            "name='{0}' automationId='{1}' controlType='{2}' enabled={3} offscreen={4} focus={5} rect={6},{7},{8},{9}" -f
+            $Element.Current.Name,
+            $Element.Current.AutomationId,
+            (Get-ElementControlTypeNameSafe -Element $Element),
+            $Element.Current.IsEnabled,
+            $Element.Current.IsOffscreen,
+            $Element.Current.HasKeyboardFocus,
+            [int]$rect.Left,
+            [int]$rect.Top,
+            [int]$rect.Width,
+            [int]$rect.Height
+        )
+    } catch {
+        return "unreadable"
+    }
+}
+
+function Get-ElementReadableValue {
+    param(
+        [System.Windows.Automation.AutomationElement]$Element
+    )
+
+    if (-not $Element) {
+        return ""
+    }
+
+    try {
+        $pattern = $Element.GetCurrentPattern([System.Windows.Automation.ValuePattern]::Pattern)
+        $value = $pattern.Current.Value
+        if ($null -ne $value) {
+            return [string]$value
+        }
+    } catch {
+    }
+
+    try {
+        $pattern = $Element.GetCurrentPattern([System.Windows.Automation.TextPattern]::Pattern)
+        $value = $pattern.DocumentRange.GetText(-1)
+        if ($null -ne $value) {
+            return ([string]$value).TrimEnd("`0")
+        }
+    } catch {
+    }
+
+    try {
+        return [string]$Element.Current.Name
+    } catch {
+    }
+
+    return ""
+}
+
+function Get-WindowHandle {
+    param(
+        [System.Windows.Automation.AutomationElement]$Element
+    )
+
+    if (-not $Element) {
+        return [IntPtr]::Zero
+    }
+
+    try {
+        $handle = [int]$Element.Current.NativeWindowHandle
+        if ($handle -gt 0) {
+            return [IntPtr]$handle
+        }
+    } catch {
+    }
+
+    return [IntPtr]::Zero
+}
+
+function Get-ElementOwningWindow {
+    param(
+        [System.Windows.Automation.AutomationElement]$Element
+    )
+
+    if (-not $Element) {
+        return $null
+    }
+
+    $walker = [System.Windows.Automation.TreeWalker]::ControlViewWalker
+    $current = $Element
+    while ($current) {
+        try {
+            $handle = Get-WindowHandle -Element $current
+            if ($handle -ne [IntPtr]::Zero) {
+                return $current
+            }
+        } catch {
+        }
+
+        try {
+            $current = $walker.GetParent($current)
+        } catch {
+            return $null
+        }
+    }
+
+    return $null
 }
 
 function Resolve-LiveDialogRoot {
@@ -287,6 +545,123 @@ function Focus-Element {
     }
 }
 
+function Focus-ElementWindow {
+    param(
+        [System.Windows.Automation.AutomationElement]$Element
+    )
+
+    if (-not $Element) {
+        return
+    }
+
+    $targetWindow = Get-ElementOwningWindow -Element $Element
+    if (-not $targetWindow) {
+        $targetWindow = $Element
+    }
+
+    try {
+        $handle = Get-WindowHandle -Element $targetWindow
+        if ($handle -ne [IntPtr]::Zero) {
+            [CodexLiveAuditWin32]::ShowWindowAsync($handle, 5) | Out-Null
+            [CodexLiveAuditWin32]::SetForegroundWindow($handle) | Out-Null
+        }
+    } catch {
+    }
+
+    try {
+        $targetWindow.SetFocus()
+    } catch {
+    }
+
+    Start-Sleep -Milliseconds 120
+}
+
+function Click-ElementCenter {
+    param(
+        [System.Windows.Automation.AutomationElement]$Element,
+        [string]$Description
+    )
+
+    if (-not $Element) {
+        throw "Missing element for $Description."
+    }
+
+    try {
+        $point = $Element.GetClickablePoint()
+        [CodexLiveAuditWin32]::SetCursorPos([int]$point.X, [int]$point.Y) | Out-Null
+        Start-Sleep -Milliseconds 50
+        [CodexLiveAuditWin32]::mouse_event(0x0002, 0, 0, 0, [UIntPtr]::Zero)
+        Start-Sleep -Milliseconds 50
+        [CodexLiveAuditWin32]::mouse_event(0x0004, 0, 0, 0, [UIntPtr]::Zero)
+        Start-Sleep -Milliseconds 120
+        return
+    } catch {
+    }
+
+    try {
+        $rect = $Element.Current.BoundingRectangle
+        $x = [int]([Math]::Round($rect.Left + ($rect.Width / 2)))
+        $y = [int]([Math]::Round($rect.Top + ($rect.Height / 2)))
+        if ($x -le 0 -or $y -le 0) {
+            throw "Element click target was offscreen or invalid."
+        }
+        [CodexLiveAuditWin32]::SetCursorPos($x, $y) | Out-Null
+        Start-Sleep -Milliseconds 50
+        [CodexLiveAuditWin32]::mouse_event(0x0002, 0, 0, 0, [UIntPtr]::Zero)
+        Start-Sleep -Milliseconds 50
+        [CodexLiveAuditWin32]::mouse_event(0x0004, 0, 0, 0, [UIntPtr]::Zero)
+        Start-Sleep -Milliseconds 120
+        return
+    } catch {
+    }
+
+    throw "Could not click $Description."
+}
+
+function Click-ElementCenterByBounds {
+    param(
+        [System.Windows.Automation.AutomationElement]$Element,
+        [string]$Description,
+        [ValidateSet("left", "right")]
+        [string]$Button = "left"
+    )
+
+    if (-not $Element) {
+        throw "Missing element for $Description."
+    }
+
+    try {
+        $rect = $Element.Current.BoundingRectangle
+        $x = [int]([Math]::Round($rect.Left + ($rect.Width / 2)))
+        $y = [int]([Math]::Round($rect.Top + ($rect.Height / 2)))
+        if ($x -le 0 -or $y -le 0) {
+            throw "Element click target was offscreen or invalid."
+        }
+
+        $owningWindow = Get-ElementOwningWindow -Element $Element
+        $windowHandle = Get-WindowHandle -Element $owningWindow
+        if ($windowHandle -ne [IntPtr]::Zero) {
+            [CodexLiveAuditWin32]::SetForegroundWindow($windowHandle) | Out-Null
+            Start-Sleep -Milliseconds 80
+            [CodexLiveAuditWin32]::SendWindowClick($windowHandle, $x, $y, ($Button -eq "right"))
+            Start-Sleep -Milliseconds 160
+            return
+        }
+
+        $down = if ($Button -eq "right") { 0x0008 } else { 0x0002 }
+        $up = if ($Button -eq "right") { 0x0010 } else { 0x0004 }
+        [CodexLiveAuditWin32]::SetCursorPos($x, $y) | Out-Null
+        Start-Sleep -Milliseconds 60
+        [CodexLiveAuditWin32]::mouse_event($down, 0, 0, 0, [UIntPtr]::Zero)
+        Start-Sleep -Milliseconds 60
+        [CodexLiveAuditWin32]::mouse_event($up, 0, 0, 0, [UIntPtr]::Zero)
+        Start-Sleep -Milliseconds 160
+        return
+    } catch {
+        throw "Could not $Button-click $Description by bounds: $($_.Exception.Message)"
+    }
+}
+
 function Invoke-Element {
     param(
         [System.Windows.Automation.AutomationElement]$Element,
@@ -361,6 +736,118 @@ function Send-VirtualKey {
     [CodexLiveAuditWin32]::keybd_event($Key, 0, 2, [UIntPtr]::Zero)
 }
 
+function Send-EnterToElementWindow {
+    param(
+        [System.Windows.Automation.AutomationElement]$Element,
+        [string]$Description
+    )
+
+    $owningWindow = Get-ElementOwningWindow -Element $Element
+    $windowHandle = Get-WindowHandle -Element $owningWindow
+    if ($windowHandle -ne [IntPtr]::Zero) {
+        [CodexLiveAuditWin32]::SetForegroundWindow($windowHandle) | Out-Null
+        Start-Sleep -Milliseconds 80
+        [CodexLiveAuditWin32]::SendWindowKey($windowHandle, 0x0D)
+        Start-Sleep -Milliseconds 80
+        Write-AuditStep -Stage "FB037" -Message "enter sent to owning window for '$Description'"
+        return
+    }
+
+    Send-VirtualKey -Key 0x0D
+    Write-AuditStep -Stage "FB037" -Message "enter sent by virtual key fallback for '$Description'"
+}
+
+function Focus-OverlayInputForSubmit {
+    param(
+        [System.Windows.Automation.AutomationElement]$Overlay,
+        [System.Windows.Automation.AutomationElement]$InputElement,
+        [string]$Description
+    )
+
+    $liveOverlay = Get-OverlayWindow
+    if ($liveOverlay) {
+        $Overlay = $liveOverlay
+        Focus-ElementWindow -Element $Overlay
+    }
+
+    if ($Overlay) {
+        $liveInput = Get-OverlayInput -Overlay $Overlay
+        if ($liveInput) {
+            $InputElement = $liveInput
+        }
+    }
+
+    if (-not $InputElement) {
+        throw "Missing overlay input for $Description."
+    }
+
+    Focus-ElementWindow -Element $InputElement
+    Click-ElementCenterByBounds -Element $InputElement -Description $Description -Button "right"
+    Click-ElementCenterByBounds -Element $InputElement -Description $Description -Button "left"
+    try {
+        $InputElement.SetFocus()
+    } catch {
+    }
+    Start-Sleep -Milliseconds 160
+    Write-AuditStep -Stage "FB037" -Message "input focused for '$Description' state=$(Get-ElementStateSummary -Element $InputElement)"
+    return $InputElement
+}
+
+function Submit-OverlayInput {
+    param(
+        [System.Windows.Automation.AutomationElement]$InputElement,
+        [string]$Description
+    )
+
+    Focus-ElementWindow -Element $InputElement
+    Click-ElementCenterByBounds -Element $InputElement -Description $Description -Button "right"
+    Click-ElementCenterByBounds -Element $InputElement -Description $Description -Button "left"
+    try {
+        $InputElement.SetFocus()
+    } catch {
+    }
+    Start-Sleep -Milliseconds 80
+    Send-EnterToElementWindow -Element $InputElement -Description $Description
+}
+
+function Engage-OverlayInputForSubmit {
+    param(
+        [System.Windows.Automation.AutomationElement]$InputElement,
+        [string]$ExpectedValue,
+        [string]$Description
+    )
+
+    Focus-ElementWindow -Element $InputElement
+    Click-ElementCenterByBounds -Element $InputElement -Description $Description -Button "right"
+    Click-ElementCenterByBounds -Element $InputElement -Description $Description -Button "left"
+    try {
+        $InputElement.SetFocus()
+    } catch {
+    }
+
+    try {
+        [System.Windows.Forms.SendKeys]::SendWait("{END}")
+        Start-Sleep -Milliseconds 30
+        [System.Windows.Forms.SendKeys]::SendWait(" ")
+        Start-Sleep -Milliseconds 30
+        [System.Windows.Forms.SendKeys]::SendWait("{BACKSPACE}")
+    } catch {
+        Send-VirtualKey -Key 0x23
+        Start-Sleep -Milliseconds 30
+        Send-VirtualKey -Key 0x20
+        Start-Sleep -Milliseconds 30
+        Send-VirtualKey -Key 0x08
+    }
+
+    Start-Sleep -Milliseconds 120
+    $currentValue = Get-ElementReadableValue -Element $InputElement
+    if ($currentValue -ne $ExpectedValue) {
+        Set-ElementValue -Element $InputElement -Value $ExpectedValue -Description "$Description value restore"
+        Start-Sleep -Milliseconds 80
+    }
+    Write-AuditStep -Stage "FB037" -Message "input engagement nudged for '$Description' state=$(Get-ElementStateSummary -Element $InputElement) value='$(Get-ElementReadableValue -Element $InputElement)'"
+}
+
 function Send-OverlayHotkey {
     try {
         [System.Windows.Forms.SendKeys]::SendWait("^%{HOME}")
@@ -412,9 +899,12 @@ function Wait-ForRuntimeMarker {
 
 function Stop-AuditRuntimeHelper {
     if ($script:AuditRuntimeProcess) {
+        Write-AuditStep -Stage "CLEANUP" -Message "stopping audit runtime helper pid=$($script:AuditRuntimeProcess.Id)"
         try {
             Stop-Process -Id $script:AuditRuntimeProcess.Id -Force -ErrorAction Stop
+            Write-AuditStep -Stage "CLEANUP" -Message "audit runtime helper stopped"
         } catch {
+            Add-CleanupNote -Action "stop_runtime_helper" -Result "helper_failure" -Details "could not stop audit runtime helper pid=$($script:AuditRuntimeProcess.Id): $($_.Exception.Message)"
         }
         $script:AuditRuntimeProcess = $null
         Start-Sleep -Milliseconds 350
@@ -487,6 +977,17 @@ function Open-Overlay {
     }
 
     Wait-ForRuntimeMarker -Marker "RENDERER_MAIN|COMMAND_OVERLAY_READY" -StartLine $startLine -TimeoutSeconds 8 | Out-Null
+    $existingOverlay = Get-OverlayWindow
+    if ($existingOverlay) {
+        try {
+            Close-WindowByEsc -Window $existingOverlay
+            Start-Sleep -Milliseconds 300
+        } catch {
+        }
+    }
+
+    Send-OverlayHotkey
+    Start-Sleep -Milliseconds 300
     return (Wait-Until -TimeoutSeconds ([Math]::Max(4, $TimeoutSeconds)) -Description "overlay window" -Condition {
             $overlay = Get-OverlayWindow
             if (-not $overlay) {
@@ -839,7 +1340,920 @@ function Seed-AuditSource {
     [System.IO.File]::WriteAllText($SourcePath, $json, $encoding)
 }
 
+function Write-SourcePayload {
+    param([object]$Payload)
+
+    $json = ($Payload | ConvertTo-Json -Depth 8) + "`n"
+    $encoding = New-Object System.Text.UTF8Encoding($false)
+    [System.IO.File]::WriteAllText($SourcePath, $json, $encoding)
+}
+
+function Seed-Fb037EmptySource {
+    Write-SourcePayload -Payload ([ordered]@{
+            schema_version = 1
+            actions        = @()
+            groups         = @()
+        })
+}
+
+function New-Fb037OverrideAction {
+    param(
+        [string]$Id,
+        [string]$Title,
+        [string]$Alias
+    )
+
+    return [ordered]@{
+        id              = $Id
+        title           = $Title
+        target_kind     = "folder"
+        target          = (Join-Path $RootDir "Docs")
+        aliases         = @($Alias)
+        invocation_mode = "aliases_only"
+        trigger_mode    = "open"
+    }
+}
+
+function Seed-Fb037OverrideSource {
+    param([string[]]$Aliases)
+
+    $actions = @()
+    foreach ($alias in $Aliases) {
+        $slug = ($alias -replace "[^A-Za-z0-9]+", "_").Trim("_").ToLowerInvariant()
+        $title = "Saved Override " + ((Get-Culture).TextInfo.ToTitleCase($alias))
+        $actions += New-Fb037OverrideAction -Id "saved_override_$slug" -Title $title -Alias $alias
+    }
+
+    Write-SourcePayload -Payload ([ordered]@{
+            schema_version = 1
+            actions        = $actions
+            groups         = @()
+        })
+}
+
+function Add-ScenarioResult {
+    param(
+        [string]$Name,
+        [string]$Result,
+        [string]$Details,
+        [object]$Artifacts = $null
+    )
+
+    $script:ScenarioResults.Add([pscustomobject]@{
+            name      = $Name
+            result    = $Result
+            details   = $Details
+            artifacts = $Artifacts
+        })
+    Write-AuditStep -Stage "SCENARIO" -Message "$Name :: $Result :: $Details"
+}
+
+function Add-CleanupNote {
+    param(
+        [string]$Action,
+        [string]$Result,
+        [string]$Details
+    )
+
+    $script:CleanupNotes.Add([pscustomobject]@{
+            action  = $Action
+            result  = $Result
+            details = $Details
+    })
+    Write-AuditStep -Stage "CLEANUP" -Message "$Action :: $Result :: $Details"
+}
+
+function Get-CleanupSummary {
+    $resultValues = @($script:CleanupNotes | ForEach-Object { $_.result })
+    return [pscustomobject]@{
+        success_count          = @($resultValues | Where-Object { $_ -eq "success" }).Count
+        os_blocked_count       = @($resultValues | Where-Object { $_ -eq "os_blocked" }).Count
+        helper_failure_count   = @($resultValues | Where-Object { $_ -eq "helper_failure" }).Count
+        baseline_skipped_count = @($resultValues | Where-Object { $_ -eq "baseline_skipped" }).Count
+    }
+}
+
+function Get-Fb037ManagedProcesses {
+    $processes = @()
+    foreach ($name in $script:Fb037ManagedProcessNames) {
+        $processes += @(Get-Process -Name $name -ErrorAction SilentlyContinue)
+    }
+    return @($processes)
+}
+
+function Test-BaselineAppProcess {
+    param([int]$ProcessId)
+    return ($script:BaselineAppPids -contains $ProcessId)
+}
+
+function Get-RuntimeLinesSince {
+    param([int]$StartLine)
+
+    if (-not (Test-Path -LiteralPath $AuditRuntimeLogPath)) {
+        return @()
+    }
+
+    $lines = @(Get-Content -LiteralPath $AuditRuntimeLogPath)
+    if ($lines.Count -le $StartLine) {
+        return ,@()
+    }
+
+    return ,@($lines | Select-Object -Skip $StartLine)
+}
+
+function Get-RuntimeTailText {
+    param(
+        [int]$StartLine,
+        [int]$Count = 8
+    )
+
+    $lines = Get-RuntimeLinesSince -StartLine $StartLine
+    if ($lines.Count -eq 0) {
+        return "<no fresh runtime lines>"
+    }
+
+    return (@($lines | Select-Object -Last $Count) -join " || ")
+}
+
+function Wait-ForCommandSubmitOutcome {
+    param(
+        [string]$ExpectedActionId,
+        [int]$StartLine,
+        [int]$TimeoutSeconds = 3
+    )
+
+    return (Wait-Until -TimeoutSeconds $TimeoutSeconds -Description "submit outcome for action_id=$ExpectedActionId" -Condition {
+            $lines = Get-RuntimeLinesSince -StartLine $StartLine
+            foreach ($line in $lines) {
+                if ($line -like "*RENDERER_MAIN|COMMAND_CONFIRM_READY|action_id=$ExpectedActionId*") {
+                    return [pscustomobject]@{
+                        Kind = "confirm"
+                        Line = $line
+                    }
+                }
+                if ($line -like "*RENDERER_MAIN|COMMAND_CONFIRM_READY|action_id=*" -and $line -notlike "*action_id=$ExpectedActionId*") {
+                    return [pscustomobject]@{
+                        Kind = "wrong_confirm"
+                        Line = $line
+                    }
+                }
+                if ($line -like "*RENDERER_MAIN|COMMAND_NOT_FOUND*") {
+                    return [pscustomobject]@{
+                        Kind = "not_found"
+                        Line = $line
+                    }
+                }
+                if ($line -like "*RENDERER_MAIN|COMMAND_AMBIGUOUS*") {
+                    return [pscustomobject]@{
+                        Kind = "ambiguous"
+                        Line = $line
+                    }
+                }
+                if ($line -like "*OVERLAY_TRACE|source=renderer|event=submit_result*" -and $line -like "*result='not_found'*") {
+                    return [pscustomobject]@{
+                        Kind = "not_found"
+                        Line = $line
+                    }
+                }
+                if ($line -like "*OVERLAY_TRACE|source=renderer|event=submit_result*" -and $line -like "*result='ambiguous'*") {
+                    return [pscustomobject]@{
+                        Kind = "ambiguous"
+                        Line = $line
+                    }
+                }
+            }
+
+            return $null
+        })
+}
+
+function Assert-RuntimeMarkerAbsent {
+    param(
+        [string]$Marker,
+        [int]$StartLine
+    )
+
+    $lines = Get-RuntimeLinesSince -StartLine $StartLine
+    foreach ($line in $lines) {
+        if ($line -like "*$Marker*") {
+            throw "Unexpected runtime marker found after line ${StartLine}: $Marker"
+        }
+    }
+}
+
+function Find-RootWindowByNamePattern {
+    param([string[]]$NamePatterns)
+
+    $children = [System.Windows.Automation.AutomationElement]::RootElement.FindAll(
+        [System.Windows.Automation.TreeScope]::Children,
+        [System.Windows.Automation.Condition]::TrueCondition
+    )
+
+    for ($i = 0; $i -lt $children.Count; $i++) {
+        $window = $children.Item($i)
+        try {
+            if ($window.Current.IsOffscreen) {
+                continue
+            }
+
+            foreach ($pattern in $NamePatterns) {
+                if ($window.Current.Name -like $pattern) {
+                    return $window
+                }
+            }
+        } catch {
+        }
+    }
+
+    return $null
+}
+
+function Wait-ForRootWindowByNamePattern {
+    param(
+        [string[]]$NamePatterns,
+        [int]$TimeoutSeconds = 8
+    )
+
+    $description = "window matching " + ($NamePatterns -join ", ")
+    return (Wait-Until -Description $description -TimeoutSeconds $TimeoutSeconds -Condition {
+            $window = Find-RootWindowByNamePattern -NamePatterns $NamePatterns
+            if ($window -and (Test-ElementUsable -Element $window -RequireEnabled $false)) {
+                return $window
+            }
+            return $null
+        })
+}
+
+function Get-ProcessLaunchProbe {
+    param([string[]]$ProcessNames)
+
+    $processes = @()
+    $baselineProcesses = @()
+    foreach ($processName in $ProcessNames) {
+        $matchingProcesses = @(
+            Get-Process -Name $processName -ErrorAction SilentlyContinue
+        )
+        $processes += @(
+            $matchingProcesses |
+                Where-Object {
+                    ($_.StartTime -ge $script:AuditStartedAt.AddSeconds(-2)) -and
+                    -not (Test-BaselineAppProcess -ProcessId ([int]$_.Id))
+                }
+        )
+        $baselineProcesses += @(
+            $matchingProcesses |
+                Where-Object { Test-BaselineAppProcess -ProcessId ([int]$_.Id) }
+        )
+    }
+
+    $processIds = @($processes | Select-Object -ExpandProperty Id -ErrorAction SilentlyContinue)
+    $baselineProcessIds = @($baselineProcesses | Select-Object -ExpandProperty Id -ErrorAction SilentlyContinue)
+    $windows = @()
+    $baselineWindows = @()
+    if ($processIds.Count -gt 0) {
+        foreach ($window in [CodexLiveAuditWin32]::GetTopLevelWindows()) {
+            if ($processIds -contains [int]$window.ProcessId) {
+                $windows += $window
+            }
+        }
+    }
+    if ($baselineProcessIds.Count -gt 0) {
+        foreach ($window in [CodexLiveAuditWin32]::GetTopLevelWindows()) {
+            if ($baselineProcessIds -contains [int]$window.ProcessId) {
+                $baselineWindows += $window
+            }
+        }
+    }
+
+    return [pscustomobject]@{
+        processes          = @($processes | ForEach-Object {
+                [pscustomobject]@{
+                    id                = $_.Id
+                    process_name      = $_.ProcessName
+                    main_window_title = $_.MainWindowTitle
+                    main_window_handle = $_.MainWindowHandle.ToInt64()
+                    start_time        = $_.StartTime.ToString("o")
+                }
+            })
+        windows            = @($windows | ForEach-Object {
+                [pscustomobject]@{
+                    handle     = $_.Handle.ToInt64()
+                    process_id = $_.ProcessId
+                    title      = $_.Title
+                    class_name = $_.ClassName
+                    is_visible = $_.IsVisible
+                }
+            })
+        baseline_processes = @($baselineProcesses | ForEach-Object {
+                [pscustomobject]@{
+                    id                = $_.Id
+                    process_name      = $_.ProcessName
+                    main_window_title = $_.MainWindowTitle
+                    main_window_handle = $_.MainWindowHandle.ToInt64()
+                    start_time        = $_.StartTime.ToString("o")
+                }
+            })
+        baseline_windows   = @($baselineWindows | ForEach-Object {
+                [pscustomobject]@{
+                    handle     = $_.Handle.ToInt64()
+                    process_id = $_.ProcessId
+                    title      = $_.Title
+                    class_name = $_.ClassName
+                    is_visible = $_.IsVisible
+                }
+            })
+    }
+}
+
+function Write-LaunchProbeArtifact {
+    param(
+        [string]$Label,
+        [object]$Probe,
+        [string]$Classification
+    )
+
+    $path = Join-Path $OutputDir "$Label.json"
+    [pscustomobject]@{
+        classification = $Classification
+        probe          = $Probe
+    } | ConvertTo-Json -Depth 8 | Set-Content -LiteralPath $path -Encoding utf8
+
+    return $path
+}
+
+function Resolve-AutomationElementFromWindowInfo {
+    param([object]$WindowInfo)
+
+    if (-not $WindowInfo) {
+        return $null
+    }
+
+    try {
+        if (-not $WindowInfo.IsVisible) {
+            return $null
+        }
+        $handle = [IntPtr]::new([Int64]$WindowInfo.Handle)
+        if ($handle -eq [IntPtr]::Zero) {
+            return $null
+        }
+        $element = [System.Windows.Automation.AutomationElement]::FromHandle($handle)
+        if ($element -and (Test-ElementUsable -Element $element -RequireEnabled $false)) {
+            return $element
+        }
+    } catch {
+    }
+
+    return $null
+}
+
+function Wait-ForLaunchedWindowEvidence {
+    param(
+        [string[]]$NamePatterns,
+        [string[]]$ProcessNames,
+        [int]$TimeoutSeconds = 14,
+        [switch]$AllowProcessOnlyEvidence,
+        [switch]$AllowExistingWindowEvidence
+    )
+
+    $description = "visible launched window matching " + (($NamePatterns + $ProcessNames) -join ", ")
+    Write-AuditStep -Stage "WAIT" -Message "waiting for $description"
+    $deadline = (Get-Date).AddSeconds($TimeoutSeconds)
+    $lastProbe = $null
+    $lastProbeSignature = ""
+    $lastProbeHeartbeatAt = Get-Date
+    $processOnlyEligibleAt = $null
+    $processOnlyEvidenceProbe = $null
+    while ((Get-Date) -lt $deadline) {
+        $lastProbe = Get-ProcessLaunchProbe -ProcessNames $ProcessNames
+        $probeSignature = "processes=$($lastProbe.processes.Count);windows=$($lastProbe.windows.Count);baseline_processes=$($lastProbe.baseline_processes.Count);baseline_windows=$($lastProbe.baseline_windows.Count)"
+        if ($probeSignature -ne $lastProbeSignature) {
+            $lastProbeSignature = $probeSignature
+            $lastProbeHeartbeatAt = Get-Date
+            Write-AuditStep -Stage "WAIT" -Message "$description probe update: $probeSignature"
+        } elseif ((Get-Date) -ge $lastProbeHeartbeatAt.AddSeconds(2)) {
+            $lastProbeHeartbeatAt = Get-Date
+            Write-AuditStep -Stage "WAIT" -Message "$description probe stable: $probeSignature"
+        }
+        if ($AllowProcessOnlyEvidence -and $lastProbe.processes.Count -gt 0 -and -not $processOnlyEligibleAt) {
+            $processOnlyEligibleAt = (Get-Date).AddSeconds(3)
+            $processOnlyEvidenceProbe = $lastProbe
+            Write-AuditStep -Stage "WAIT" -Message "$description process-only evidence candidate observed; waiting briefly for a visible window"
+        }
+
+        $uiaWindow = Find-RootWindowByNamePattern -NamePatterns $NamePatterns
+        if ($uiaWindow -and (Test-ElementUsable -Element $uiaWindow -RequireEnabled $false)) {
+            $uiaProcessId = 0
+            try {
+                $uiaProcessId = [int]$uiaWindow.Current.ProcessId
+            } catch {
+            }
+            $launchedProcessIds = @($lastProbe.processes | ForEach-Object { [int]$_.id })
+            if ($ProcessNames.Count -eq 0 -or $launchedProcessIds -contains $uiaProcessId -or $lastProbe.processes.Count -gt 0) {
+                $method = if ($ProcessNames.Count -gt 0 -and $lastProbe.processes.Count -gt 0 -and -not ($launchedProcessIds -contains $uiaProcessId)) {
+                    "uia_name_pattern_after_process"
+                } else {
+                    "uia_name_pattern"
+                }
+                Write-AuditStep -Stage "WAIT" -Message "satisfied $description via $method"
+                return [pscustomobject]@{
+                    element        = $uiaWindow
+                    method         = $method
+                    probe          = $lastProbe
+                    classification = "visible_window"
+                }
+            }
+        }
+
+        if ($AllowExistingWindowEvidence -and $lastProbe.processes.Count -eq 0 -and $lastProbe.baseline_processes.Count -gt 0 -and $uiaWindow -and (Test-ElementUsable -Element $uiaWindow -RequireEnabled $false)) {
+            Write-AuditStep -Stage "WAIT" -Message "satisfied $description via existing baseline window after launch request"
+            return [pscustomobject]@{
+                element        = $uiaWindow
+                method         = "existing_baseline_window_after_launch_request"
+                probe          = $lastProbe
+                classification = "existing_window_reused"
+            }
+        }
+
+        foreach ($candidate in $lastProbe.windows) {
+            if (-not $candidate.is_visible) {
+                continue
+            }
+
+            $matches = $false
+            foreach ($pattern in $NamePatterns) {
+                if ($candidate.title -like $pattern -or $candidate.class_name -like $pattern) {
+                    $matches = $true
+                    break
+                }
+            }
+            if (-not $matches -and $ProcessNames.Count -gt 0) {
+                $matches = $true
+            }
+            if (-not $matches) {
+                continue
+            }
+
+            $element = Resolve-AutomationElementFromWindowInfo -WindowInfo $candidate
+            if ($element) {
+                Write-AuditStep -Stage "WAIT" -Message "satisfied $description via Win32 process window"
+                return [pscustomobject]@{
+                    element        = $element
+                    method         = "win32_process_window"
+                    probe          = $lastProbe
+                    classification = "visible_window"
+                }
+            }
+
+            Write-AuditStep -Stage "WAIT" -Message "satisfied $description via Win32 visible-window probe"
+            return [pscustomobject]@{
+                element        = $null
+                method         = "win32_visible_window_probe"
+                probe          = $lastProbe
+                classification = "visible_window_probe"
+            }
+        }
+
+        if ($AllowProcessOnlyEvidence -and $processOnlyEvidenceProbe -and $processOnlyEligibleAt -and (Get-Date) -ge $processOnlyEligibleAt) {
+            Write-AuditStep -Stage "WAIT" -Message "satisfied $description via classified process-only launch evidence"
+            return [pscustomobject]@{
+                element        = $null
+                method         = "process_only_no_visible_window"
+                probe          = $processOnlyEvidenceProbe
+                classification = "process_launched_no_visible_window"
+            }
+        }
+
+        if ($NoProgressTimeoutSeconds -gt 0 -and (Get-Date) -ge $script:LastProgressAt.AddSeconds($NoProgressTimeoutSeconds)) {
+            $probeJson = if ($lastProbe) { $lastProbe | ConvertTo-Json -Depth 6 -Compress } else { "{}" }
+            throw "No-progress watchdog exceeded while waiting for $description. Last confirmed progress: $($script:LastProgressPoint). Process/window probe: $probeJson"
+        }
+
+        Start-Sleep -Milliseconds 150
+    }
+
+    $probeJson = if ($lastProbe) { $lastProbe | ConvertTo-Json -Depth 6 -Compress } else { "{}" }
+    throw "Timed out waiting for $description. Last confirmed progress: $($script:LastProgressPoint). Process/window probe: $probeJson"
+}
+
+function Close-RootWindowsByNamePattern {
+    param([string[]]$NamePatterns)
+
+    $closed = 0
+    while ($true) {
+        $window = Find-RootWindowByNamePattern -NamePatterns $NamePatterns
+        if (-not $window) {
+            break
+        }
+
+        try {
+            Close-WindowByEsc -Window $window
+            Start-Sleep -Milliseconds 250
+        } catch {
+        }
+
+        try {
+            if (-not $window.Current.IsOffscreen) {
+                Focus-Element -Element $window
+                [System.Windows.Forms.SendKeys]::SendWait("%{F4}")
+                Start-Sleep -Milliseconds 450
+            }
+        } catch {
+        }
+
+        $closed += 1
+        if ($closed -ge 6) {
+            break
+        }
+    }
+
+    return $closed
+}
+
+function Close-RootWindowsForProcessIds {
+    param(
+        [int[]]$ProcessIds,
+        [string[]]$NamePatterns
+    )
+
+    if (-not $ProcessIds -or $ProcessIds.Count -eq 0) {
+        return 0
+    }
+
+    $closed = 0
+    $windows = @(
+        [CodexLiveAuditWin32]::GetTopLevelWindows() |
+            Where-Object { $ProcessIds -contains [int]$_.ProcessId }
+    )
+    Write-AuditStep -Stage "CLEANUP" -Message "close_window scan found $($windows.Count) top-level launched window(s) for process ids: $($ProcessIds -join ', ')"
+
+    $maxCloseAttempts = 12
+    for ($i = 0; $i -lt $windows.Count; $i++) {
+        Assert-NoProgressBudget -Activity "cleanup close-window scan"
+        if ($i -ge $maxCloseAttempts) {
+            Write-AuditStep -Stage "CLEANUP" -Message "close_window attempts reached $maxCloseAttempts; remaining cleanup will be classified by process termination"
+            break
+        }
+
+        $windowInfo = $windows[$i]
+        try {
+            $matchesName = ($NamePatterns.Count -eq 0)
+            foreach ($pattern in $NamePatterns) {
+                if ($windowInfo.Title -like $pattern -or $windowInfo.ClassName -like $pattern) {
+                    $matchesName = $true
+                    break
+                }
+            }
+            if (-not $matchesName) {
+                continue
+            }
+
+            Write-AuditStep -Stage "CLEANUP" -Message "close_window attempt pid=$($windowInfo.ProcessId) handle=$($windowInfo.Handle.ToInt64()) title='$($windowInfo.Title)' class='$($windowInfo.ClassName)'"
+            $window = Resolve-AutomationElementFromWindowInfo -WindowInfo $windowInfo
+            if (-not $window) {
+                Write-AuditStep -Stage "CLEANUP" -Message "close_window probe-only window handle=$($windowInfo.Handle.ToInt64()) pid=$($windowInfo.ProcessId); process termination will classify final cleanup"
+                continue
+            }
+
+            Close-WindowByEsc -Window $window
+            Start-Sleep -Milliseconds 250
+            if (-not $window.Current.IsOffscreen) {
+                Focus-Element -Element $window
+                [System.Windows.Forms.SendKeys]::SendWait("%{F4}")
+                Start-Sleep -Milliseconds 450
+            }
+            $closed += 1
+        } catch {
+            Add-CleanupNote -Action "close_window" -Result "helper_failure" -Details "could not request close for process-owned window: $($_.Exception.Message)"
+        }
+    }
+
+    return $closed
+}
+
+function Stop-Fb037LaunchedApps {
+    Write-AuditStep -Stage "CLEANUP" -Message "starting FB-037 launched-app cleanup"
+    Assert-NoProgressBudget -Activity "FB-037 launched-app cleanup start"
+    $launchedProcesses = @(
+        Get-Fb037ManagedProcesses |
+            Where-Object {
+                ($_.StartTime -ge $script:AuditStartedAt.AddSeconds(-2)) -and
+                -not (Test-BaselineAppProcess -ProcessId ([int]$_.Id))
+            }
+    )
+    $baselineProcesses = @(
+        Get-Fb037ManagedProcesses |
+            Where-Object { Test-BaselineAppProcess -ProcessId ([int]$_.Id) }
+    )
+    if ($baselineProcesses.Count -gt 0) {
+        Add-CleanupNote -Action "baseline_processes" -Result "baseline_skipped" -Details "preserved baseline app process ids: $((@($baselineProcesses | ForEach-Object { $_.Id }) -join ', '))"
+    }
+
+    $launchedProcessIds = @($launchedProcesses | ForEach-Object { [int]$_.Id })
+    Write-AuditStep -Stage "CLEANUP" -Message "FB-037 launched process ids: $($launchedProcessIds -join ', ')"
+    $closedWindows = Close-RootWindowsForProcessIds -ProcessIds $launchedProcessIds -NamePatterns @("*Task Manager*", "*Calculator*", "*Notepad*", "*Untitled*", "*Paint*", "*Docs*")
+    if ($closedWindows -gt 0) {
+        Add-CleanupNote -Action "close_windows" -Result "success" -Details "requested close for $closedWindows launched window(s)"
+    }
+
+    foreach ($process in $launchedProcesses) {
+        Assert-NoProgressBudget -Activity "FB-037 stop-process cleanup"
+        Write-AuditStep -Stage "CLEANUP" -Message "stop_process attempt $($process.ProcessName) pid=$($process.Id)"
+        try {
+            Stop-Process -Id $process.Id -Force -ErrorAction Stop
+            Add-CleanupNote -Action "stop_process" -Result "success" -Details "stopped $($process.ProcessName) pid=$($process.Id)"
+        } catch {
+            $result = if ($_.Exception.Message -like "*Cannot find a process*" -or $_.Exception.Message -like "*process identifier*") {
+                "success"
+            } elseif ($_.Exception.Message -like "*Access is denied*") {
+                "os_blocked"
+            } else {
+                "helper_failure"
+            }
+            $details = if ($result -eq "success") {
+                "$($process.ProcessName) pid=$($process.Id) already exited before forced stop"
+            } else {
+                "could not stop $($process.ProcessName) pid=$($process.Id): $($_.Exception.Message)"
+            }
+            Add-CleanupNote -Action "stop_process" -Result $result -Details $details
+        }
+    }
+    Write-AuditStep -Stage "CLEANUP" -Message "FB-037 launched-app cleanup complete"
+}
+
+function Invoke-Fb037Command {
+    param(
+        [string]$ScenarioName,
+        [string]$Phrase,
+        [string]$ExpectedActionId,
+        [string[]]$ExpectedWindowPatterns = @(),
+        [string[]]$ExpectedProcessNames = @(),
+        [string[]]$ForbiddenActionIds = @(),
+        [switch]$AllowProcessOnlyEvidence,
+        [switch]$AllowExistingWindowEvidence
+    )
+
+    Write-AuditStep -Stage "FB037" -Message "running '$Phrase' expecting action_id=$ExpectedActionId"
+    $overlay = Open-Overlay
+    $overlayInput = Resolve-OverlayInput -Overlay $overlay
+    $startLine = Get-RuntimeLogLineCount
+    $overlayInput = Focus-OverlayInputForSubmit -Overlay $overlay -InputElement $overlayInput -Description "FB-037 command '$Phrase'"
+    Set-ElementValue -Element $overlayInput -Value $Phrase -Description "FB-037 command '$Phrase'"
+    Write-AuditStep -Stage "FB037" -Message "text set for '$Phrase' state=$(Get-ElementStateSummary -Element $overlayInput) value='$(Get-ElementReadableValue -Element $overlayInput)'"
+    Wait-ForRuntimeMarker -Marker "OVERLAY_TRACE|source=renderer|event=local_text_changed" -StartLine $startLine -TimeoutSeconds 4 | Out-Null
+
+    $confirmed = $false
+    for ($attempt = 1; $attempt -le 3; $attempt++) {
+        $overlay = Get-OverlayWindow
+        if (-not $overlay) {
+            $overlay = Open-Overlay
+        }
+        $overlayInput = Resolve-OverlayInput -Overlay $overlay
+        $overlayInput = Focus-OverlayInputForSubmit -Overlay $overlay -InputElement $overlayInput -Description "FB-037 command '$Phrase' submit attempt $attempt"
+        Engage-OverlayInputForSubmit -InputElement $overlayInput -ExpectedValue $Phrase -Description "FB-037 command '$Phrase' submit attempt $attempt"
+        $submitStartLine = Get-RuntimeLogLineCount
+        Write-AuditStep -Stage "FB037" -Message "submit attempted for '$Phrase' attempt=$attempt"
+        Submit-OverlayInput -InputElement $overlayInput -Description "FB-037 command '$Phrase' submit attempt $attempt"
+
+        try {
+            $outcome = Wait-ForCommandSubmitOutcome -ExpectedActionId $ExpectedActionId -StartLine $submitStartLine -TimeoutSeconds 3
+        } catch {
+            Write-AuditStep -Stage "FB037" -Message "submit attempt $attempt did not produce a confirm or failure marker for '$Phrase'. runtime_tail=$(Get-RuntimeTailText -StartLine $submitStartLine)"
+            continue
+        }
+
+        if ($outcome.Kind -eq "confirm") {
+            Write-AuditStep -Stage "FB037" -Message "submit confirmed for '$Phrase' attempt=$attempt line=$($outcome.Line)"
+            $confirmed = $true
+            break
+        }
+
+        throw "Submit for '$Phrase' produced $($outcome.Kind) instead of action_id=$ExpectedActionId. Runtime line: $($outcome.Line)"
+    }
+
+    if (-not $confirmed) {
+        throw "Submit for '$Phrase' did not reach COMMAND_CONFIRM_READY for action_id=$ExpectedActionId after retries. Runtime tail: $(Get-RuntimeTailText -StartLine $startLine)"
+    }
+
+    $confirmPath = Capture-ElementScreenshot -Element $overlay -Label "${ScenarioName}_confirm" -DelayMs 180
+
+    Write-AuditStep -Stage "FB037" -Message "launch submit attempted for '$Phrase'"
+    Send-EnterToElementWindow -Element $overlay -Description "FB-037 command '$Phrase' launch"
+    Wait-ForRuntimeMarker -Marker "RENDERER_MAIN|COMMAND_LAUNCH_REQUEST_SENT|action_id=$ExpectedActionId" -StartLine $startLine -TimeoutSeconds 8 | Out-Null
+    foreach ($forbiddenActionId in $ForbiddenActionIds) {
+        Assert-RuntimeMarkerAbsent -Marker "RENDERER_MAIN|COMMAND_LAUNCH_REQUEST_SENT|action_id=$forbiddenActionId" -StartLine $startLine
+    }
+    $resultPath = Capture-ElementScreenshot -Element $overlay -Label "${ScenarioName}_result" -DelayMs 180
+
+    $windowPath = ""
+    $windowMethod = ""
+    $windowProbe = $null
+    $windowProbePath = ""
+    $windowClassification = ""
+    if ($ExpectedWindowPatterns.Count -gt 0) {
+        $windowEvidence = Wait-ForLaunchedWindowEvidence -NamePatterns $ExpectedWindowPatterns -ProcessNames $ExpectedProcessNames -TimeoutSeconds 14 -AllowProcessOnlyEvidence:$AllowProcessOnlyEvidence -AllowExistingWindowEvidence:$AllowExistingWindowEvidence
+        $windowMethod = $windowEvidence.method
+        $windowProbe = $windowEvidence.probe
+        $windowClassification = $windowEvidence.classification
+        if ($windowEvidence.element) {
+            $windowPath = Capture-ElementScreenshot -Element $windowEvidence.element -Label "${ScenarioName}_launched_window" -DelayMs 180
+        } else {
+            $windowProbePath = Write-LaunchProbeArtifact -Label "${ScenarioName}_launch_probe" -Probe $windowProbe -Classification $windowClassification
+        }
+    }
+
+    Close-WindowByEsc -Window $overlay
+
+    $artifacts = [pscustomobject]@{
+        confirm_capture = $confirmPath
+        result_capture  = $resultPath
+        window_capture  = $windowPath
+        window_method   = $windowMethod
+        launch_probe    = $windowProbe
+        launch_probe_capture = $windowProbePath
+        launch_classification = $windowClassification
+    }
+    Add-ScenarioResult -Name $ScenarioName -Result "PASS" -Details "Phrase '$Phrase' resolved and launched action_id=$ExpectedActionId." -Artifacts $artifacts
+    return $artifacts
+}
+
+function Assert-Fb037CreateCollisionRejected {
+    param(
+        [string]$ScenarioName,
+        [string]$Alias
+    )
+
+    Write-AuditStep -Stage "FB037" -Message "verifying create collision rejection for '$Alias'"
+    $overlay = Open-Overlay
+    $createButton = Get-OverlayButton -Overlay $overlay -AutomationIds @(
+        "QApplication.commandOverlayWindow.commandPanel.savedActionInventory.QFrame.savedActionCreateButton",
+        "QApplication.commandOverlayWindow.commandPanel.savedActionInventory.savedActionCreateButton"
+    )
+    Invoke-Element -Element $createButton -Description "Create Custom Task button"
+    $createDialog = Wait-ForDialog -Name "Create Custom Task"
+    Set-ElementValue -Element (Get-CreateDialogInput -Dialog $createDialog -LeafId "savedActionCreateTitleInput") -Value "Blocked $Alias" -Description "create collision title"
+    Set-ElementValue -Element (Get-CreateDialogInput -Dialog $createDialog -LeafId "savedActionCreateAliasesInput") -Value $Alias -Description "create collision aliases"
+    Set-ElementValue -Element (Get-CreateDialogInput -Dialog $createDialog -LeafId "savedActionCreateTargetInput") -Value "notepad.exe" -Description "create collision target"
+    $createSubmit = Get-FirstButtonByName -Root $createDialog -Name "Create"
+    Invoke-Element -Element $createSubmit -Description "Create collision submit"
+    Start-Sleep -Milliseconds 300
+    $capturePath = Capture-ElementScreenshot -Element $createDialog -Label "${ScenarioName}_create_collision" -DelayMs 180
+    Close-WindowByEsc -Window $createDialog
+    Add-ScenarioResult -Name $ScenarioName -Result "PASS" -Details "Create dialog rejected built-in phrase '$Alias'." -Artifacts ([pscustomobject]@{ capture = $capturePath })
+}
+
+function Assert-Fb037EditCollisionRejected {
+    param(
+        [string]$ScenarioName,
+        [string]$Alias
+    )
+
+    Write-AuditStep -Stage "FB037" -Message "verifying edit collision rejection for '$Alias'"
+    Seed-Fb037OverrideSource -Aliases @("fb037 editable safe")
+    $overlay = Open-Overlay
+    $manageTasksButton = Get-OverlayButton -Overlay $overlay -AutomationIds @(
+        "QApplication.commandOverlayWindow.commandPanel.savedActionInventory.QFrame.savedActionCreatedTasksButton",
+        "QApplication.commandOverlayWindow.commandPanel.savedActionInventory.savedActionCreatedTasksButton"
+    )
+    Invoke-Element -Element $manageTasksButton -Description "Manage Custom Tasks button"
+    $manageTasksDialog = Wait-ForDialog -Name "Manage Custom Tasks"
+    $editButton = Wait-Until -Description "first Edit button for FB-037 edit collision" -Condition {
+        $button = Get-FirstEditButton -Root $manageTasksDialog
+        if ($button -and (Test-ElementUsable -Element $button)) { return $button }
+        return $null
+    }
+    Invoke-Element -Element $editButton -Description "first Edit button"
+    $editDialog = Wait-ForDialog -Name "Edit Custom Task"
+    Set-ElementValue -Element (Get-CreateDialogInput -Dialog $editDialog -LeafId "savedActionCreateAliasesInput") -Value $Alias -Description "edit collision aliases"
+    $saveButton = Get-FirstButtonByName -Root $editDialog -Name "Save"
+    if (-not $saveButton) {
+        $saveButton = Get-FirstButtonByName -Root $editDialog -Name "Update"
+    }
+    Invoke-Element -Element $saveButton -Description "Edit collision submit"
+    Start-Sleep -Milliseconds 300
+    $capturePath = Capture-ElementScreenshot -Element $editDialog -Label "${ScenarioName}_edit_collision" -DelayMs 180
+    Close-WindowByEsc -Window $editDialog
+    Close-WindowByEsc -Window $manageTasksDialog
+    Add-ScenarioResult -Name $ScenarioName -Result "PASS" -Details "Edit dialog rejected built-in phrase '$Alias'." -Artifacts ([pscustomobject]@{ capture = $capturePath })
+}
+
+function Write-AuditManifest {
+    param(
+        [string]$Status = "PASS",
+        [string]$FailureMessage = ""
+    )
+
+    $script:ManifestStatus = $Status
+    $script:ManifestFailureMessage = $FailureMessage
+    $manifest = [pscustomobject]@{
+        capture_dir                   = $OutputDir
+        status                        = $Status
+        failure_message               = $FailureMessage
+        captures                      = $script:Captures
+        scenarios                     = $script:ScenarioResults
+        cleanup_notes                 = $script:CleanupNotes
+        cleanup_summary               = Get-CleanupSummary
+        baseline_app_process_ids      = $script:BaselineAppPids
+        step_log                      = $StepLogPath
+        timeout_budgets               = [pscustomobject]@{
+            default_timeout_seconds     = $TimeoutSeconds
+            no_progress_timeout_seconds = $NoProgressTimeoutSeconds
+        }
+        last_confirmed_progress_point = $script:LastProgressPoint
+    }
+    $manifest | ConvertTo-Json -Depth 8 | Set-Content -LiteralPath $ManifestPath -Encoding utf8
+
+    [pscustomobject]@{
+        capture_dir = $OutputDir
+        manifest    = $ManifestPath
+        status      = $Status
+        scenarios   = $script:ScenarioResults
+        captures    = $script:Captures
+    } | ConvertTo-Json -Depth 8
+}
+
+function Run-Fb037Validation {
+    try {
+    Write-AuditStep -Stage "BUDGET" -Message "FB-037 live validation budgets active: default_timeout=${TimeoutSeconds}s no_progress=${NoProgressTimeoutSeconds}s"
+    Backup-Source
+    Write-AuditStep -Stage "SOURCE" -Message "saved action source backed up"
+    Seed-Fb037EmptySource
+    Write-AuditStep -Stage "SOURCE" -Message "FB-037 empty source seeded for built-in fallback scenarios"
+    Launch-Desktop
+    Write-AuditStep -Stage "RUNTIME" -Message "desktop runtime launched and ready"
+
+    $builtInCases = @(
+        @{ Name = "fb037_builtin_task_manager"; Phrase = "open task manager"; ActionId = "open_task_manager"; Windows = @("*Task Manager*"); Processes = @("taskmgr"); AllowExisting = $true; AllowProcessOnly = $false },
+        @{ Name = "fb037_builtin_calculator"; Phrase = "open calculator"; ActionId = "open_calculator"; Windows = @("*Calculator*"); Processes = @("CalculatorApp", "calc"); AllowExisting = $false; AllowProcessOnly = $false },
+        @{ Name = "fb037_builtin_notepad"; Phrase = "open notepad"; ActionId = "open_notepad"; Windows = @("*Notepad*", "*Untitled*"); Processes = @("notepad"); AllowExisting = $false; AllowProcessOnly = $true },
+        @{ Name = "fb037_builtin_paint"; Phrase = "open paint"; ActionId = "open_paint"; Windows = @("*Paint*", "*Untitled*"); Processes = @("mspaint"); AllowExisting = $false; AllowProcessOnly = $true }
+    )
+    foreach ($case in $builtInCases) {
+        Invoke-Fb037Command -ScenarioName $case["Name"] -Phrase $case["Phrase"] -ExpectedActionId $case["ActionId"] -ExpectedWindowPatterns $case["Windows"] -ExpectedProcessNames $case["Processes"] -AllowExistingWindowEvidence:([bool]$case["AllowExisting"]) -AllowProcessOnlyEvidence:([bool]$case["AllowProcessOnly"]) | Out-Null
+        Stop-Fb037LaunchedApps
+    }
+
+    Seed-Fb037OverrideSource -Aliases @("task manager", "calculator", "notepad", "paint")
+    Write-AuditStep -Stage "SOURCE" -Message "FB-037 saved-action override source seeded"
+    $overrideCases = @(
+        @{ Name = "fb037_override_task_manager"; Phrase = "task manager"; ActionId = "saved_override_task_manager"; Forbidden = "open_task_manager" },
+        @{ Name = "fb037_override_calculator"; Phrase = "calculator"; ActionId = "saved_override_calculator"; Forbidden = "open_calculator" },
+        @{ Name = "fb037_override_notepad"; Phrase = "notepad"; ActionId = "saved_override_notepad"; Forbidden = "open_notepad" },
+        @{ Name = "fb037_override_paint"; Phrase = "paint"; ActionId = "saved_override_paint"; Forbidden = "open_paint" }
+    )
+    foreach ($case in $overrideCases) {
+        Invoke-Fb037Command -ScenarioName $case["Name"] -Phrase $case["Phrase"] -ExpectedActionId $case["ActionId"] -ForbiddenActionIds @($case["Forbidden"]) | Out-Null
+        Stop-Fb037LaunchedApps
+    }
+
+    Seed-Fb037EmptySource
+    Assert-Fb037CreateCollisionRejected -ScenarioName "fb037_authoring_create_task_manager_collision" -Alias "task manager"
+    Assert-Fb037CreateCollisionRejected -ScenarioName "fb037_authoring_create_calculator_collision" -Alias "calculator"
+    Assert-Fb037CreateCollisionRejected -ScenarioName "fb037_authoring_create_notepad_collision" -Alias "notepad"
+    Assert-Fb037CreateCollisionRejected -ScenarioName "fb037_authoring_create_paint_collision" -Alias "paint"
+    Assert-Fb037EditCollisionRejected -ScenarioName "fb037_authoring_edit_task_manager_collision" -Alias "task manager"
+
+    Seed-Fb037OverrideSource -Aliases @("calculator", "paint")
+    Write-AuditStep -Stage "SOURCE" -Message "FB-037 mixed source seeded"
+    Invoke-Fb037Command -ScenarioName "fb037_mixed_task_manager_builtin" -Phrase "task manager" -ExpectedActionId "open_task_manager" -ExpectedWindowPatterns @("*Task Manager*") -ExpectedProcessNames @("taskmgr") -AllowExistingWindowEvidence | Out-Null
+    Stop-Fb037LaunchedApps
+    Invoke-Fb037Command -ScenarioName "fb037_mixed_calculator_saved" -Phrase "calculator" -ExpectedActionId "saved_override_calculator" -ForbiddenActionIds @("open_calculator") | Out-Null
+    Stop-Fb037LaunchedApps
+    Invoke-Fb037Command -ScenarioName "fb037_mixed_notepad_builtin" -Phrase "notepad" -ExpectedActionId "open_notepad" -ExpectedWindowPatterns @("*Notepad*", "*Untitled*") -ExpectedProcessNames @("notepad") -AllowProcessOnlyEvidence | Out-Null
+    Stop-Fb037LaunchedApps
+    Invoke-Fb037Command -ScenarioName "fb037_mixed_paint_saved" -Phrase "paint" -ExpectedActionId "saved_override_paint" -ForbiddenActionIds @("open_paint") | Out-Null
+    Stop-Fb037LaunchedApps
+
+    Seed-Fb037EmptySource
+    Invoke-Fb037Command -ScenarioName "fb037_repeated_notepad_first" -Phrase "notepad" -ExpectedActionId "open_notepad" -ExpectedWindowPatterns @("*Notepad*", "*Untitled*") -ExpectedProcessNames @("notepad") -AllowProcessOnlyEvidence | Out-Null
+    Stop-Fb037LaunchedApps
+    Invoke-Fb037Command -ScenarioName "fb037_repeated_notepad_second" -Phrase "notepad" -ExpectedActionId "open_notepad" -ExpectedWindowPatterns @("*Notepad*", "*Untitled*") -ExpectedProcessNames @("notepad") -AllowProcessOnlyEvidence | Out-Null
+    Stop-Fb037LaunchedApps
+
+    Restore-Source
+    Write-AuditStep -Stage "SOURCE" -Message "saved action source restored"
+    Write-AuditManifest -Status "PASS"
+    } catch {
+        $failureMessage = $_.Exception.Message
+        Add-ScenarioResult -Name "fb037_validation_run" -Result "FAIL" -Details $failureMessage
+        Write-AuditManifest -Status "FAIL" -FailureMessage $failureMessage | Out-Null
+        try {
+            Stop-Fb037LaunchedApps
+        } catch {
+            Add-CleanupNote -Action "fb037_cleanup" -Result "blocked" -Details $_.Exception.Message
+        }
+        try {
+            Restore-Source
+            Write-AuditStep -Stage "SOURCE" -Message "saved action source restored after failure"
+        } catch {
+            Add-CleanupNote -Action "restore_source" -Result "blocked" -Details $_.Exception.Message
+        }
+        Write-AuditManifest -Status "FAIL" -FailureMessage $failureMessage
+        throw
+    }
+}
+
 function Stop-LaunchedDesktopProcesses {
+    Write-AuditStep -Stage "CLEANUP" -Message "checking for launched desktop runtime helper processes"
     $newPython = Get-CimInstance Win32_Process |
         Where-Object {
             $_.Name -in @("python.exe", "pythonw.exe") -and
@@ -851,9 +2265,23 @@ function Stop-LaunchedDesktopProcesses {
         }
 
     foreach ($process in $newPython) {
+        Assert-NoProgressBudget -Activity "desktop runtime process cleanup"
+        Write-AuditStep -Stage "CLEANUP" -Message "stopping launched desktop runtime pid=$($process.ProcessId)"
         try {
             Stop-Process -Id $process.ProcessId -Force -ErrorAction Stop
+            Add-CleanupNote -Action "stop_desktop_runtime" -Result "success" -Details "stopped launched desktop runtime pid=$($process.ProcessId)"
         } catch {
+            $result = if ($_.Exception.Message -like "*Cannot find a process*" -or $_.Exception.Message -like "*process identifier*") {
+                "success"
+            } else {
+                "helper_failure"
+            }
+            $details = if ($result -eq "success") {
+                "launched desktop runtime pid=$($process.ProcessId) already exited before forced stop"
+            } else {
+                "could not stop launched desktop runtime pid=$($process.ProcessId): $($_.Exception.Message)"
+            }
+            Add-CleanupNote -Action "stop_desktop_runtime" -Result $result -Details $details
         }
     }
 }
@@ -942,11 +2370,19 @@ function Get-TaskGroupAssignmentButton {
 }
 
 try {
+    if ($Fb037Validation) {
+        Run-Fb037Validation
+    } else {
+    Write-AuditStep -Stage "BUDGET" -Message "launcher live audit budgets active: default_timeout=${TimeoutSeconds}s no_progress=${NoProgressTimeoutSeconds}s"
     Backup-Source
+    Write-AuditStep -Stage "SOURCE" -Message "saved action source backed up"
     Seed-AuditSource
+    Write-AuditStep -Stage "SOURCE" -Message "audit source seeded"
     Launch-Desktop
+    Write-AuditStep -Stage "RUNTIME" -Message "desktop runtime launched and ready"
 
     $overlay = Open-Overlay
+    Write-AuditStep -Stage "OVERLAY" -Message "overlay opened for entry capture"
     $overlayInput = Resolve-OverlayInput -Overlay $overlay
     Capture-ElementScreenshot -Element $overlay -Label "overlay_entry" | Out-Null
 
@@ -954,19 +2390,23 @@ try {
     Send-VirtualKey -Key 0x0D
     Start-Sleep -Milliseconds 350
     Capture-ElementScreenshot -Element $overlay -Label "overlay_ambiguity" | Out-Null
+    Write-AuditStep -Stage "CAPTURE" -Message "ambiguity surface captured"
     Close-WindowByEsc -Window $overlay
     Start-Sleep -Milliseconds 220
 
     $overlay = Open-Overlay
+    Write-AuditStep -Stage "OVERLAY" -Message "overlay reopened for confirm capture"
     $overlayInput = Resolve-OverlayInput -Overlay $overlay
     Set-ElementValue -Element $overlayInput -Value "notes task" -Description "overlay confirm text"
     Send-VirtualKey -Key 0x0D
     Start-Sleep -Milliseconds 350
     Capture-ElementScreenshot -Element $overlay -Label "overlay_confirm" | Out-Null
+    Write-AuditStep -Stage "CAPTURE" -Message "confirm surface captured"
     Close-WindowByEsc -Window $overlay
     Start-Sleep -Milliseconds 220
 
     $overlay = Open-Overlay
+    Write-AuditStep -Stage "AUTHORING" -Message "starting create dialog audit"
 
     $createButton = Get-OverlayButton -Overlay $overlay -AutomationIds @(
         "QApplication.commandOverlayWindow.commandPanel.savedActionInventory.QFrame.savedActionCreateButton",
@@ -981,6 +2421,7 @@ try {
     Invoke-Element -Element $createSubmit -Description "Create submit"
     Start-Sleep -Milliseconds 450
     Capture-ElementScreenshot -Element $createDialog -Label "create_custom_task_error" | Out-Null
+    Write-AuditStep -Stage "AUTHORING" -Message "create validation error captured"
 
     $assignGroup = Get-FirstButtonByName -Root $createDialog -Name "Assign Group..."
     Invoke-Element -Element $assignGroup -Description "Assign Group"
@@ -997,6 +2438,7 @@ try {
     Invoke-Element -Element $assignmentCreate -Description "Available Groups create"
     $inlineCreateGroupDialog = Wait-ForDialog -Name "Create Custom Group"
     Capture-ElementScreenshot -Element $inlineCreateGroupDialog -Label "create_custom_group" | Out-Null
+    Write-AuditStep -Stage "AUTHORING" -Message "inline group create dialog captured"
     Close-WindowByEsc -Window $inlineCreateGroupDialog
     Start-Sleep -Milliseconds 220
     Close-WindowByEsc -Window $assignmentDialog
@@ -1005,6 +2447,7 @@ try {
     Start-Sleep -Milliseconds 250
 
     $overlay = Open-Overlay
+    Write-AuditStep -Stage "AUTHORING" -Message "starting manage custom tasks audit"
 
     $manageTasksButton = Get-OverlayButton -Overlay $overlay -AutomationIds @(
         "QApplication.commandOverlayWindow.commandPanel.savedActionInventory.QFrame.savedActionCreatedTasksButton",
@@ -1021,12 +2464,14 @@ try {
     Invoke-Element -Element $editButton -Description "first Edit button"
     $editDialog = Wait-ForDialog -Name "Edit Custom Task"
     Capture-ElementScreenshot -Element $editDialog -Label "edit_custom_task" | Out-Null
+    Write-AuditStep -Stage "AUTHORING" -Message "edit custom task dialog captured"
     Close-WindowByEsc -Window $editDialog
     Start-Sleep -Milliseconds 220
     Close-WindowByEsc -Window $manageTasksDialog
     Start-Sleep -Milliseconds 220
 
     $overlay = Open-Overlay
+    Write-AuditStep -Stage "AUTHORING" -Message "starting direct group create audit"
 
     $createGroupButton = Get-OverlayButton -Overlay $overlay -AutomationIds @(
         "QApplication.commandOverlayWindow.commandPanel.savedActionInventory.QFrame.savedActionCreateGroupButton",
@@ -1035,10 +2480,12 @@ try {
     Invoke-Element -Element $createGroupButton -Description "Create Custom Group button"
     $directCreateGroupDialog = Wait-ForDialog -Name "Create Custom Group"
     Capture-ElementScreenshot -Element $directCreateGroupDialog -Label "create_custom_group_direct" | Out-Null
+    Write-AuditStep -Stage "AUTHORING" -Message "direct group create dialog captured"
     Close-WindowByEsc -Window $directCreateGroupDialog
     Start-Sleep -Milliseconds 220
 
     $overlay = Open-Overlay
+    Write-AuditStep -Stage "AUTHORING" -Message "starting manage custom groups audit"
     $manageGroupsButton = Get-OverlayButton -Overlay $overlay -AutomationIds @(
         "QApplication.commandOverlayWindow.commandPanel.savedActionInventory.QFrame.savedActionCreatedGroupsButton",
         "QApplication.commandOverlayWindow.commandPanel.savedActionInventory.savedActionCreatedGroupsButton"
@@ -1046,13 +2493,16 @@ try {
     Invoke-Element -Element $manageGroupsButton -Description "Manage Custom Groups button"
     $manageGroupsDialog = Wait-ForDialog -Name "Manage Custom Groups"
     Capture-ElementScreenshot -Element $manageGroupsDialog -Label "manage_custom_groups" | Out-Null
+    Write-AuditStep -Stage "AUTHORING" -Message "manage custom groups dialog captured"
     Close-WindowByEsc -Window $manageGroupsDialog
     Start-Sleep -Milliseconds 220
 
     Write-InvalidSource
+    Write-AuditStep -Stage "SOURCE" -Message "invalid source written for recovery audit"
     Start-Sleep -Milliseconds 250
 
     $overlay = Open-Overlay
+    Write-AuditStep -Stage "AUTHORING" -Message "starting invalid-source management audit"
     $manageTasksButton = Get-OverlayButton -Overlay $overlay -AutomationIds @(
         "QApplication.commandOverlayWindow.commandPanel.savedActionInventory.QFrame.savedActionCreatedTasksButton",
         "QApplication.commandOverlayWindow.commandPanel.savedActionInventory.savedActionCreatedTasksButton"
@@ -1065,19 +2515,28 @@ try {
     Invoke-Element -Element $manageTasksButton -Description "Manage Custom Tasks button invalid source"
     $invalidTasksDialog = Wait-ForDialog -Name "Manage Custom Tasks"
     Capture-ElementScreenshot -Element $invalidTasksDialog -Label "manage_custom_tasks_invalid_source" | Out-Null
+    Write-AuditStep -Stage "AUTHORING" -Message "invalid-source manage tasks captured"
     Close-WindowByEsc -Window $invalidTasksDialog
     Start-Sleep -Milliseconds 220
 
     Invoke-Element -Element $manageGroupsButton -Description "Manage Custom Groups button invalid source"
     $invalidGroupsDialog = Wait-ForDialog -Name "Manage Custom Groups"
     Capture-ElementScreenshot -Element $invalidGroupsDialog -Label "manage_custom_groups_invalid_source" | Out-Null
+    Write-AuditStep -Stage "AUTHORING" -Message "invalid-source manage groups captured"
     Close-WindowByEsc -Window $invalidGroupsDialog
 
     Restore-Source
+    Write-AuditStep -Stage "SOURCE" -Message "saved action source restored"
 
     $manifest = [pscustomobject]@{
-        capture_dir = $OutputDir
-        captures    = $script:Captures
+        capture_dir                   = $OutputDir
+        captures                      = $script:Captures
+        step_log                      = $StepLogPath
+        timeout_budgets               = [pscustomobject]@{
+            default_timeout_seconds     = $TimeoutSeconds
+            no_progress_timeout_seconds = $NoProgressTimeoutSeconds
+        }
+        last_confirmed_progress_point = $script:LastProgressPoint
     }
     $manifest | ConvertTo-Json -Depth 6 | Set-Content -LiteralPath $ManifestPath -Encoding utf8
 
@@ -1086,9 +2545,37 @@ try {
         manifest    = $ManifestPath
         captures    = $script:Captures
     } | ConvertTo-Json -Depth 6
+    }
 }
 finally {
-    Stop-AuditRuntimeHelper
-    Restore-Source
-    Stop-LaunchedDesktopProcesses
+    if (-not (Test-Path -LiteralPath $ManifestPath)) {
+        try {
+            Write-AuditStep -Stage "MANIFEST" -Message "manifest missing before final cleanup; writing abort manifest"
+            Write-AuditManifest -Status "ABORTED" -FailureMessage "Run reached final cleanup before manifest generation." | Out-Null
+        } catch {
+            Write-AuditStep -Stage "MANIFEST" -Message "failed to write pre-cleanup abort manifest: $($_.Exception.Message)"
+        }
+    }
+
+    try {
+        Write-AuditStep -Stage "CLEANUP" -Message "starting live audit cleanup"
+        Stop-AuditRuntimeHelper
+        Write-AuditStep -Stage "CLEANUP" -Message "restoring saved action source during final cleanup"
+        Restore-Source
+        Write-AuditStep -Stage "CLEANUP" -Message "saved action source restore completed during final cleanup"
+        Stop-LaunchedDesktopProcesses
+        Write-AuditStep -Stage "CLEANUP" -Message "live audit cleanup complete"
+    } catch {
+        Add-CleanupNote -Action "final_cleanup" -Result "helper_failure" -Details $_.Exception.Message
+        if ($script:ManifestStatus -eq "PASS") {
+            $script:ManifestStatus = "FAIL"
+            $script:ManifestFailureMessage = "Final cleanup failed: $($_.Exception.Message)"
+        }
+    }
+
+    try {
+        Write-AuditManifest -Status $script:ManifestStatus -FailureMessage $script:ManifestFailureMessage | Out-Null
+    } catch {
+        Write-AuditStep -Stage "MANIFEST" -Message "failed to refresh final manifest after cleanup: $($_.Exception.Message)"
+    }
 }

--- a/dev/orin_saved_action_authoring_validation.py
+++ b/dev/orin_saved_action_authoring_validation.py
@@ -936,6 +936,140 @@ def _test_edit_rejects_builtin_collisions_without_writing():
         )
 
 
+def _test_notepad_builtin_collisions_are_rejected_before_write():
+    with tempfile.TemporaryDirectory() as temp_dir:
+        source_path = Path(temp_dir) / "saved_actions.json"
+
+        try:
+            create_saved_action_from_draft(
+                SavedActionDraft(
+                    title="Notepad",
+                    target_kind="app",
+                    target="calc.exe",
+                    aliases=("Open Notepad", "Launch Notepad"),
+                ),
+                source_path,
+            )
+        except SavedActionDraftValidationError:
+            pass
+        else:
+            raise AssertionError("Notepad built-in collisions should be rejected before write")
+
+        _assert(
+            not source_path.exists(),
+            "rejecting a Notepad built-in collision should not create or modify the saved-action source file",
+        )
+
+
+def _test_edit_rejects_notepad_builtin_collisions_without_writing():
+    with tempfile.TemporaryDirectory() as temp_dir:
+        source_path = Path(temp_dir) / "saved_actions.json"
+        _write_json(
+            source_path,
+            {
+                "schema_version": 1,
+                "actions": [
+                    {
+                        "id": "open_reports",
+                        "title": "Open Reports",
+                        "target_kind": "folder",
+                        "target": r"C:\Reports",
+                        "aliases": ["show reports"],
+                    }
+                ],
+            },
+        )
+        original_text = source_path.read_text(encoding="utf-8")
+
+        try:
+            update_saved_action_from_draft(
+                "open_reports",
+                SavedActionDraft(
+                    title="Notepad",
+                    target_kind="app",
+                    target="calc.exe",
+                    aliases=("Open Notepad", "Launch Notepad"),
+                ),
+                source_path,
+            )
+        except SavedActionDraftValidationError:
+            pass
+        else:
+            raise AssertionError("editing into a Notepad built-in collision should be rejected")
+
+        _assert(
+            source_path.read_text(encoding="utf-8") == original_text,
+            "rejecting a Notepad built-in collision during edit should leave the source untouched",
+        )
+
+
+def _test_paint_builtin_collisions_are_rejected_before_write():
+    with tempfile.TemporaryDirectory() as temp_dir:
+        source_path = Path(temp_dir) / "saved_actions.json"
+
+        try:
+            create_saved_action_from_draft(
+                SavedActionDraft(
+                    title="Paint",
+                    target_kind="app",
+                    target="notepad.exe",
+                    aliases=("Open Paint", "Launch Paint"),
+                ),
+                source_path,
+            )
+        except SavedActionDraftValidationError:
+            pass
+        else:
+            raise AssertionError("Paint built-in collisions should be rejected before write")
+
+        _assert(
+            not source_path.exists(),
+            "rejecting a Paint built-in collision should not create or modify the saved-action source file",
+        )
+
+
+def _test_edit_rejects_paint_builtin_collisions_without_writing():
+    with tempfile.TemporaryDirectory() as temp_dir:
+        source_path = Path(temp_dir) / "saved_actions.json"
+        _write_json(
+            source_path,
+            {
+                "schema_version": 1,
+                "actions": [
+                    {
+                        "id": "open_reports",
+                        "title": "Open Reports",
+                        "target_kind": "folder",
+                        "target": r"C:\Reports",
+                        "aliases": ["show reports"],
+                    }
+                ],
+            },
+        )
+        original_text = source_path.read_text(encoding="utf-8")
+
+        try:
+            update_saved_action_from_draft(
+                "open_reports",
+                SavedActionDraft(
+                    title="Paint",
+                    target_kind="app",
+                    target="notepad.exe",
+                    aliases=("Open Paint", "Launch Paint"),
+                ),
+                source_path,
+            )
+        except SavedActionDraftValidationError:
+            pass
+        else:
+            raise AssertionError("editing into a Paint built-in collision should be rejected")
+
+        _assert(
+            source_path.read_text(encoding="utf-8") == original_text,
+            "rejecting a Paint built-in collision during edit should leave the source untouched",
+        )
+
+
 def _test_edit_allows_other_saved_action_collisions_without_self_collision():
     with tempfile.TemporaryDirectory() as temp_dir:
         source_path = Path(temp_dir) / "saved_actions.json"
@@ -1482,6 +1616,10 @@ def main():
         ("delete removes existing record and reloads catalog", _test_delete_removes_existing_record_and_reloads_catalog),
         ("delete rejects missing record without write", _test_delete_rejects_missing_record_without_writing),
         ("edit rejects built-in collisions without write", _test_edit_rejects_builtin_collisions_without_writing),
+        ("Notepad built-in collisions rejected before write", _test_notepad_builtin_collisions_are_rejected_before_write),
+        ("edit rejects Notepad built-in collisions without write", _test_edit_rejects_notepad_builtin_collisions_without_writing),
+        ("Paint built-in collisions rejected before write", _test_paint_builtin_collisions_are_rejected_before_write),
+        ("edit rejects Paint built-in collisions without write", _test_edit_rejects_paint_builtin_collisions_without_writing),
         ("edit allows other saved-action overlaps without self-collision", _test_edit_allows_other_saved_action_collisions_without_self_collision),
         ("invalid edit input is rejected before write", _test_invalid_edit_input_is_rejected_before_write),
         ("invalid non-url edit targets rejected before write", _test_invalid_non_url_edit_targets_are_rejected_before_write),

--- a/dev/orin_saved_action_source_validation.py
+++ b/dev/orin_saved_action_source_validation.py
@@ -57,6 +57,10 @@ def _builtin_ids():
     return tuple(action.id for action in DEFAULT_COMMAND_ACTIONS)
 
 
+def _ids(actions):
+    return tuple(action.id for action in actions)
+
+
 def _test_default_source_bootstraps_template_without_actions():
     with tempfile.TemporaryDirectory() as temp_dir:
         with _with_local_app_data(temp_dir):
@@ -215,6 +219,174 @@ def _test_valid_url_saved_actions_extend_the_effective_catalog():
         )
 
 
+def _test_saved_action_phrase_collision_overrides_builtin_resolution():
+    with tempfile.TemporaryDirectory() as temp_dir:
+        source_path = Path(temp_dir) / "saved_task_manager_override.json"
+        _write_json(
+            source_path,
+            {
+                "schema_version": 1,
+                "actions": [
+                    {
+                        "id": "personal_task_manager",
+                        "title": "Task Manager",
+                        "target_kind": "app",
+                        "target": "notepad.exe",
+                        "aliases": ["open task manager", "launch task manager"],
+                    }
+                ],
+            },
+        )
+
+        saved_actions = load_saved_command_actions(source_path)
+        catalog = build_default_command_action_catalog(source_path)
+
+        _assert(
+            len(saved_actions) == 1 and saved_actions[0].id == "personal_task_manager",
+            "a saved action with a built-in phrase collision should remain loadable",
+        )
+        _assert(
+            catalog.saved_action_inventory.status_kind == "loaded",
+            "built-in phrase overrides should remain visible as loaded saved actions",
+        )
+        for phrase in ("task manager", "open task manager", "launch task manager"):
+            resolved = catalog.resolve_actions(phrase)
+            _assert(
+                _ids(resolved) == ("personal_task_manager",),
+                f"saved action should resolve instead of the built-in for {phrase!r}",
+            )
+            _assert(
+                resolved[0].origin == "saved",
+                "built-in phrase overrides should preserve saved origin metadata",
+            )
+
+
+def _test_calculator_saved_action_phrase_collision_overrides_builtin_resolution():
+    with tempfile.TemporaryDirectory() as temp_dir:
+        source_path = Path(temp_dir) / "saved_calculator_override.json"
+        _write_json(
+            source_path,
+            {
+                "schema_version": 1,
+                "actions": [
+                    {
+                        "id": "personal_calculator",
+                        "title": "Calculator",
+                        "target_kind": "app",
+                        "target": "notepad.exe",
+                        "aliases": ["open calculator", "launch calculator"],
+                    }
+                ],
+            },
+        )
+
+        saved_actions = load_saved_command_actions(source_path)
+        catalog = build_default_command_action_catalog(source_path)
+
+        _assert(
+            len(saved_actions) == 1 and saved_actions[0].id == "personal_calculator",
+            "a saved Calculator action with a built-in phrase collision should remain loadable",
+        )
+        _assert(
+            catalog.saved_action_inventory.status_kind == "loaded",
+            "Calculator built-in phrase overrides should remain visible as loaded saved actions",
+        )
+        for phrase in ("calculator", "open calculator", "launch calculator"):
+            resolved = catalog.resolve_actions(phrase)
+            _assert(
+                _ids(resolved) == ("personal_calculator",),
+                f"saved Calculator action should resolve instead of the built-in for {phrase!r}",
+            )
+            _assert(
+                resolved[0].origin == "saved",
+                "Calculator built-in phrase overrides should preserve saved origin metadata",
+            )
+
+
+def _test_notepad_saved_action_phrase_collision_overrides_builtin_resolution():
+    with tempfile.TemporaryDirectory() as temp_dir:
+        source_path = Path(temp_dir) / "saved_notepad_override.json"
+        _write_json(
+            source_path,
+            {
+                "schema_version": 1,
+                "actions": [
+                    {
+                        "id": "personal_notepad",
+                        "title": "Notepad",
+                        "target_kind": "app",
+                        "target": "calc.exe",
+                        "aliases": ["open notepad", "launch notepad"],
+                    }
+                ],
+            },
+        )
+
+        saved_actions = load_saved_command_actions(source_path)
+        catalog = build_default_command_action_catalog(source_path)
+
+        _assert(
+            len(saved_actions) == 1 and saved_actions[0].id == "personal_notepad",
+            "a saved Notepad action with a built-in phrase collision should remain loadable",
+        )
+        _assert(
+            catalog.saved_action_inventory.status_kind == "loaded",
+            "Notepad built-in phrase overrides should remain visible as loaded saved actions",
+        )
+        for phrase in ("notepad", "open notepad", "launch notepad"):
+            resolved = catalog.resolve_actions(phrase)
+            _assert(
+                _ids(resolved) == ("personal_notepad",),
+                f"saved Notepad action should resolve instead of the built-in for {phrase!r}",
+            )
+            _assert(
+                resolved[0].origin == "saved",
+                "Notepad built-in phrase overrides should preserve saved origin metadata",
+            )
+
+
+def _test_paint_saved_action_phrase_collision_overrides_builtin_resolution():
+    with tempfile.TemporaryDirectory() as temp_dir:
+        source_path = Path(temp_dir) / "saved_paint_override.json"
+        _write_json(
+            source_path,
+            {
+                "schema_version": 1,
+                "actions": [
+                    {
+                        "id": "personal_paint",
+                        "title": "Paint",
+                        "target_kind": "app",
+                        "target": "notepad.exe",
+                        "aliases": ["open paint", "launch paint"],
+                    }
+                ],
+            },
+        )
+
+        saved_actions = load_saved_command_actions(source_path)
+        catalog = build_default_command_action_catalog(source_path)
+
+        _assert(
+            len(saved_actions) == 1 and saved_actions[0].id == "personal_paint",
+            "a saved Paint action with a built-in phrase collision should remain loadable",
+        )
+        _assert(
+            catalog.saved_action_inventory.status_kind == "loaded",
+            "Paint built-in phrase overrides should remain visible as loaded saved actions",
+        )
+        for phrase in ("paint", "open paint", "launch paint"):
+            resolved = catalog.resolve_actions(phrase)
+            _assert(
+                _ids(resolved) == ("personal_paint",),
+                f"saved Paint action should resolve instead of the built-in for {phrase!r}",
+            )
+            _assert(
+                resolved[0].origin == "saved",
+                "Paint built-in phrase overrides should preserve saved origin metadata",
+            )
+
+
 def _test_unsupported_target_kind_fails_closed():
     with tempfile.TemporaryDirectory() as temp_dir:
         source_path = Path(temp_dir) / "unsupported_target_kind.json"
@@ -341,7 +513,7 @@ def _test_duplicate_saved_ids_fail_closed():
         )
 
 
-def _test_duplicate_saved_phrases_fail_closed():
+def _test_duplicate_saved_phrases_resolve_as_ambiguity():
     with tempfile.TemporaryDirectory() as temp_dir:
         source_path = Path(temp_dir) / "duplicate_phrases.json"
         _write_json(
@@ -367,13 +539,20 @@ def _test_duplicate_saved_phrases_fail_closed():
             },
         )
 
+        saved_actions = load_saved_command_actions(source_path)
+        catalog = build_default_command_action_catalog(source_path)
+
         _assert(
-            load_saved_command_actions(source_path) == (),
-            "duplicate saved-action titles or aliases should fail closed to no saved actions",
+            _ids(saved_actions) == ("open_reports", "open_reports_archive"),
+            "saved-vs-saved exact phrase overlaps should remain loadable ambiguity candidates",
+        )
+        _assert(
+            _ids(catalog.resolve_actions("show reports")) == ("open_reports", "open_reports_archive"),
+            "saved-vs-saved exact phrase overlaps should resolve as an explicit ambiguity set",
         )
 
 
-def _test_builtin_collisions_fail_closed():
+def _test_builtin_id_collisions_fail_closed():
     with tempfile.TemporaryDirectory() as temp_dir:
         source_path = Path(temp_dir) / "builtin_collision.json"
         _write_json(
@@ -394,11 +573,11 @@ def _test_builtin_collisions_fail_closed():
 
         _assert(
             load_saved_command_actions(source_path) == (),
-            "collisions against built-in ids or phrases should fail closed to no saved actions",
+            "collisions against built-in ids should fail closed to no saved actions",
         )
         _assert(
             build_default_command_action_catalog(source_path).saved_action_inventory.status_kind == "invalid_saved_actions",
-            "built-in collisions should remain visible as invalid saved-action entries",
+            "built-in id collisions should remain visible as invalid saved-action entries",
         )
 
 
@@ -409,12 +588,16 @@ def main():
         ("empty and invalid source fallback", _test_empty_or_invalid_custom_sources_fail_closed),
         ("valid saved actions extend catalog", _test_valid_saved_actions_extend_the_effective_catalog),
         ("valid url saved actions extend catalog", _test_valid_url_saved_actions_extend_the_effective_catalog),
+        ("saved action phrase collision overrides built-in resolution", _test_saved_action_phrase_collision_overrides_builtin_resolution),
+        ("Calculator saved action phrase collision overrides built-in resolution", _test_calculator_saved_action_phrase_collision_overrides_builtin_resolution),
+        ("Notepad saved action phrase collision overrides built-in resolution", _test_notepad_saved_action_phrase_collision_overrides_builtin_resolution),
+        ("Paint saved action phrase collision overrides built-in resolution", _test_paint_saved_action_phrase_collision_overrides_builtin_resolution),
         ("unsupported target kind fails closed", _test_unsupported_target_kind_fails_closed),
         ("invalid url targets fail closed", _test_invalid_url_targets_fail_closed),
         ("invalid non-url targets fail closed", _test_invalid_non_url_targets_fail_closed),
         ("duplicate saved ids fail closed", _test_duplicate_saved_ids_fail_closed),
-        ("duplicate saved phrases fail closed", _test_duplicate_saved_phrases_fail_closed),
-        ("built-in collisions fail closed", _test_builtin_collisions_fail_closed),
+        ("duplicate saved phrases resolve as ambiguity", _test_duplicate_saved_phrases_resolve_as_ambiguity),
+        ("built-in id collisions fail closed", _test_builtin_id_collisions_fail_closed),
     ]
 
     for name, fn in tests:

--- a/dev/orin_shared_action_baseline_validation.py
+++ b/dev/orin_shared_action_baseline_validation.py
@@ -122,6 +122,206 @@ def _test_builtin_catalog_integrity():
             _assert(normalize_command_text(alias), f"{action.id} aliases should normalize to non-empty phrases")
 
 
+def _test_task_manager_builtin_catalog_entry():
+    matches = tuple(action for action in DEFAULT_COMMAND_ACTIONS if action.id == "open_task_manager")
+
+    _assert(len(matches) == 1, "the Task Manager built-in should exist exactly once")
+    action = matches[0]
+    _assert(action.title == "Open Task Manager", "the Task Manager built-in should keep the intended title")
+    _assert(action.target_kind == "app", "the Task Manager built-in should use the existing app target kind")
+    _assert(action.target == "taskmgr.exe", "the Task Manager built-in should launch taskmgr.exe")
+    _assert(action.origin == "built_in", "the Task Manager built-in should preserve built-in origin metadata")
+    _assert(
+        action.aliases == ("open task manager", "task manager", "launch task manager"),
+        "the Task Manager built-in should expose the approved exact aliases",
+    )
+
+    catalog = CommandActionCatalog()
+    for phrase in ("open task manager", "task manager", "launch task manager"):
+        _assert(
+            _ids(catalog.resolve_actions(phrase)) == ("open_task_manager",),
+            f"{phrase!r} should resolve to the Task Manager built-in",
+        )
+
+
+def _test_calculator_builtin_catalog_entry():
+    matches = tuple(action for action in DEFAULT_COMMAND_ACTIONS if action.id == "open_calculator")
+
+    _assert(len(matches) == 1, "the Calculator built-in should exist exactly once")
+    action = matches[0]
+    _assert(action.title == "Open Calculator", "the Calculator built-in should keep the intended title")
+    _assert(action.target_kind == "app", "the Calculator built-in should use the existing app target kind")
+    _assert(action.target == "calc.exe", "the Calculator built-in should launch calc.exe")
+    _assert(action.origin == "built_in", "the Calculator built-in should preserve built-in origin metadata")
+    _assert(
+        action.aliases == ("open calculator", "calculator", "launch calculator"),
+        "the Calculator built-in should expose the approved exact aliases",
+    )
+
+    catalog = CommandActionCatalog()
+    for phrase in ("open calculator", "calculator", "launch calculator"):
+        _assert(
+            _ids(catalog.resolve_actions(phrase)) == ("open_calculator",),
+            f"{phrase!r} should resolve to the Calculator built-in",
+        )
+
+
+def _test_notepad_builtin_catalog_entry():
+    matches = tuple(action for action in DEFAULT_COMMAND_ACTIONS if action.id == "open_notepad")
+
+    _assert(len(matches) == 1, "the Notepad built-in should exist exactly once")
+    action = matches[0]
+    _assert(action.title == "Open Notepad", "the Notepad built-in should keep the intended title")
+    _assert(action.target_kind == "app", "the Notepad built-in should use the existing app target kind")
+    _assert(action.target == "notepad.exe", "the Notepad built-in should launch notepad.exe")
+    _assert(action.origin == "built_in", "the Notepad built-in should preserve built-in origin metadata")
+    _assert(
+        action.aliases == ("open notepad", "notepad", "launch notepad"),
+        "the Notepad built-in should expose the approved exact aliases",
+    )
+
+    catalog = CommandActionCatalog()
+    for phrase in ("open notepad", "notepad", "launch notepad"):
+        _assert(
+            _ids(catalog.resolve_actions(phrase)) == ("open_notepad",),
+            f"{phrase!r} should resolve to the Notepad built-in",
+        )
+
+
+def _test_paint_builtin_catalog_entry():
+    matches = tuple(action for action in DEFAULT_COMMAND_ACTIONS if action.id == "open_paint")
+
+    _assert(len(matches) == 1, "the Paint built-in should exist exactly once")
+    action = matches[0]
+    _assert(action.title == "Open Paint", "the Paint built-in should keep the intended title")
+    _assert(action.target_kind == "app", "the Paint built-in should use the existing app target kind")
+    _assert(action.target == "mspaint.exe", "the Paint built-in should launch mspaint.exe")
+    _assert(action.origin == "built_in", "the Paint built-in should preserve built-in origin metadata")
+    _assert(
+        action.aliases == ("open paint", "paint", "launch paint"),
+        "the Paint built-in should expose the approved exact aliases",
+    )
+
+    catalog = CommandActionCatalog()
+    for phrase in ("open paint", "paint", "launch paint"):
+        _assert(
+            _ids(catalog.resolve_actions(phrase)) == ("open_paint",),
+            f"{phrase!r} should resolve to the Paint built-in",
+        )
+
+
+def _test_saved_actions_override_builtin_phrase_collisions():
+    saved_action = CommandAction(
+        id="personal_task_manager",
+        title="Task Manager",
+        target_kind="app",
+        target="notepad.exe",
+        aliases=("open task manager", "launch task manager"),
+        origin="saved",
+    )
+    catalog = CommandActionCatalog((*DEFAULT_COMMAND_ACTIONS, saved_action))
+
+    for phrase in ("task manager", "open task manager", "launch task manager"):
+        resolved = catalog.resolve_actions(phrase)
+        _assert(
+            _ids(resolved) == ("personal_task_manager",),
+            f"saved actions should override built-in phrase collisions for {phrase!r}",
+        )
+        _assert(
+            resolved[0].origin == "saved",
+            "saved-action phrase collisions should resolve to saved origin metadata",
+        )
+
+    _assert(
+        _ids(catalog.resolve_actions("open file explorer")) == ("open_windows_explorer",),
+        "built-ins should remain the fallback when no saved action matches the phrase",
+    )
+
+
+def _test_saved_actions_override_calculator_builtin_phrase_collisions():
+    saved_action = CommandAction(
+        id="personal_calculator",
+        title="Calculator",
+        target_kind="app",
+        target="notepad.exe",
+        aliases=("open calculator", "launch calculator"),
+        origin="saved",
+    )
+    catalog = CommandActionCatalog((*DEFAULT_COMMAND_ACTIONS, saved_action))
+
+    for phrase in ("calculator", "open calculator", "launch calculator"):
+        resolved = catalog.resolve_actions(phrase)
+        _assert(
+            _ids(resolved) == ("personal_calculator",),
+            f"saved actions should override Calculator built-in phrase collisions for {phrase!r}",
+        )
+        _assert(
+            resolved[0].origin == "saved",
+            "Calculator phrase collisions should resolve to saved origin metadata",
+        )
+
+    _assert(
+        _ids(catalog.resolve_actions("open file explorer")) == ("open_windows_explorer",),
+        "built-ins should remain the fallback after the Calculator saved-action override check",
+    )
+
+
+def _test_saved_actions_override_notepad_builtin_phrase_collisions():
+    saved_action = CommandAction(
+        id="personal_notepad",
+        title="Notepad",
+        target_kind="app",
+        target="calc.exe",
+        aliases=("open notepad", "launch notepad"),
+        origin="saved",
+    )
+    catalog = CommandActionCatalog((*DEFAULT_COMMAND_ACTIONS, saved_action))
+
+    for phrase in ("notepad", "open notepad", "launch notepad"):
+        resolved = catalog.resolve_actions(phrase)
+        _assert(
+            _ids(resolved) == ("personal_notepad",),
+            f"saved actions should override Notepad built-in phrase collisions for {phrase!r}",
+        )
+        _assert(
+            resolved[0].origin == "saved",
+            "Notepad phrase collisions should resolve to saved origin metadata",
+        )
+
+    _assert(
+        _ids(catalog.resolve_actions("open file explorer")) == ("open_windows_explorer",),
+        "built-ins should remain the fallback after the Notepad saved-action override check",
+    )
+
+
+def _test_saved_actions_override_paint_builtin_phrase_collisions():
+    saved_action = CommandAction(
+        id="personal_paint",
+        title="Paint",
+        target_kind="app",
+        target="notepad.exe",
+        aliases=("open paint", "launch paint"),
+        origin="saved",
+    )
+    catalog = CommandActionCatalog((*DEFAULT_COMMAND_ACTIONS, saved_action))
+
+    for phrase in ("paint", "open paint", "launch paint"):
+        resolved = catalog.resolve_actions(phrase)
+        _assert(
+            _ids(resolved) == ("personal_paint",),
+            f"saved actions should override Paint built-in phrase collisions for {phrase!r}",
+        )
+        _assert(
+            resolved[0].origin == "saved",
+            "Paint phrase collisions should resolve to saved origin metadata",
+        )
+
+    _assert(
+        _ids(catalog.resolve_actions("open file explorer")) == ("open_windows_explorer",),
+        "built-ins should remain the fallback after the Paint saved-action override check",
+    )
+
+
 def _test_url_target_support_is_first_class():
     _assert("url" in SUPPORTED_ACTION_TARGET_KINDS, "url targets should be a supported action target kind")
 
@@ -200,6 +400,14 @@ def main():
         ("exact match contract", _test_exact_match_contract_on_custom_catalog),
         ("ambiguous match contract", _test_ambiguous_match_contract_on_custom_catalog),
         ("built-in catalog integrity", _test_builtin_catalog_integrity),
+        ("task manager built-in catalog entry", _test_task_manager_builtin_catalog_entry),
+        ("calculator built-in catalog entry", _test_calculator_builtin_catalog_entry),
+        ("notepad built-in catalog entry", _test_notepad_builtin_catalog_entry),
+        ("paint built-in catalog entry", _test_paint_builtin_catalog_entry),
+        ("saved actions override built-in phrase collisions", _test_saved_actions_override_builtin_phrase_collisions),
+        ("saved actions override Calculator built-in phrase collisions", _test_saved_actions_override_calculator_builtin_phrase_collisions),
+        ("saved actions override Notepad built-in phrase collisions", _test_saved_actions_override_notepad_builtin_phrase_collisions),
+        ("saved actions override Paint built-in phrase collisions", _test_saved_actions_override_paint_builtin_phrase_collisions),
         ("url target support", _test_url_target_support_is_first_class),
         ("url launch path", _test_url_launch_uses_system_handler_without_path_normalization),
         ("default catalog wrapper", _test_default_catalog_wrapper_preserves_builtin_catalog),


### PR DESCRIPTION
## Summary

Updates FB-037: Curated built-in actions and PR-readiness canon.

## What Changed

- Adds the curated built-in Windows utility catalog actions for Task Manager, Calculator, Notepad, and Paint while preserving saved-action precedence.
- Hardens validation coverage and reusable live-validation helper behavior for FB-037 closeout evidence.
- Aligns governance for bounded multi-seam execution, PR Readiness blockers, post-merge release debt, and selected-next FB-038 canon without creating the FB-038 branch.

- Adds the curated built-in Windows utility catalog actions for Task Manager, Calculator, Notepad, and Paint while preserving saved-action precedence.
- Hardens validation coverage and reusable live-validation helper behavior for FB-037 closeout evidence.
- Aligns governance for bounded multi-seam execution, PR Readiness blockers, post-merge release debt, and selected-next FB-038 canon without creating the FB-038 branch.
