### PR TITLE
codex/fb-037-release-debt-packaging

### DIFF
--- a/Docs/Main.md
+++ b/Docs/Main.md
@@ -231,6 +231,13 @@ These are reference layers, not active workstream or roadmap owners.
   12. commit all required docs, canon, validator, and branch-truth changes so the worktree is clean and truth is durable in commit history
   13. run the normal branch governance validator and the PR-readiness gate mode
   14. only then allow the current branch to report `PR READY: YES` and enter PR creation
+- the normal `Release Readiness` sequence for a release-bearing branch must clear `Release Target Undefined` before reporting green:
+  1. confirm whether the branch is release-bearing or explicitly non-release
+  2. for release-bearing branches, require machine-checkable `Release Target:`, `Release Scope:`, and `Release Artifacts:` markers in the active authority record
+  3. for non-release branches, require `Release Branch: No`
+  4. allow `Release Branch: No` only for `docs/governance` branches or explicitly canon-only / repo-wide source-of-truth update branches
+  5. never use the non-release waiver for `implementation` or `release packaging` branches
+  6. never let the waiver clear `Release Debt`, weaken post-merge truth, weaken validation, or permit premature next-workstream branch creation
 - a standalone post-release canon repair is an emergency-only exception path when merged canon is already stale or when external drift made pre-merge prevention impossible
 - returned `UTS`, screenshot, interactive, PR-review, or release-review evidence must be digested into the authority record before phase advancement is recommended
 - when a slice changes user-visible behavior or another operator-facing path, do not treat `## User Test Summary` as a recap slot; route through `Docs/user_test_summary_guidance.md` and require a real manual checklist unless no meaningful manual test exists

--- a/Docs/Main.md
+++ b/Docs/Main.md
@@ -149,7 +149,7 @@ Use these for closeout policy, historical closeout lookup, and the modern Nexus-
 
 - `Docs/closeout_guidance.md`
 - `Docs/closeout_index.md`
-- `Docs/closeouts/nexus_prebeta_rebaseline_through_v1.3.1-prebeta.md`
+- `Docs/closeouts/nexus_prebeta_rebaseline_through_v1.4.0-prebeta.md`
 
 Historical closeout leaf docs are intentionally routed through `Docs/closeout_index.md`.
 

--- a/Docs/branch_records/codex_fb_037_release_debt_packaging.md
+++ b/Docs/branch_records/codex_fb_037_release_debt_packaging.md
@@ -14,7 +14,7 @@ This branch exists to prepare the public prerelease, release-state canon transit
 
 ## Current Phase
 
-- Phase: `Hardening`
+- Phase: `Live Validation`
 
 ## Phase Status
 
@@ -23,7 +23,7 @@ This branch exists to prepare the public prerelease, release-state canon transit
 - local `main`, `origin/main`, and this branch resolve to merge commit `d1277e65cf348073c73f636c8dd1b5965543f1a8`
 - FB-037 remains `Merged unreleased on main`
 - FB-038 remains selected in canon only and has no branch
-- Branch Readiness and Workstream Slice 1 are complete; release-packaging Hardening is open for artifact pressure review before Live Validation
+- Branch Readiness, Workstream Slice 1, and release-artifact Hardening are complete; release-packaging Live Validation is open for release-boundary proof before PR Readiness
 
 ## Branch Class
 
@@ -37,7 +37,7 @@ This branch exists to prepare the public prerelease, release-state canon transit
 
 ## Blockers
 
-- no active branch blockers
+- None
 
 ## Entry Basis
 
@@ -52,21 +52,20 @@ This branch exists to prepare the public prerelease, release-state canon transit
 
 ## Exit Criteria
 
-- release target remains correct and aligned with the roadmap
-- release scope remains bounded to the merged FB-037 built-in catalog milestone
-- release notes, draft rebaseline, and release-state transition checklist remain internally consistent
-- no tag, publish step, released-state canon update, or `Release Debt` clearance has occurred
+- release-boundary validation confirms the target, scope, notes, draft rebaseline, and transition checklist remain complete and internally consistent
+- validation confirms no tag, publish step, released-state canon update, or `Release Debt` clearance has occurred
+- validation confirms the draft rebaseline remains inactive and does not contradict the active `v1.3.1-prebeta` baseline
 - no product or runtime work is introduced
 - FB-038 remains unbranched until FB-037 release debt is cleared and updated `main` is revalidated
-- direct validation proves FB-037 still remains merged unreleased until the release execution slice performs the actual release
+- Live Validation evidence is digested into this authority record before PR Readiness is recommended
 
 ## Rollback Target
 
-- `Workstream`
+- `Hardening`
 
 ## Next Legal Phase
 
-- `Live Validation`
+- `PR Readiness`
 
 ## Target Release Version
 
@@ -159,6 +158,19 @@ Continuation rule:
 - no tag exists, no release was published, no released-state canon updates were applied, and `Release Debt` remains active
 - no product or runtime work was introduced
 - phase authority transitioned from `Workstream` to `Hardening`
+
+## Hardening Progress
+
+- Hardening complete:
+  `Release Artifact Pressure Review`
+- release target `v1.4.0-prebeta` remains correct and roadmap-aligned
+- release scope remains bounded to FB-037 delivered behavior
+- draft release notes do not overclaim settings, protocol, new target-kind, launcher-policy, UI, callable-group, or FB-038 work
+- draft rebaseline remains internally consistent and explicitly inactive until release execution
+- release-state transition checklist is complete, ordered, and preserves FB-038 branch deferral
+- no tag exists, no release was published, no released-state canon updates were applied, and `Release Debt` remains active
+- no product or runtime work was introduced
+- phase authority transitioned from `Hardening` to `Live Validation`
 
 ## Slice 1 Draft Release Notes
 
@@ -308,6 +320,18 @@ Hardening validation must prove:
 - draft rebaseline remains inactive until release execution
 - no `v1.4.0-prebeta` tag exists before release execution
 - FB-037 remains `Merged unreleased on main` with `Release Debt` active
+- FB-038 remains selected in canon only and no FB-038 branch exists
+- no product or runtime files changed
+
+Live Validation must prove:
+
+- branch authority record now owns `Live Validation` for this release-packaging branch
+- release-boundary evidence confirms `v1.4.0-prebeta` remains planned and unreleased
+- `Release Debt` remains active until release execution
+- draft rebaseline remains inactive until release execution
+- no `v1.4.0-prebeta` tag exists before release execution
+- no release was published
+- no released-state canon updates were applied
 - FB-038 remains selected in canon only and no FB-038 branch exists
 - no product or runtime files changed
 

--- a/Docs/branch_records/codex_fb_037_release_debt_packaging.md
+++ b/Docs/branch_records/codex_fb_037_release_debt_packaging.md
@@ -22,11 +22,13 @@ This branch exists to prepare the public prerelease, release-state canon transit
 - branch was created from updated `main`
 - local `main` and `origin/main` resolve to merge commit `d1277e65cf348073c73f636c8dd1b5965543f1a8`
 - this branch is based on that merge commit and carries release-packaging commits on top of it
-- FB-037 remains `Merged unreleased on main`
+- FB-037 is released as `v1.4.0-prebeta` on this release-execution branch
+- FB-037 `Release Debt` is cleared in release-state canon
 - FB-038 remains selected in canon only and has no branch
 - Branch Readiness, Workstream Slice 1, release-artifact Hardening, release-packaging Live Validation, and PR Readiness are complete
 - release-packaging PR Readiness closed after merge-target canon, release-boundary proof, successor branch deferral, Governance Drift Audit, and PR gate validation passed
-- Release Readiness is open for the release-execution authorization and execution pass; no tag, release, released-state canon update, `Release Debt` clearance, or FB-038 branch creation has occurred yet
+- Release Readiness executed the release-state canon transition for FB-037; Git tag `v1.4.0-prebeta` is the supported public release artifact in this environment
+- GitHub Release publication is not supported in this environment because `gh` and API credentials are unavailable; the API lookup remains the publication proof point
 
 ## Branch Class
 
@@ -36,7 +38,7 @@ This branch exists to prepare the public prerelease, release-state canon transit
 
 - Release Target: `v1.4.0-prebeta`
 - Release Scope: FB-037 curated built-in Windows utility catalog prerelease, including Task Manager, Calculator, Notepad, and Paint built-ins plus saved-action override, authoring collision, confirm/result preservation, callable-group regression preservation, and reusable helper proof support.
-- Release Artifacts: draft release notes, draft `Docs/closeouts/nexus_prebeta_rebaseline_through_v1.4.0-prebeta.md`, release-state transition checklist, `v1.4.0-prebeta` Git tag plan, and public prerelease notes plan.
+- Release Artifacts: release notes, active `Docs/closeouts/nexus_prebeta_rebaseline_through_v1.4.0-prebeta.md`, release-state transition checklist, `v1.4.0-prebeta` Git tag, and public prerelease notes content.
 
 ## Blockers
 
@@ -55,12 +57,12 @@ This branch exists to prepare the public prerelease, release-state canon transit
 
 ## Exit Criteria
 
-- release target, release scope, and release artifacts remain explicit and validated
-- release-boundary proof remains green before execution: no tag, publish step, released-state canon update, or `Release Debt` clearance has occurred
-- draft rebaseline remains inactive and does not contradict the active `v1.3.1-prebeta` baseline until release execution activates it
-- release-state transition checklist remains complete and ordered
-- release execution is run only by an explicit Release Readiness execution pass
-- FB-038 remains selected in canon only and unbranched until FB-037 release debt is cleared and updated `main` is revalidated
+- release target, release scope, and release artifacts are explicit and validated
+- release-state canon transitions mark FB-037 `Released (v1.4.0-prebeta)` and `Closed`
+- `Release Debt` for FB-037 is cleared
+- the `v1.4.0-prebeta` rebaseline is active
+- release-state transition checklist remains complete and ordered as historical proof
+- FB-038 remains selected in canon only and unbranched until updated `main` is revalidated
 - no product or runtime work is introduced
 
 ## Rollback Target
@@ -73,9 +75,9 @@ This branch exists to prepare the public prerelease, release-state canon transit
 
 ## Target Release Version
 
-- planned version: `v1.4.0-prebeta`
+- released version: `v1.4.0-prebeta`
 - basis: latest public prerelease is `v1.3.1-prebeta`, and FB-037 carries a `minor prerelease` release floor
-- release-state note: this planned version does not mark FB-037 released, clear `Release Debt`, create a tag, or publish a release
+- release-state note: release execution marks FB-037 released, clears `Release Debt`, activates the rebaseline, and creates the `v1.4.0-prebeta` Git tag
 
 ## Release Scope
 
@@ -91,9 +93,9 @@ FB-037 release packaging covers the merged built-in catalog expansion:
 - callable-group regression preservation from the released FB-041 baseline
 - reusable live-validation helper reliability improvements that supported FB-037 proof
 
-## Required Release-Facing Updates
+## Release-Facing Updates Applied
 
-The release execution slice must prepare or update:
+The release execution slice updates:
 
 - `Docs/feature_backlog.md`
   - move FB-037 from `Merged unreleased on main` to `Released (v1.4.0-prebeta)`
@@ -113,7 +115,7 @@ The release execution slice must prepare or update:
 - `Docs/closeout_index.md`
   - update the current Nexus-era baseline pointer if a new rebaseline is created
 - `Docs/closeouts/nexus_prebeta_rebaseline_through_v1.4.0-prebeta.md`
-  - draft prepared in Slice 1; becomes active only after release execution updates `Docs/closeout_index.md`
+  - activate the Slice 1 draft as the current Nexus-era rebaseline
 - Git tag and release artifacts
   - tag: `v1.4.0-prebeta`
   - release notes covering the FB-037 built-in catalog milestone
@@ -221,9 +223,22 @@ Continuation rule:
   - no product or runtime work was introduced
 - phase authority transitioned from `PR Readiness` to `Release Readiness`
 
-## Slice 1 Draft Release Notes
+## Release Execution Progress
 
-Draft release notes for `v1.4.0-prebeta`:
+- Release Readiness release execution complete for FB-037.
+- release-state canon marks FB-037 `Released (v1.4.0-prebeta)` and `Closed`
+- `Release Debt` for FB-037 is cleared
+- `Docs/closeouts/nexus_prebeta_rebaseline_through_v1.4.0-prebeta.md` is active
+- `Docs/closeout_index.md` points to the `v1.4.0-prebeta` rebaseline
+- release notes are preserved in this branch record
+- Git tag: `v1.4.0-prebeta`
+- GitHub Release publication: unsupported in this environment because no `gh` CLI or API token is available
+- FB-038 remains selected in canon only and unbranched
+- no product or runtime work was introduced
+
+## Release Notes
+
+Release notes for `v1.4.0-prebeta`:
 
 Title:
 
@@ -270,11 +285,11 @@ Validation evidence:
 - Draft file prepared:
   - `Docs/closeouts/nexus_prebeta_rebaseline_through_v1.4.0-prebeta.md`
 - Activation rule:
-  - this draft must not become the active baseline until the release execution pass creates or confirms the `v1.4.0-prebeta` tag, updates release-state canon, and points `Docs/closeout_index.md` at the new baseline.
+  - release execution activates this baseline by creating the `v1.4.0-prebeta` tag, updating release-state canon, and pointing `Docs/closeout_index.md` at the new baseline.
 
 ## Slice 1 Release-State Transition Checklist
 
-Later release execution must perform these steps in order:
+Release execution performed these steps in order:
 
 1. Confirm `v1.4.0-prebeta` tag does not already exist.
 2. Confirm no FB-038 branch exists.
@@ -324,15 +339,15 @@ Later release execution must perform these steps in order:
 - no settings or protocol behavior
 - no launcher-policy changes
 - no UI or confirm/result changes
-- no release tag creation before an explicit release execution pass
-- no marking FB-037 released before an explicit release execution pass
+- no release tag creation before the explicit Release Readiness execution pass
+- no marking FB-037 released before the explicit Release Readiness execution pass
 - no FB-038 branch creation
 - no next implementation admission work
 
 ## Reuse Baseline
 
 - `Docs/workstreams/FB-037_built_in_actions_and_settings_expansion.md`
-- `Docs/closeouts/nexus_prebeta_rebaseline_through_v1.3.1-prebeta.md`
+- `Docs/closeouts/nexus_prebeta_rebaseline_through_v1.4.0-prebeta.md`
 - `Docs/prebeta_roadmap.md`
 - `Docs/feature_backlog.md`
 - `Docs/workstreams/index.md`
@@ -340,51 +355,51 @@ Later release execution must perform these steps in order:
 
 ## Validation Contract
 
-Branch Readiness validation must prove:
+Branch Readiness validation proved:
 
 - branch authority record exists and declares `release packaging`
 - branch authority record carries `Release Target:`, `Release Scope:`, and `Release Artifacts:`
 - branch remains based on updated `main`
-- FB-037 remains merged unreleased until release execution
-- planned target version does not imply release completion
+- FB-037 remained merged unreleased until release execution
+- planned target version did not imply release completion
 - FB-038 remains selected in canon only and no FB-038 branch exists
 - no product or runtime files changed
 - `python dev/orin_branch_governance_validation.py` passes
 - `git diff --check` passes
 
-Workstream planning validation must prove:
+Workstream planning validation proved:
 
 - branch authority record now owns `Workstream` for this release-packaging branch
 - branch authority record keeps explicit release-bearing markers for `Release Target:`, `Release Scope:`, and `Release Artifacts:`
-- FB-037 remains `Merged unreleased on main`
-- `Release Debt` remains active until release execution
-- planned target version does not imply release completion
+- FB-037 remained `Merged unreleased on main`
+- `Release Debt` remained active until release execution
+- planned target version did not imply release completion
 - FB-038 remains selected in canon only and no FB-038 branch exists
 - no product or runtime files changed
 
-Hardening validation must prove:
+Hardening validation proved:
 
 - branch authority record now owns `Hardening` for this release-packaging branch
 - release artifact set remains complete and internally consistent
-- draft rebaseline remains inactive until release execution
-- no `v1.4.0-prebeta` tag exists before release execution
-- FB-037 remains `Merged unreleased on main` with `Release Debt` active
+- draft rebaseline remained inactive until release execution
+- no `v1.4.0-prebeta` tag existed before release execution
+- FB-037 remained `Merged unreleased on main` with `Release Debt` active
 - FB-038 remains selected in canon only and no FB-038 branch exists
 - no product or runtime files changed
 
-Live Validation must prove:
+Live Validation proved:
 
 - branch authority record now owns `Live Validation` for this release-packaging branch
-- release-boundary evidence confirms `v1.4.0-prebeta` remains planned and unreleased
-- `Release Debt` remains active until release execution
-- draft rebaseline remains inactive until release execution
-- no `v1.4.0-prebeta` tag exists before release execution
-- no release was published
-- no released-state canon updates were applied
+- release-boundary evidence confirmed `v1.4.0-prebeta` remained planned and unreleased
+- `Release Debt` remained active until release execution
+- draft rebaseline remained inactive until release execution
+- no `v1.4.0-prebeta` tag existed before release execution
+- no release was published before release execution
+- no released-state canon updates were applied before release execution
 - FB-038 remains selected in canon only and no FB-038 branch exists
 - no product or runtime files changed
 
-Release execution validation must later prove:
+Release execution validation must prove:
 
 - release-state canon transitions are complete
 - release artifacts are present and internally consistent

--- a/Docs/branch_records/codex_fb_037_release_debt_packaging.md
+++ b/Docs/branch_records/codex_fb_037_release_debt_packaging.md
@@ -1,0 +1,321 @@
+# Branch Authority Record: codex/fb-037-release-debt-packaging
+
+## Branch Identity
+
+- Branch: `codex/fb-037-release-debt-packaging`
+- Workstream: `FB-037`
+- Branch Class: `release packaging`
+
+## Purpose / Why It Exists
+
+Open the release-packaging lane for FB-037 after the implementation branch merged to `main` as unreleased implementation debt.
+
+This branch exists to prepare the public prerelease, release-state canon transitions, baseline or release-note artifacts, and tag/release plan needed to clear `Release Debt` for FB-037 without admitting FB-038 or reopening product implementation work.
+
+## Current Phase
+
+- Phase: `Hardening`
+
+## Phase Status
+
+- `Active Branch`
+- branch was created from updated `main`
+- local `main`, `origin/main`, and this branch resolve to merge commit `d1277e65cf348073c73f636c8dd1b5965543f1a8`
+- FB-037 remains `Merged unreleased on main`
+- FB-038 remains selected in canon only and has no branch
+- Branch Readiness and Workstream Slice 1 are complete; release-packaging Hardening is open for artifact pressure review before Live Validation
+
+## Branch Class
+
+- `release packaging`
+
+## Release-Bearing Markers
+
+- Release Target: `v1.4.0-prebeta`
+- Release Scope: FB-037 curated built-in Windows utility catalog prerelease, including Task Manager, Calculator, Notepad, and Paint built-ins plus saved-action override, authoring collision, confirm/result preservation, callable-group regression preservation, and reusable helper proof support.
+- Release Artifacts: draft release notes, draft `Docs/closeouts/nexus_prebeta_rebaseline_through_v1.4.0-prebeta.md`, release-state transition checklist, `v1.4.0-prebeta` Git tag plan, and public prerelease notes plan.
+
+## Blockers
+
+- no active branch blockers
+
+## Entry Basis
+
+- updated `main` is aligned with `origin/main`
+- FB-037 is the current merged-unreleased release-debt owner
+- repo truth before this branch resolves to `Release Readiness`, `No Active Branch`, and `Release Debt` (FB-037)
+- the release floor for FB-037 is `minor prerelease`
+- latest public prerelease is `v1.3.1-prebeta`
+- target release version is planned as `v1.4.0-prebeta`
+- FB-038 is selected as the next implementation workstream in canon only
+- no FB-038 branch exists
+
+## Exit Criteria
+
+- release target remains correct and aligned with the roadmap
+- release scope remains bounded to the merged FB-037 built-in catalog milestone
+- release notes, draft rebaseline, and release-state transition checklist remain internally consistent
+- no tag, publish step, released-state canon update, or `Release Debt` clearance has occurred
+- no product or runtime work is introduced
+- FB-038 remains unbranched until FB-037 release debt is cleared and updated `main` is revalidated
+- direct validation proves FB-037 still remains merged unreleased until the release execution slice performs the actual release
+
+## Rollback Target
+
+- `Workstream`
+
+## Next Legal Phase
+
+- `Live Validation`
+
+## Target Release Version
+
+- planned version: `v1.4.0-prebeta`
+- basis: latest public prerelease is `v1.3.1-prebeta`, and FB-037 carries a `minor prerelease` release floor
+- release-state note: this planned version does not mark FB-037 released, clear `Release Debt`, create a tag, or publish a release
+
+## Release Scope
+
+FB-037 release packaging covers the merged built-in catalog expansion:
+
+- built-in Task Manager action
+- built-in Calculator action
+- built-in Notepad action
+- built-in Paint action
+- saved-action override authority over built-in aliases
+- authoring collision protection for built-in phrases
+- confirm/result flow preservation for built-ins and saved-action overrides
+- callable-group regression preservation from the released FB-041 baseline
+- reusable live-validation helper reliability improvements that supported FB-037 proof
+
+## Required Release-Facing Updates
+
+The release execution slice must prepare or update:
+
+- `Docs/feature_backlog.md`
+  - move FB-037 from `Merged unreleased on main` to `Released (v1.4.0-prebeta)`
+  - move `Record State` from `Promoted` to `Closed`
+  - clear `Release Debt`
+- `Docs/prebeta_roadmap.md`
+  - update latest public prerelease to `v1.4.0-prebeta`
+  - update latest public release commit to the release commit
+  - remove FB-037 from current release debt
+  - preserve FB-038 as selected-next canon only until Branch Readiness after release
+- `Docs/workstreams/index.md`
+  - move FB-037 from `Merged / Release Debt Owners` to `Closed`
+- `Docs/workstreams/FB-037_built_in_actions_and_settings_expansion.md`
+  - convert the current release-debt truth to released historical truth
+  - clear `Release Debt`
+  - finalize release evidence and release notes references
+- `Docs/closeout_index.md`
+  - update the current Nexus-era baseline pointer if a new rebaseline is created
+- `Docs/closeouts/nexus_prebeta_rebaseline_through_v1.4.0-prebeta.md`
+  - draft prepared in Slice 1; becomes active only after release execution updates `Docs/closeout_index.md`
+- Git tag and release artifacts
+  - tag: `v1.4.0-prebeta`
+  - release notes covering the FB-037 built-in catalog milestone
+
+## Workstream Slice Plan
+
+### Slice 1: Release Artifact And Transition Draft
+
+Boundary:
+
+- draft the `v1.4.0-prebeta` release notes content for FB-037
+- decide whether the release needs a new Nexus pre-Beta rebaseline file
+- if a rebaseline is needed, prepare the draft baseline file without changing latest-public-release truth yet
+- prepare the exact release-state transition checklist for the later release execution pass
+- keep FB-037 as `Merged unreleased on main` with `Release Debt` active until tag/release execution happens
+
+Explicit non-includes:
+
+- no product or runtime code changes
+- no release tag creation
+- no publishing
+- no marking FB-037 released
+- no clearing `Release Debt`
+- no FB-038 branch creation
+- no next implementation admission
+
+Validation target:
+
+- `python dev/orin_branch_governance_validation.py`
+- `git diff --check`
+- live branch check that no FB-038 branch exists
+- release-truth check that `v1.4.0-prebeta` does not already exist as a tag before release execution
+
+Continuation rule:
+
+- keep this as a single-slice Workstream plan until release artifacts are prepared and validated
+- do not run a multi-seam release execution chain because release notes, rebaseline, canon transition, tag creation, and publishing cross release-state boundaries and should be gated separately
+
+## Workstream Progress
+
+- Workstream Slice 1 complete:
+  `Release Artifact And Transition Draft`
+- release target review passed for `v1.4.0-prebeta`
+- release scope review passed and remains limited to FB-037 built-in catalog release packaging
+- draft release notes, draft rebaseline, and release-state transition checklist are complete and internally consistent
+- no tag exists, no release was published, no released-state canon updates were applied, and `Release Debt` remains active
+- no product or runtime work was introduced
+- phase authority transitioned from `Workstream` to `Hardening`
+
+## Slice 1 Draft Release Notes
+
+Draft release notes for `v1.4.0-prebeta`:
+
+Title:
+
+- `v1.4.0-prebeta - Curated built-in actions`
+
+Summary:
+
+- Adds the first curated built-in Windows utility catalog under the existing shared action model.
+- Built-ins now include Task Manager, Calculator, Notepad, and Paint.
+- Saved actions continue to win over built-ins when a saved action matches the same phrase.
+- Authoring collision protection prevents create/edit flows from silently overriding built-in phrases.
+- Confirm and result surfaces remain on the existing interaction flow.
+- Callable-group execution and single-action behavior remain unchanged.
+
+Included:
+
+- `open_task_manager` targeting `taskmgr.exe`
+- `open_calculator` targeting `calc.exe`
+- `open_notepad` targeting `notepad.exe`
+- `open_paint` targeting `mspaint.exe`
+- exact alias coverage for `open ...`, bare utility name, and `launch ...` phrases for each built-in
+- source-loaded saved-action override behavior for built-in phrase collisions
+- create/edit authoring rejection for built-in phrase collisions
+- manifest-backed Live Validation evidence across built-in execution, saved-action override, authoring boundary, mixed environment, and repeated execution scenarios
+
+Not included:
+
+- no Nexus settings or protocol actions
+- no new target kinds
+- no shell arguments or launcher-policy changes
+- no UI redesign or confirm/result copy changes
+- no callable-group behavior changes
+- no FB-038 taskbar/tray or Create Custom Task work
+
+Validation evidence:
+
+- repo-side shared-action, saved-action source, authoring, interaction, callable-group, and governance validators passed during the FB-037 implementation branch
+- closeout-grade Live Validation evidence is preserved at `dev\logs\launcher_live_window_audit\20260420_112713\manifest.json`
+
+## Slice 1 Rebaseline Decision
+
+- Rebaseline required: `Yes`
+- Reason: `v1.4.0-prebeta` is a minor prerelease that adds a user-facing built-in catalog milestone and materially updates the shared pre-Beta interaction baseline.
+- Draft file prepared:
+  - `Docs/closeouts/nexus_prebeta_rebaseline_through_v1.4.0-prebeta.md`
+- Activation rule:
+  - this draft must not become the active baseline until the release execution pass creates or confirms the `v1.4.0-prebeta` tag, updates release-state canon, and points `Docs/closeout_index.md` at the new baseline.
+
+## Slice 1 Release-State Transition Checklist
+
+Later release execution must perform these steps in order:
+
+1. Confirm `v1.4.0-prebeta` tag does not already exist.
+2. Confirm no FB-038 branch exists.
+3. Confirm FB-037 still remains `Promoted`, `Merged unreleased on main`, and blocked by `Release Debt`.
+4. Update `Docs/feature_backlog.md`:
+   - `Status: Released (v1.4.0-prebeta)`
+   - `Record State: Closed`
+   - `Target Version: v1.4.0-prebeta`
+   - remove FB-037 `Blocker: Release Debt`
+   - remove or replace the planned release-packaging target marker
+5. Update `Docs/prebeta_roadmap.md`:
+   - latest public prerelease: `v1.4.0-prebeta`
+   - latest public release commit: release execution commit
+   - remove FB-037 from current release debt
+   - move FB-037 into released or recently closed context
+   - keep FB-038 selected with `Branch: Not created`
+6. Update `Docs/workstreams/index.md`:
+   - remove FB-037 from `Merged / Release Debt Owners`
+   - add FB-037 under `Closed`
+7. Update `Docs/workstreams/FB-037_built_in_actions_and_settings_expansion.md`:
+   - set `Record State` to `Closed`
+   - set `Status` to `Released (v1.4.0-prebeta)`
+   - set `Target Version` to `v1.4.0-prebeta`
+   - clear the release-debt blocker
+   - convert the current release-debt note into historical released truth
+   - reference release notes and the `v1.4.0-prebeta` rebaseline
+8. Update `Docs/closeout_index.md`:
+   - point current Nexus-era baseline to `Docs/closeouts/nexus_prebeta_rebaseline_through_v1.4.0-prebeta.md`
+9. Finalize `Docs/closeouts/nexus_prebeta_rebaseline_through_v1.4.0-prebeta.md`:
+   - remove draft-only wording
+   - make it the active released baseline only after the tag/release step is authorized
+10. Update this branch authority record for PR-safe merge truth:
+    - move it from active branch authority to historical branch authority before PR readiness, or remove it if no durable record is needed
+11. Run:
+    - `python dev/orin_branch_governance_validation.py`
+    - `git diff --check`
+12. Create or confirm the Git tag:
+    - `v1.4.0-prebeta`
+13. Prepare/publish release notes using the Slice 1 draft notes above.
+14. Confirm no stale FB-037 `Release Debt` references remain in current-state canon.
+15. Confirm FB-038 remains unbranched until updated `main` is revalidated for Branch Readiness.
+
+## Explicit Non-Goals
+
+- no product or runtime code changes
+- no new built-in actions
+- no settings or protocol behavior
+- no launcher-policy changes
+- no UI or confirm/result changes
+- no release tag creation before an explicit release execution pass
+- no marking FB-037 released before an explicit release execution pass
+- no FB-038 branch creation
+- no next implementation admission work
+
+## Reuse Baseline
+
+- `Docs/workstreams/FB-037_built_in_actions_and_settings_expansion.md`
+- `Docs/closeouts/nexus_prebeta_rebaseline_through_v1.3.1-prebeta.md`
+- `Docs/prebeta_roadmap.md`
+- `Docs/feature_backlog.md`
+- `Docs/workstreams/index.md`
+- prior FB-037 Live Validation evidence at `dev\logs\launcher_live_window_audit\20260420_112713\manifest.json`
+
+## Validation Contract
+
+Branch Readiness validation must prove:
+
+- branch authority record exists and declares `release packaging`
+- branch authority record carries `Release Target:`, `Release Scope:`, and `Release Artifacts:`
+- branch remains based on updated `main`
+- FB-037 remains merged unreleased until release execution
+- planned target version does not imply release completion
+- FB-038 remains selected in canon only and no FB-038 branch exists
+- no product or runtime files changed
+- `python dev/orin_branch_governance_validation.py` passes
+- `git diff --check` passes
+
+Workstream planning validation must prove:
+
+- branch authority record now owns `Workstream` for this release-packaging branch
+- branch authority record keeps explicit release-bearing markers for `Release Target:`, `Release Scope:`, and `Release Artifacts:`
+- FB-037 remains `Merged unreleased on main`
+- `Release Debt` remains active until release execution
+- planned target version does not imply release completion
+- FB-038 remains selected in canon only and no FB-038 branch exists
+- no product or runtime files changed
+
+Hardening validation must prove:
+
+- branch authority record now owns `Hardening` for this release-packaging branch
+- release artifact set remains complete and internally consistent
+- draft rebaseline remains inactive until release execution
+- no `v1.4.0-prebeta` tag exists before release execution
+- FB-037 remains `Merged unreleased on main` with `Release Debt` active
+- FB-038 remains selected in canon only and no FB-038 branch exists
+- no product or runtime files changed
+
+Release execution validation must later prove:
+
+- release-state canon transitions are complete
+- release artifacts are present and internally consistent
+- `Release Target Undefined` is not active because release-bearing markers remain explicit
+- the release tag points to the intended release commit
+- no stale FB-037 release-debt references remain after release
+- next implementation admission remains deferred until updated `main` is revalidated

--- a/Docs/branch_records/codex_fb_037_release_debt_packaging.md
+++ b/Docs/branch_records/codex_fb_037_release_debt_packaging.md
@@ -14,7 +14,7 @@ This branch exists to prepare the public prerelease, release-state canon transit
 
 ## Current Phase
 
-- Phase: `Live Validation`
+- Phase: `PR Readiness`
 
 ## Phase Status
 
@@ -24,7 +24,7 @@ This branch exists to prepare the public prerelease, release-state canon transit
 - this branch is based on that merge commit and carries release-packaging commits on top of it
 - FB-037 remains `Merged unreleased on main`
 - FB-038 remains selected in canon only and has no branch
-- Branch Readiness, Workstream Slice 1, and release-artifact Hardening are complete; release-packaging Live Validation is open for release-boundary proof before PR Readiness
+- Branch Readiness, Workstream Slice 1, release-artifact Hardening, and release-packaging Live Validation are complete; release-packaging PR Readiness is open for merge-target canon, drift, branch-authority, and PR gate checks
 
 ## Branch Class
 
@@ -53,20 +53,22 @@ This branch exists to prepare the public prerelease, release-state canon transit
 
 ## Exit Criteria
 
-- release-boundary validation confirms the target, scope, notes, draft rebaseline, and transition checklist remain complete and internally consistent
-- validation confirms no tag, publish step, released-state canon update, or `Release Debt` clearance has occurred
-- validation confirms the draft rebaseline remains inactive and does not contradict the active `v1.3.1-prebeta` baseline
+- branch truth is durable in commit history and the worktree is clean
+- merge-target canon remains complete and still represents FB-037 as `Merged unreleased on main` with `Release Debt` active until release execution
+- release-boundary proof remains green: no tag, publish step, released-state canon update, or `Release Debt` clearance has occurred
+- draft rebaseline remains inactive and does not contradict the active `v1.3.1-prebeta` baseline
+- Governance Drift Audit is completed for the release-packaging branch
+- branch authority record is made merge-safe as historical truth or removed before PR completion
+- FB-038 remains selected in canon only and unbranched until FB-037 release debt is cleared and updated `main` is revalidated
 - no product or runtime work is introduced
-- FB-038 remains unbranched until FB-037 release debt is cleared and updated `main` is revalidated
-- Live Validation evidence is digested into this authority record before PR Readiness is recommended
 
 ## Rollback Target
 
-- `Hardening`
+- `Live Validation`
 
 ## Next Legal Phase
 
-- `PR Readiness`
+- `Release Readiness`
 
 ## Target Release Version
 
@@ -172,6 +174,24 @@ Continuation rule:
 - no tag exists, no release was published, no released-state canon updates were applied, and `Release Debt` remains active
 - no product or runtime work was introduced
 - phase authority transitioned from `Hardening` to `Live Validation`
+
+## Live Validation Progress
+
+- Live Validation complete:
+  `Release Boundary Proof`
+- branch-truth correction was made durable in commit `e1dd905`
+- release target `v1.4.0-prebeta` remains planned and unreleased
+- release scope remains bounded to FB-037 delivered built-in catalog behavior and supporting proof artifacts
+- draft release notes remain accurate and do not claim settings/protocol, new target-kind, launcher-policy, UI, callable-group, or FB-038 work
+- draft rebaseline remains explicitly inactive and does not override the active `v1.3.1-prebeta` baseline
+- release-state transition checklist remains complete and ordered for the later release execution pass
+- local tag check confirmed no `v1.4.0-prebeta` tag exists
+- remote tag check confirmed no `v1.4.0-prebeta` tag exists on `origin`
+- GitHub release lookup for `v1.4.0-prebeta` returned `404`
+- FB-037 remains `Merged unreleased on main` with `Release Debt` active
+- FB-038 remains selected in canon only and no local or remote FB-038 branch exists
+- no product or runtime work was introduced
+- phase authority transitioned from `Live Validation` to `PR Readiness`
 
 ## Slice 1 Draft Release Notes
 

--- a/Docs/branch_records/codex_fb_037_release_debt_packaging.md
+++ b/Docs/branch_records/codex_fb_037_release_debt_packaging.md
@@ -14,7 +14,7 @@ This branch exists to prepare the public prerelease, release-state canon transit
 
 ## Current Phase
 
-- Phase: `PR Readiness`
+- Phase: `Release Readiness`
 
 ## Phase Status
 
@@ -24,7 +24,9 @@ This branch exists to prepare the public prerelease, release-state canon transit
 - this branch is based on that merge commit and carries release-packaging commits on top of it
 - FB-037 remains `Merged unreleased on main`
 - FB-038 remains selected in canon only and has no branch
-- Branch Readiness, Workstream Slice 1, release-artifact Hardening, and release-packaging Live Validation are complete; release-packaging PR Readiness is open for merge-target canon, drift, branch-authority, and PR gate checks
+- Branch Readiness, Workstream Slice 1, release-artifact Hardening, release-packaging Live Validation, and PR Readiness are complete
+- release-packaging PR Readiness closed after merge-target canon, release-boundary proof, successor branch deferral, Governance Drift Audit, and PR gate validation passed
+- Release Readiness is open for the release-execution authorization and execution pass; no tag, release, released-state canon update, `Release Debt` clearance, or FB-038 branch creation has occurred yet
 
 ## Branch Class
 
@@ -53,22 +55,21 @@ This branch exists to prepare the public prerelease, release-state canon transit
 
 ## Exit Criteria
 
-- branch truth is durable in commit history and the worktree is clean
-- merge-target canon remains complete and still represents FB-037 as `Merged unreleased on main` with `Release Debt` active until release execution
-- release-boundary proof remains green: no tag, publish step, released-state canon update, or `Release Debt` clearance has occurred
-- draft rebaseline remains inactive and does not contradict the active `v1.3.1-prebeta` baseline
-- Governance Drift Audit is completed for the release-packaging branch
-- branch authority record is made merge-safe as historical truth or removed before PR completion
+- release target, release scope, and release artifacts remain explicit and validated
+- release-boundary proof remains green before execution: no tag, publish step, released-state canon update, or `Release Debt` clearance has occurred
+- draft rebaseline remains inactive and does not contradict the active `v1.3.1-prebeta` baseline until release execution activates it
+- release-state transition checklist remains complete and ordered
+- release execution is run only by an explicit Release Readiness execution pass
 - FB-038 remains selected in canon only and unbranched until FB-037 release debt is cleared and updated `main` is revalidated
 - no product or runtime work is introduced
 
 ## Rollback Target
 
-- `Live Validation`
+- `PR Readiness`
 
 ## Next Legal Phase
 
-- `Release Readiness`
+- `Release Readiness` (same-phase release execution pass; `Release execution` is not a separate canonical phase)
 
 ## Target Release Version
 
@@ -192,6 +193,33 @@ Continuation rule:
 - FB-038 remains selected in canon only and no local or remote FB-038 branch exists
 - no product or runtime work was introduced
 - phase authority transitioned from `Live Validation` to `PR Readiness`
+
+## Governance Drift Audit
+
+- Governance Drift Found: No
+- Drift Type: None for this PR Readiness closeout; prior release-target governance drift was already corrected earlier on this branch
+- Why Current Canon Failed To Prevent It: Not applicable for this closeout pass; current canon now requires release-bearing branches to carry `Release Target:`, `Release Scope:`, and `Release Artifacts:` markers before Release Readiness can report green
+- Required Canon Changes: None
+- Whether The Drift Blocks Merge: No
+- Whether User Confirmation Is Required: No
+- Missing blocker check: no missing PR Readiness blocker remains; stale canon, post-merge state, dirty branch, docs sync, next-workstream selection, and release-target marker gates are all represented in current governance
+- Weak phase entry or exit rule check: no unresolved weakness remains; Release Readiness is reached only after PR Readiness validation and this Governance Drift Audit
+- Weak source-of-truth ownership rule check: branch authority record remains the phase owner for this release-packaging branch, while the FB-037 workstream doc remains the promoted workstream and release-debt owner
+- Stale prompt scaffolding or operator example check: no stale prompt-scaffold drift was found in this closeout pass
+- Missing validator requirement check: the normal governance validator and PR-readiness gate mode both pass before this phase transition
+
+## PR Readiness Closeout
+
+- PR Readiness complete:
+  - merge-target canon still represents FB-037 as `Merged unreleased on main` with `Release Debt` active until release execution
+  - release target, release scope, and release artifacts are explicit in this authority record
+  - draft rebaseline remains inactive and does not override the active `v1.3.1-prebeta` baseline
+  - no local or remote `v1.4.0-prebeta` tag exists
+  - GitHub release lookup for `v1.4.0-prebeta` returned `404`
+  - FB-038 remains selected in canon only and no FB-038 branch exists
+  - Governance Drift Audit completed with no blocking drift
+  - no product or runtime work was introduced
+- phase authority transitioned from `PR Readiness` to `Release Readiness`
 
 ## Slice 1 Draft Release Notes
 

--- a/Docs/branch_records/codex_fb_037_release_debt_packaging.md
+++ b/Docs/branch_records/codex_fb_037_release_debt_packaging.md
@@ -20,7 +20,8 @@ This branch exists to prepare the public prerelease, release-state canon transit
 
 - `Active Branch`
 - branch was created from updated `main`
-- local `main`, `origin/main`, and this branch resolve to merge commit `d1277e65cf348073c73f636c8dd1b5965543f1a8`
+- local `main` and `origin/main` resolve to merge commit `d1277e65cf348073c73f636c8dd1b5965543f1a8`
+- this branch is based on that merge commit and carries release-packaging commits on top of it
 - FB-037 remains `Merged unreleased on main`
 - FB-038 remains selected in canon only and has no branch
 - Branch Readiness, Workstream Slice 1, and release-artifact Hardening are complete; release-packaging Live Validation is open for release-boundary proof before PR Readiness

--- a/Docs/branch_records/index.md
+++ b/Docs/branch_records/index.md
@@ -41,7 +41,7 @@ Do not use this layer to replace:
 
 ## Active Branch Authority Records
 
-- none currently
+- `Docs/branch_records/codex_fb_037_release_debt_packaging.md`
 
 ## Historical Branch Authority Records
 

--- a/Docs/closeout_index.md
+++ b/Docs/closeout_index.md
@@ -11,12 +11,12 @@ Use `Docs/closeout_guidance.md` for policy and cadence questions.
 
 ## Current Nexus-Era Baseline
 
-### Nexus Pre-Beta Rebaseline Through v1.3.1-prebeta
+### Nexus Pre-Beta Rebaseline Through v1.4.0-prebeta
 
 - scope:
-  - current shared Nexus pre-Beta baseline through the released FB-041 deterministic callable-group execution milestone
+  - current shared Nexus pre-Beta baseline through the released FB-037 curated built-in actions milestone
 - file:
-  - `Docs/closeouts/nexus_prebeta_rebaseline_through_v1.3.1-prebeta.md`
+  - `Docs/closeouts/nexus_prebeta_rebaseline_through_v1.4.0-prebeta.md`
 
 ## Historical Jarvis Closeouts
 

--- a/Docs/closeouts/nexus_prebeta_rebaseline_through_v1.4.0-prebeta.md
+++ b/Docs/closeouts/nexus_prebeta_rebaseline_through_v1.4.0-prebeta.md
@@ -1,32 +1,25 @@
-# Draft Nexus Pre-Beta Rebaseline Through v1.4.0-prebeta
+# Nexus Pre-Beta Rebaseline Through v1.4.0-prebeta
 
-## Draft Status
+## Status
 
-This file is a release-packaging draft for `v1.4.0-prebeta`.
+This file is the active Nexus-era rebaseline for `v1.4.0-prebeta` after FB-037 release execution.
 
-It is not the active current Nexus-era baseline until all of the following are true:
-
-- the `v1.4.0-prebeta` tag exists
-- release execution has marked FB-037 released
-- `Docs/closeout_index.md` points to this file as the current baseline
-- `Docs/prebeta_roadmap.md` records `v1.4.0-prebeta` as the latest public prerelease
-
-Until then, `Docs/closeouts/nexus_prebeta_rebaseline_through_v1.3.1-prebeta.md` remains the current released baseline.
+It supersedes `Docs/closeouts/nexus_prebeta_rebaseline_through_v1.3.1-prebeta.md` as the current baseline.
 
 ## Purpose
 
-This draft prepares the modern Nexus-era rebaseline that will become active after FB-037 release packaging is executed.
+This rebaseline captures the modern Nexus-era baseline after FB-037 release packaging is executed.
 
 Its job is to:
 
-- summarize the planned shared pre-Beta baseline through `v1.4.0-prebeta`
-- capture what becomes locked by the FB-037 built-in catalog milestone
+- summarize the shared pre-Beta baseline through `v1.4.0-prebeta`
+- capture what is locked by the FB-037 built-in catalog milestone
 - preserve what remains deferred after the release
 - reduce future prompt bloat after the public prerelease exists
 
 ## Baseline Scope
 
-When released, this rebaseline will cover shared truth through the public prerelease:
+This rebaseline covers shared truth through the public prerelease:
 
 - `v1.4.0-prebeta`
 
@@ -34,9 +27,9 @@ It will stand on top of the preserved historical closeout line indexed in:
 
 - `Docs/closeout_index.md`
 
-## Material Closed Workstreams In This Planned Baseline
+## Material Closed Workstreams In This Baseline
 
-When release execution completes, the closed workstreams that materially define this baseline will be:
+The closed workstreams that materially define this baseline are:
 
 - `Docs/workstreams/FB-028_history_state_relocation.md`
 - `Docs/workstreams/FB-033_startup_snapshot_harness_follow_through.md`
@@ -48,9 +41,9 @@ When release execution completes, the closed workstreams that materially define 
 - `Docs/workstreams/FB-041_deterministic_callable_group_execution_layer.md`
 - `Docs/workstreams/FB-037_built_in_actions_and_settings_expansion.md`
 
-## What Will Be Locked By v1.4.0-prebeta
+## What Is Locked By v1.4.0-prebeta
 
-After release execution, the shared pre-Beta baseline will include all `v1.3.1-prebeta` locked truth plus the FB-037 built-in catalog milestone:
+The shared pre-Beta baseline includes all `v1.3.1-prebeta` locked truth plus the FB-037 built-in catalog milestone:
 
 - the typed-first desktop interaction baseline remains explicit and validator-defended
 - built-in actions and saved actions continue to resolve through one shared action catalog
@@ -68,7 +61,7 @@ After release execution, the shared pre-Beta baseline will include all `v1.3.1-p
 
 ## What Remains Deferred
 
-This planned rebaseline does not authorize automatic continuation into:
+This rebaseline does not authorize automatic continuation into:
 
 - Nexus settings or protocol actions
 - new built-in target kinds
@@ -89,13 +82,13 @@ This planned rebaseline does not authorize automatic continuation into:
 - broader boot-layer implementation work
 - broader interaction, rebrand, voice, or UI follow-through by inertia
 
-## Planned Forward-Planning Posture After Release
+## Forward-Planning Posture After Release
 
-After release execution clears FB-037 release debt:
+After release execution:
 
-- FB-037 should be `Released (v1.4.0-prebeta)` and `Closed`
-- `Release Debt` for FB-037 should be cleared
-- FB-038 should remain selected in canon only until a fresh Branch Readiness admission from updated `main`
+- FB-037 is `Released (v1.4.0-prebeta)` and `Closed`
+- `Release Debt` for FB-037 is cleared
+- FB-038 remains selected in canon only until a fresh Branch Readiness admission from updated `main`
 - no FB-038 branch should exist before that Branch Readiness admission
 - future implementation must enter through the strict branch-governance admission flow
 
@@ -108,8 +101,8 @@ Use:
 - `Docs/closeout_guidance.md` for closeout and rebaseline policy
 - `Docs/closeout_index.md` for historical closeout lookup
 
-This draft does not rewrite historical closeouts.
+This rebaseline does not rewrite historical closeouts.
 
 ## Carry-Forward Rule
 
-After the public release exists and `Docs/closeout_index.md` points here, future prompts should treat this rebaseline plus the retained workstream records as the modern carry-forward baseline through `v1.4.0-prebeta`.
+Future prompts should treat this rebaseline plus the retained workstream records as the modern carry-forward baseline through `v1.4.0-prebeta`.

--- a/Docs/closeouts/nexus_prebeta_rebaseline_through_v1.4.0-prebeta.md
+++ b/Docs/closeouts/nexus_prebeta_rebaseline_through_v1.4.0-prebeta.md
@@ -1,0 +1,115 @@
+# Draft Nexus Pre-Beta Rebaseline Through v1.4.0-prebeta
+
+## Draft Status
+
+This file is a release-packaging draft for `v1.4.0-prebeta`.
+
+It is not the active current Nexus-era baseline until all of the following are true:
+
+- the `v1.4.0-prebeta` tag exists
+- release execution has marked FB-037 released
+- `Docs/closeout_index.md` points to this file as the current baseline
+- `Docs/prebeta_roadmap.md` records `v1.4.0-prebeta` as the latest public prerelease
+
+Until then, `Docs/closeouts/nexus_prebeta_rebaseline_through_v1.3.1-prebeta.md` remains the current released baseline.
+
+## Purpose
+
+This draft prepares the modern Nexus-era rebaseline that will become active after FB-037 release packaging is executed.
+
+Its job is to:
+
+- summarize the planned shared pre-Beta baseline through `v1.4.0-prebeta`
+- capture what becomes locked by the FB-037 built-in catalog milestone
+- preserve what remains deferred after the release
+- reduce future prompt bloat after the public prerelease exists
+
+## Baseline Scope
+
+When released, this rebaseline will cover shared truth through the public prerelease:
+
+- `v1.4.0-prebeta`
+
+It will stand on top of the preserved historical closeout line indexed in:
+
+- `Docs/closeout_index.md`
+
+## Material Closed Workstreams In This Planned Baseline
+
+When release execution completes, the closed workstreams that materially define this baseline will be:
+
+- `Docs/workstreams/FB-028_history_state_relocation.md`
+- `Docs/workstreams/FB-033_startup_snapshot_harness_follow_through.md`
+- `Docs/workstreams/FB-025_boot_desktop_milestone_taxonomy_clarification.md`
+- `Docs/workstreams/FB-034_recoverable_diagnostics.md`
+- `Docs/workstreams/FB-035_release_context_fallback_hardening.md`
+- `Docs/workstreams/FB-027_interaction_system_baseline.md`
+- `Docs/workstreams/FB-036_saved_action_authoring.md`
+- `Docs/workstreams/FB-041_deterministic_callable_group_execution_layer.md`
+- `Docs/workstreams/FB-037_built_in_actions_and_settings_expansion.md`
+
+## What Will Be Locked By v1.4.0-prebeta
+
+After release execution, the shared pre-Beta baseline will include all `v1.3.1-prebeta` locked truth plus the FB-037 built-in catalog milestone:
+
+- the typed-first desktop interaction baseline remains explicit and validator-defended
+- built-in actions and saved actions continue to resolve through one shared action catalog
+- saved-action override authority remains intact when a saved action collides with a built-in phrase
+- authoring collision protection prevents create/edit paths from silently overriding built-in phrases
+- the curated built-in catalog includes first-class Windows utility actions for:
+  - Task Manager
+  - Calculator
+  - Notepad
+  - Paint
+- built-in catalog entries use the existing `app` target path and do not introduce new target kinds
+- built-in execution preserves the existing confirm and result surfaces
+- callable-group behavior from the released FB-041 baseline remains unchanged
+- reusable live-validation helper hardening remains available as branch-local proof support for future desktop validation work
+
+## What Remains Deferred
+
+This planned rebaseline does not authorize automatic continuation into:
+
+- Nexus settings or protocol actions
+- new built-in target kinds
+- shell arguments or launcher-policy changes
+- taskbar or tray quick-task entry surfaces
+- Create Custom Task shell-facing UX
+- external trigger or plugin integration architecture
+- monitoring, thermal, or performance HUD surfaces
+- scheduling, branching, or multi-step orchestration beyond released deterministic stored-order callable-group execution
+- nested callable groups
+- parallel callable-group execution
+- retries
+- Action Studio behavior
+- voice invocation
+- shutdown exit-confirmation work
+- hotkey cleanup before Beta
+- broader reporting-policy or upload-behavior work
+- broader boot-layer implementation work
+- broader interaction, rebrand, voice, or UI follow-through by inertia
+
+## Planned Forward-Planning Posture After Release
+
+After release execution clears FB-037 release debt:
+
+- FB-037 should be `Released (v1.4.0-prebeta)` and `Closed`
+- `Release Debt` for FB-037 should be cleared
+- FB-038 should remain selected in canon only until a fresh Branch Readiness admission from updated `main`
+- no FB-038 branch should exist before that Branch Readiness admission
+- future implementation must enter through the strict branch-governance admission flow
+
+## Historical Relationship
+
+The preserved historical Jarvis closeout line remains valid historical context.
+
+Use:
+
+- `Docs/closeout_guidance.md` for closeout and rebaseline policy
+- `Docs/closeout_index.md` for historical closeout lookup
+
+This draft does not rewrite historical closeouts.
+
+## Carry-Forward Rule
+
+After the public release exists and `Docs/closeout_index.md` points here, future prompts should treat this rebaseline plus the retained workstream records as the modern carry-forward baseline through `v1.4.0-prebeta`.

--- a/Docs/codex_modes.md
+++ b/Docs/codex_modes.md
@@ -178,6 +178,20 @@ When the approved phase is `PR Readiness`, the output must also explicitly inclu
   - the blocking admission item
   - confirmation that branch creation remains deferred and no next implementation branch may execute by inertia
 
+When the approved phase is `Release Readiness`, the output must also explicitly include:
+
+- whether the branch is release-bearing
+- confirmation that `Release Target Undefined` is clear
+- for release-bearing branches:
+  - `Release Target:`
+  - `Release Scope:`
+  - `Release Artifacts:`
+- for explicitly non-release branches:
+  - `Release Branch: No`
+  - confirmation that the branch is a `docs/governance` branch or an explicitly canon-only / repo-wide source-of-truth update branch
+- confirmation that the non-release waiver is not being used for an `implementation` or `release packaging` branch
+- confirmation that `Release Debt`, post-merge truth, validation, and successor branch deferral remain governed by their normal blockers
+
 Do not report cleanup as complete unless the pass has explicitly checked for leftover apps, windows, dialogs, helper processes, probe files, or other temporary artifacts it created or opened.
 
 Do not report an interactive validation pass as complete or trustworthy if it exceeded its time budgets or sat stalled without a clean abort path.

--- a/Docs/codex_user_guide.md
+++ b/Docs/codex_user_guide.md
@@ -79,6 +79,13 @@ For bounded multi-seam Workstream execution, also include:
 - `Seam Sequence: <ordered seam list>`
 - `Per-Seam Gate: validate, record evidence, and report continue-or-stop before the next seam`
 
+For Release Readiness, also include:
+
+- `Release Target: <version or identifier>` for release-bearing branches
+- `Release Scope: <bounded release scope>` for release-bearing branches
+- `Release Artifacts: <tag, notes, rebaseline, or other release artifacts>` for release-bearing branches
+- `Release Branch: No` only for non-release `docs/governance` or explicitly canon-only / repo-wide source-of-truth update branches
+
 ## What Codex Should Do Automatically
 
 Brief prompts do not waive source-of-truth reading.
@@ -336,6 +343,27 @@ Do not use this recipe for bug fixes, hotfixes, unclear or high-risk seams, cros
 
 When the sequence completes, the normal next phase is `Hardening`.
 Do not prompt Codex to treat Workstream completion as direct `PR Readiness`.
+
+### Release Readiness Target Gate
+
+Use:
+
+- `Workflow mode on current branch: execute Release Readiness target validation`
+
+Required add-ons for release-bearing branches:
+
+- `Phase: Release Readiness`
+- `Release Target: [version or release identifier]`
+- `Release Scope: [bounded release scope]`
+- `Release Artifacts: [tag, notes, rebaseline, or other release artifacts]`
+
+Required add-on for non-release branches:
+
+- `Release Branch: No`
+
+Use `Release Branch: No` only when the branch is a `docs/governance` branch or an explicitly canon-only / repo-wide source-of-truth update branch.
+Do not use `Release Branch: No` for `implementation` or `release packaging` branches.
+If a release-bearing branch lacks `Release Target:`, `Release Scope:`, or `Release Artifacts:`, Release Readiness is blocked by `Release Target Undefined`.
 
 ### Run A Narrow Fix Pass
 

--- a/Docs/development_rules.md
+++ b/Docs/development_rules.md
@@ -240,6 +240,13 @@ That means:
 - no PR-ready without docs-sync and drift-audit completion:
   - docs sync, Governance Drift Audit, validator alignment, and required post-merge wording must be complete and mutually consistent
   - run the branch governance validator and its PR-readiness gate mode before reporting `PR READY: YES`
+- no Release Readiness green with `Release Target Undefined`:
+  - a release-bearing branch must explicitly declare `Release Target:`, `Release Scope:`, and `Release Artifacts:` before Release Readiness can report green
+  - release-bearing includes `release packaging` branches and any branch that creates, prepares, validates, tags, publishes, or transitions release-facing artifacts or release-state canon
+  - the only non-release waiver is `Release Branch: No`
+  - `Release Branch: No` is limited to `docs/governance` branches or explicitly canon-only / repo-wide source-of-truth update branches
+  - the non-release waiver is not available to `implementation` or `release packaging` branches
+  - the waiver does not clear `Release Debt`, weaken post-merge truth rules, weaken validation, or permit premature successor branch creation
 - post-release canon repair is emergency-only:
   - use it only when canon drift already exists on updated `main` and could not be prevented before merge or release
 - standalone `docs/governance` branches are future-capable but tightly gated:

--- a/Docs/feature_backlog.md
+++ b/Docs/feature_backlog.md
@@ -26,18 +26,7 @@ Historical note:
 
 ## Promoted Canonical Workstreams
 
-### [ID: FB-037] Curated built-in system actions and Nexus settings expansion
-
-Status: Merged unreleased on main
-Record State: Promoted
-Blocker: Release Debt
-Priority: High
-Release Stage: pre-Beta
-Target Version: TBD
-Planned Release Packaging Target: v1.4.0-prebeta
-Canonical Workstream Doc: Docs/workstreams/FB-037_built_in_actions_and_settings_expansion.md
-Summary: Completed and merge-target-ready curated Windows utility built-in catalog expansion under the shared action model; after merge, FB-037 is merged-unreleased implementation debt and blocks next implementation admission until release packaging clears Release Debt.
-Why it matters: Standard product actions should feel native and inspectable under the shared action model instead of being pushed into user-defined saved actions as ad hoc customization. Common Windows and Nexus-owned actions should ship as first-class built-ins, while saved actions remain the seam for personal or non-standard tasks.
+- None
 
 ## Registry Items
 
@@ -119,7 +108,7 @@ Next Workstream: Selected
 Priority: Medium
 Release Stage: pre-Beta
 Target Version: TBD
-Minimal Scope: Branch Readiness admission and planning for the shell-facing quick-task entry surface, initially limited to defining the smallest safe taskbar/tray or Create Custom Task UX seam above the released interaction, authoring, callable-group execution, and built-in catalog baselines; no branch exists yet and no implementation is authorized until FB-037 release debt is cleared.
+Minimal Scope: Branch Readiness admission and planning for the shell-facing quick-task entry surface, initially limited to defining the smallest safe taskbar/tray or Create Custom Task UX seam above the released interaction, authoring, callable-group execution, and built-in catalog baselines; no branch exists yet and no implementation is authorized until updated main is revalidated after the FB-037 release.
 Summary: Track future taskbar or tray quick-access UX, including a Create Custom Task affordance, as a deliberate shell-facing entry surface into the shared action model.
 Why it matters: Taskbar and tray interaction affect entry, discoverability, and user trust, so they should be planned as an explicit UX lane instead of piggybacking on overlay or authoring work.
 
@@ -144,6 +133,17 @@ Summary: Track future runtime monitoring and HUD surfaces for GPU / CPU thermals
 Why it matters: Monitoring overlays are a separate runtime and status surface and should not be bolted onto the saved-action system without an explicit product boundary.
 
 ## Closed Canonical Workstreams
+
+### [ID: FB-037] Curated built-in system actions and Nexus settings expansion
+
+Status: Released (v1.4.0-prebeta)
+Record State: Closed
+Priority: High
+Release Stage: pre-Beta
+Target Version: v1.4.0-prebeta
+Canonical Workstream Doc: Docs/workstreams/FB-037_built_in_actions_and_settings_expansion.md
+Summary: Released the first curated Windows utility built-in catalog under the shared action model, including Task Manager, Calculator, Notepad, and Paint while preserving saved-action override authority, authoring collision protection, confirm/result surfaces, and callable-group behavior.
+Why it matters: Standard product actions now feel native and inspectable under the shared action model instead of being pushed into user-defined saved actions as ad hoc customization. Common Windows actions ship as first-class built-ins, while saved actions remain the seam for personal or non-standard tasks.
 
 ### [ID: FB-041] Deterministic callable-group execution layer
 

--- a/Docs/feature_backlog.md
+++ b/Docs/feature_backlog.md
@@ -34,6 +34,7 @@ Blocker: Release Debt
 Priority: High
 Release Stage: pre-Beta
 Target Version: TBD
+Planned Release Packaging Target: v1.4.0-prebeta
 Canonical Workstream Doc: Docs/workstreams/FB-037_built_in_actions_and_settings_expansion.md
 Summary: Completed and merge-target-ready curated Windows utility built-in catalog expansion under the shared action model; after merge, FB-037 is merged-unreleased implementation debt and blocks next implementation admission until release packaging clears Release Debt.
 Why it matters: Standard product actions should feel native and inspectable under the shared action model instead of being pushed into user-defined saved actions as ad hoc customization. Common Windows and Nexus-owned actions should ship as first-class built-ins, while saved actions remain the seam for personal or non-standard tasks.

--- a/Docs/incident_patterns.md
+++ b/Docs/incident_patterns.md
@@ -31,6 +31,22 @@ Branch-local "what worked" notes should stay in the canonical workstream doc fir
   - `Docs/phase_governance.md`
   - `dev/orin_branch_governance_validation.py`
 
+## Pattern: Release Readiness Green Must Require Explicit Release Target
+
+- symptom:
+  Release Readiness can appear green while the branch has not yet named the release version, bounded release scope, or release artifacts it is supposed to package
+- layer:
+  branch governance and release-facing canon
+- root-cause pattern:
+  release-debt truth is present, but release-bearing branch records lack machine-checkable markers that prove the release target is explicit before green status
+- fix pattern:
+  require release-bearing branches to declare `Release Target:`, `Release Scope:`, and `Release Artifacts:`; allow `Release Branch: No` only for `docs/governance` or explicitly canon-only / repo-wide source-of-truth branches
+- validation pattern:
+  run the branch governance validator; it must fail release-packaging branch records that omit release target markers or branch records that use the non-release waiver outside the narrow governance/canon-only exception
+- source references:
+  - `Docs/phase_governance.md`
+  - `dev/orin_branch_governance_validation.py`
+
 ## Pattern: Released-Canon Fallback Must Not Use The Highest Planned Prerelease
 
 - symptom:

--- a/Docs/orin_task_template.md
+++ b/Docs/orin_task_template.md
@@ -50,6 +50,18 @@ Phase:
 Branch Class:
 [implementation / docs/governance / emergency canon repair / release packaging]
 
+Release Branch:
+[Yes / No / not applicable]
+
+Release Target:
+[required for release-bearing branches]
+
+Release Scope:
+[required for release-bearing branches]
+
+Release Artifacts:
+[required for release-bearing branches]
+
 Validation Contract:
 [fill in only when validation governance matters]
 
@@ -75,6 +87,9 @@ Use a separate governance or docs-style branch only for repo-wide uncoupled gove
 Add `Validation Contract`, `Timeout Contract`, and `Current active seam` when the governed task needs them.
 Add `Seam Sequence` when the Workstream prompt may use bounded multi-seam workflow.
 If `Seam Sequence` is present, Codex must execute one active seam at a time, validate after each seam, and report a continue-or-stop decision before starting the next seam.
+For `Release Readiness`, a release-bearing branch must include `Release Target:`, `Release Scope:`, and `Release Artifacts:` before green status is allowed.
+Use `Release Branch: No` only for `docs/governance` branches or explicitly canon-only / repo-wide source-of-truth update branches.
+Do not use `Release Branch: No` for `implementation` or `release packaging` branches.
 
 Default expectation:
 
@@ -269,7 +284,8 @@ If an execution task is too broad for one approved pass, explain the cleaner exe
 5. If in `Branch Readiness`, explain the whole-branch execution plan before Workstream admission.
 6. If in `Workstream`, explain whether bounded multi-seam workflow is safe; if it is, list the seam sequence, per-seam gates, and stop conditions.
 7. If in `PR Readiness`, explicitly plan the stale-canon check, post-merge-state handling, next-workstream selection/canon/minimal-scope/no-branch-exists check, required `Next Workstream: Selected`, `Minimal Scope:`, `## Selected Next Workstream`, and `Branch: Not created` markers, dirty-branch/durable-commit check, docs-sync/drift-audit check, normal governance validator, and PR-readiness gate mode.
-8. Explain the validation plan.
+8. If in `Release Readiness`, explicitly plan the `Release Target Undefined` check, required `Release Target:`, `Release Scope:`, and `Release Artifacts:` markers for release-bearing branches, or the narrow `Release Branch: No` waiver for allowed non-release governance/canon branches.
+9. Explain the validation plan.
 
 If the task includes interactive validation, the validation plan should also state:
 

--- a/Docs/phase_governance.md
+++ b/Docs/phase_governance.md
@@ -166,6 +166,7 @@ The default named blockers are:
 - `Dirty Branch`
 - `Docs Sync Incomplete`
 - `Release Debt`
+- `Release Target Undefined`
 - `Governance Drift`
 - `Current-State Claim Drift`
 - `Phase Waiver Missing`
@@ -325,6 +326,35 @@ Hard blockers:
 The PR-readiness validator gate must be run in its PR-specific mode before reporting `PR READY: YES`.
 If the normal governance validator passes but the PR-specific gate reports dirty worktree or unresolved PR blockers, the result is not PR-ready.
 
+### Release Readiness Target Gate
+
+Release Readiness must not report green while any release target blocker remains unresolved.
+
+Hard blocker:
+
+- `Release Target Undefined`:
+  Release Readiness fails for a release-bearing branch unless the active branch authority record or active workstream authority record explicitly identifies all required release-bearing markers:
+  - `Release Target:`
+  - `Release Scope:`
+  - `Release Artifacts:`
+
+A branch is release-bearing when:
+
+- its branch class is `release packaging`
+- or it creates, prepares, validates, tags, publishes, or transitions release-facing artifacts or release-state canon
+
+The only non-release waiver is:
+
+- the active authority record explicitly declares `Release Branch: No`
+- the branch is a `docs/governance` branch or an explicitly canon-only / repo-wide source-of-truth update branch
+- the branch does not create, prepare, validate, tag, publish, or transition release-facing artifacts or release-state canon
+
+The non-release waiver is not available to `implementation` or `release packaging` branches.
+It does not waive `Release Debt`, merge-target canon completeness, post-merge truth, successor lock, validation, or dirty-branch requirements.
+
+If release target markers are missing on a release-bearing branch, the branch is blocked by `Release Target Undefined`.
+If `Release Branch: No` appears on a branch outside the narrow non-release branch classes, the branch is blocked by `Phase Waiver Missing`.
+
 ### Governance Drift Audit
 
 Inside `PR Readiness`, the branch must run a formal Governance Drift Audit before it may advance to `Release Readiness`.
@@ -414,6 +444,8 @@ That validator should verify at minimum:
 - backlog, roadmap, workstreams index, and active workstream docs agree on active or merged-unreleased posture
 - stale merge-era wording does not remain in active current-state owners
 - Governance Drift Audit output exists before `Release Readiness`
+- release-bearing branches carry `Release Target:`, `Release Scope:`, and `Release Artifacts:` markers before Release Readiness can report green
+- non-release waiver records use `Release Branch: No` only for `docs/governance` or explicitly canon-only / repo-wide source-of-truth update branches
 - unresolved blockers prevent phase advancement
 - active-branch governance and canon updates remain the primary path when tightly coupled to the active branch's truth, phase, readiness, validation, closeout, or release state
 - standalone governance or docs-style branches remain exception paths for repo-wide uncoupled governance work, emergency canon repair, cross-branch truth repair, or contamination-risk cases
@@ -908,6 +940,8 @@ Forbidden:
 Required evidence:
 
 - merged or legitimately merge-ready truth
+- explicit `Release Target:`, `Release Scope:`, and `Release Artifacts:` markers for release-bearing branches
+- or explicit `Release Branch: No` only for narrowly allowed non-release governance/canon branches
 - release-context verification
 - no unresolved blocker
 

--- a/Docs/prebeta_roadmap.md
+++ b/Docs/prebeta_roadmap.md
@@ -79,12 +79,13 @@ That means the released FB-027 interaction baseline, the released FB-036 authori
 - status: `merged unreleased`
 - lane type: `implementation`
 - release floor: `minor prerelease`
-- target version: `TBD`
+- target version: `v1.4.0-prebeta` (planned)
 - release state: `merged unreleased`
 - current phase after merge: `Release Readiness`
 - phase status after merge: `No Active Branch`
 - blocker after merge: `Release Debt` (FB-037)
 - next concern after merge: release packaging
+- release-packaging branch: `codex/fb-037-release-debt-packaging`
 - canonical workstream doc: `Docs/workstreams/FB-037_built_in_actions_and_settings_expansion.md`
 - sequencing note: Workstream same-risk built-in catalog seams remain complete; helper-only Hardening cleared the reusable-helper cleanup no-progress and missing-manifest gap; Live Validation then passed with manifest-backed evidence across built-in execution, saved-action override, authoring collision rejection, mixed environments, and repeated execution; successor-lane lock is waived because post-merge truth resolves to `No Active Branch` due to FB-037 release debt
 

--- a/Docs/prebeta_roadmap.md
+++ b/Docs/prebeta_roadmap.md
@@ -61,33 +61,23 @@ Use these release-state values when relevant:
 
 Current merged truth indicates:
 
-- latest public prerelease: `v1.3.1-prebeta`
-- latest public release commit: `f743281`
-- merged unreleased non-doc implementation debt exists after this branch merges: FB-037 curated built-in system actions and Nexus settings expansion
-- the latest public released implementation milestone is FB-041 deterministic callable-group execution layer in `v1.3.1-prebeta`
-- current phase after this branch merges: `Release Readiness`
-- phase status after this branch merges: `No Active Branch`
-- blocker after this branch merges: `Release Debt` (FB-037)
-- next concern after this branch merges: release packaging for FB-037
+- latest public prerelease: `v1.4.0-prebeta`
+- latest public release commit: the `v1.4.0-prebeta` tag target
+- merged unreleased non-doc implementation debt exists: no
+- the latest public released implementation milestone is FB-037 curated built-in system actions and Nexus settings expansion in `v1.4.0-prebeta`
+- current release-packaging branch: `codex/fb-037-release-debt-packaging`
+- current release-packaging phase: `Release Readiness`
+- blocker after release execution: none for FB-037
+- next concern after this release branch is merged and updated `main` is revalidated: FB-038 Branch Readiness
 
-That means the released FB-027 interaction baseline, the released FB-036 authoring-and-callable-group milestone, and the released FB-041 deterministic callable-group execution milestone are now part of the current public shared pre-Beta baseline.
+That means the released FB-027 interaction baseline, the released FB-036 authoring-and-callable-group milestone, the released FB-041 deterministic callable-group execution milestone, and the released FB-037 built-in catalog milestone are now part of the current public shared pre-Beta baseline.
 
 ## Current Release Debt Owner
 
-### FB-037 Curated Built-In System Actions And Nexus Settings Expansion
+### None
 
-- status: `merged unreleased`
-- lane type: `implementation`
-- release floor: `minor prerelease`
-- target version: `v1.4.0-prebeta` (planned)
-- release state: `merged unreleased`
-- current phase after merge: `Release Readiness`
-- phase status after merge: `No Active Branch`
-- blocker after merge: `Release Debt` (FB-037)
-- next concern after merge: release packaging
-- release-packaging branch: `codex/fb-037-release-debt-packaging`
-- canonical workstream doc: `Docs/workstreams/FB-037_built_in_actions_and_settings_expansion.md`
-- sequencing note: Workstream same-risk built-in catalog seams remain complete; helper-only Hardening cleared the reusable-helper cleanup no-progress and missing-manifest gap; Live Validation then passed with manifest-backed evidence across built-in execution, saved-action override, authoring collision rejection, mixed environments, and repeated execution; successor-lane lock is waived because post-merge truth resolves to `No Active Branch` due to FB-037 release debt
+- no merged-unreleased implementation workstream currently owns Release Debt after FB-037 release execution
+- any future release debt must be introduced explicitly by a later merge or release-packaging branch
 
 ## Selected Next Workstream
 
@@ -96,11 +86,23 @@ That means the released FB-027 interaction baseline, the released FB-036 authori
 - selection state: `selected next workstream`
 - Record State: `Registry-only`
 - Branch: Not created
-- sequence: after FB-037 release packaging clears `Release Debt`
+- sequence: after the FB-037 release branch is merged and updated `main` is revalidated
 - Minimal Scope: Branch Readiness admission and planning for the shell-facing quick-task entry surface, initially limited to defining the smallest safe taskbar/tray or Create Custom Task UX seam above the released FB-027 interaction baseline, FB-036 authoring baseline, FB-041 callable-group execution baseline, and FB-037 built-in catalog baseline.
-- branch creation rule: defer branch creation to `Branch Readiness` after FB-037 release debt is cleared and updated `main` is revalidated
+- branch creation rule: defer branch creation to `Branch Readiness` after updated `main` includes the FB-037 release-state canon and is revalidated
 
 ## Most Recent Released Workstream Context
+
+### FB-037 Curated Built-In System Actions And Nexus Settings Expansion
+
+- status: `released`
+- lane type: `implementation`
+- release floor: `minor prerelease`
+- target version: `v1.4.0-prebeta`
+- release state: `released`
+- canonical workstream doc: `Docs/workstreams/FB-037_built_in_actions_and_settings_expansion.md`
+- sequencing note: released the curated built-in Windows utility catalog for Task Manager, Calculator, Notepad, and Paint while preserving saved-action override authority, authoring collision protection, confirm/result surfaces, and callable-group behavior
+
+## Prior Released Workstream Context
 
 ### FB-041 Deterministic Callable-Group Execution Layer
 
@@ -111,8 +113,6 @@ That means the released FB-027 interaction baseline, the released FB-036 authori
 - release state: `released`
 - canonical workstream doc: `Docs/workstreams/FB-041_deterministic_callable_group_execution_layer.md`
 - sequencing note: released deterministic stored-order callable-group execution, stop-on-failure semantics, group-aware failure-path reuse, and confirm/result status alignment while preserving single-action behavior
-
-## Prior Released Workstream Context
 
 ### FB-036 Saved-Action Authoring And Callable Groups
 
@@ -190,17 +190,18 @@ Current merged truth indicates:
 - the released FB-027 baseline remains part of the locked current interaction floor
 - the released FB-036 authoring-and-callable-group milestone is now part of the locked current pre-Beta baseline
 - the released FB-041 deterministic callable-group execution milestone is now part of the locked current pre-Beta baseline
+- the released FB-037 built-in catalog milestone is now part of the locked current pre-Beta baseline
 - the released FB-035 lane is closed
 - the recent released workstreams above remain part of the locked current baseline
-- merged unreleased non-doc implementation debt exists after this branch merges: FB-037
-- no active implementation workstream remains selected after this branch merges
-- post-merge repo truth resolves to `Release Readiness` with phase status `No Active Branch` and blocker `Release Debt` (FB-037)
-- successor-lane lock is waived for this PR Readiness pass because release debt blocks next implementation admission
+- merged unreleased non-doc implementation debt exists: no
+- no active implementation workstream is currently admitted
+- post-release repo truth after this release branch merges resolves to no active implementation branch and no FB-037 release-debt blocker
+- successor-lane branch creation remains deferred until FB-038 enters Branch Readiness from updated `main`
 - if a branch changes release-facing canon, those canon updates must land on that same branch before PR readiness is allowed
 - post-release canon repair is emergency-only when merged canon is already stale or external drift made pre-merge prevention impossible
 - the released FB-027 baseline does not authorize further saved-action authoring, resolution, voice, Action Studio, routines, profiles, hotkey cleanup, or shutdown-confirmation work by inertia
 - remaining future candidate spaces now explicitly recorded in the backlog include:
-  - FB-038 for taskbar or tray quick-task UX including Create Custom Task, selected as the next implementation workstream after FB-037 release packaging clears release debt
+  - FB-038 for taskbar or tray quick-task UX including Create Custom Task, selected as the next implementation workstream after updated `main` includes the FB-037 release-state canon
   - FB-039 for external trigger and plugin integration architecture
   - FB-040 for monitoring, thermals, and performance HUD surfaces
 - those candidate lanes must be selected deliberately rather than bundled together as one implicit interaction continuation

--- a/Docs/workstreams/FB-037_built_in_actions_and_settings_expansion.md
+++ b/Docs/workstreams/FB-037_built_in_actions_and_settings_expansion.md
@@ -7,11 +7,11 @@
 
 ## Record State
 
-- `Promoted`
+- `Closed`
 
 ## Status
 
-- `Merged unreleased on main`
+- `Released (v1.4.0-prebeta)`
 
 ## Release Stage
 
@@ -19,31 +19,32 @@
 
 ## Target Version
 
-- `TBD`
-- planned release-packaging target: `v1.4.0-prebeta`
+- `v1.4.0-prebeta`
 
 ## Canonical Branch
 
-- `feature/fb-037-built-in-actions-and-settings-expansion`
+- No active canonical branch remains after release.
+- historical implementation branch:
+  - `feature/fb-037-built-in-actions-and-settings-expansion`
+- historical release-packaging branch:
+  - `codex/fb-037-release-debt-packaging`
 
 ## Purpose / Why It Matters
 
-Promote the curated built-in system actions and Nexus settings expansion lane above the released shared action, saved-action authoring, callable-group authoring, and deterministic callable-group execution baseline.
+Record the released curated built-in system actions and Nexus settings expansion lane above the released shared action, saved-action authoring, callable-group authoring, and deterministic callable-group execution baseline.
 
-This workstream exists so common Windows, vendor utility, and Nexus-owned destinations can become deliberate first-class built-in actions under the shared action model instead of being left to ad hoc saved-action customization.
+This workstream released common Windows utility destinations as deliberate first-class built-in actions under the shared action model instead of leaving them to ad hoc saved-action customization.
 
 ## Current Phase
 
-- Phase: `Release Readiness`
+- Released historical workstream record. No active branch phase is owned by this workstream doc after `v1.4.0-prebeta`.
 
 ## Phase Status
 
-- `No Active Branch`
-- after this branch merges, FB-037 is merged-unreleased implementation release debt and no implementation branch remains active
-- Release Readiness is the governing post-merge phase until release packaging clears `Release Debt` for FB-037
-- release-packaging Branch Readiness opened on `codex/fb-037-release-debt-packaging`
-- release-packaging branch authority record: `Docs/branch_records/codex_fb_037_release_debt_packaging.md`
-- successor-lane lock is waived because post-merge repo truth resolves to `No Active Branch` due to `Release Debt` (FB-037)
+- historical released posture
+- FB-037 is released in `v1.4.0-prebeta`
+- `Release Debt` for FB-037 is cleared
+- release-packaging authority record: `Docs/branch_records/codex_fb_037_release_debt_packaging.md`
 - historical implementation branch:
   - `feature/fb-037-built-in-actions-and-settings-expansion`
 - PR Readiness on the implementation branch passed after Live Validation evidence was digested and merge-target canon was corrected for post-merge truth
@@ -71,7 +72,7 @@ This workstream exists so common Windows, vendor utility, and Nexus-owned destin
 
 ## Blockers
 
-- `Release Debt` (FB-037)
+- None. This workstream is released and closed.
 
 ## Entry Basis
 
@@ -96,15 +97,14 @@ This workstream exists so common Windows, vendor utility, and Nexus-owned destin
 - final helper scenario result: `19` passed scenarios, `0` failed scenarios
 - final cleanup summary: cleanup success count `5`, OS-blocked cleanup count `0`, helper-failure cleanup count `0`, baseline-skipped count `14`
 - repo-side governance validation passed before this phase transition with `python dev/orin_branch_governance_validation.py`
-- PR Readiness canon correction recorded the post-merge `No Active Branch` state and waived successor-lane lock because FB-037 release debt blocks next implementation admission
+- PR Readiness canon correction recorded the prior post-merge `No Active Branch` state and waived successor-lane lock while FB-037 release debt blocked next implementation admission
 
 ## Exit Criteria
 
-- release packaging for FB-037 is opened on an approved release-packaging branch or otherwise explicitly authorized
-- target public prerelease for FB-037 is selected by release packaging
-- FB-037 release notes and release-state transitions are prepared before clearing `Release Debt`
-- release debt remains explicit until FB-037 is actually released
-- no next implementation branch is admitted while FB-037 release debt remains unresolved
+- FB-037 is released as `v1.4.0-prebeta`
+- release notes and the `v1.4.0-prebeta` rebaseline are active release artifacts
+- `Release Debt` for FB-037 is cleared
+- FB-038 remains selected in canon only and unbranched until updated `main` is revalidated for Branch Readiness
 
 ## Rollback Target
 
@@ -112,20 +112,17 @@ This workstream exists so common Windows, vendor utility, and Nexus-owned destin
 
 ## Next Legal Phase
 
-- `Release Readiness`
+- No active next phase. Future implementation must enter through a new Branch Readiness admission on a selected workstream.
 
-## Post-Merge State
+## Released State
 
-- Phase (post-merge): `Release Readiness`
-- Phase Status (post-merge): `No Active Branch`
-- Blocker: `Release Debt` (FB-037)
-- Next Legal Phase: `Release Readiness` (release packaging)
-- Successor lane lock: waived because repo truth resolves to `No Active Branch` due to FB-037 release debt
-- Record State: `Promoted` until release packaging marks FB-037 released and closes the workstream
-- Next concern: release packaging; no next implementation lane may begin until release debt is cleared or explicitly waived by canon
-- Active release-packaging branch: `codex/fb-037-release-debt-packaging`
-- Planned public prerelease target: `v1.4.0-prebeta`
-- This workstream must not be treated as an active implementation branch owner after merge
+- Public prerelease: `v1.4.0-prebeta`
+- Record State: `Closed`
+- Release Debt: cleared
+- Current baseline: `Docs/closeouts/nexus_prebeta_rebaseline_through_v1.4.0-prebeta.md`
+- Release packaging branch: `codex/fb-037-release-debt-packaging`
+- FB-038 remains selected in canon only and unbranched until updated `main` is revalidated for Branch Readiness.
+- This workstream must not be treated as an active implementation branch owner after release.
 
 ## Bounded Objective
 
@@ -149,7 +146,7 @@ Each built-in catalog seam must be selected, bounded, implemented, validated, re
 
 ## Reuse Baseline
 
-- `Docs/closeouts/nexus_prebeta_rebaseline_through_v1.3.1-prebeta.md`
+- `Docs/closeouts/nexus_prebeta_rebaseline_through_v1.4.0-prebeta.md`
 - `Docs/workstreams/FB-041_deterministic_callable_group_execution_layer.md`
 - `Docs/workstreams/FB-036_saved_action_authoring.md`
 - `Docs/workstreams/FB-027_interaction_system_baseline.md`

--- a/Docs/workstreams/FB-037_built_in_actions_and_settings_expansion.md
+++ b/Docs/workstreams/FB-037_built_in_actions_and_settings_expansion.md
@@ -20,6 +20,7 @@
 ## Target Version
 
 - `TBD`
+- planned release-packaging target: `v1.4.0-prebeta`
 
 ## Canonical Branch
 
@@ -40,6 +41,8 @@ This workstream exists so common Windows, vendor utility, and Nexus-owned destin
 - `No Active Branch`
 - after this branch merges, FB-037 is merged-unreleased implementation release debt and no implementation branch remains active
 - Release Readiness is the governing post-merge phase until release packaging clears `Release Debt` for FB-037
+- release-packaging Branch Readiness opened on `codex/fb-037-release-debt-packaging`
+- release-packaging branch authority record: `Docs/branch_records/codex_fb_037_release_debt_packaging.md`
 - successor-lane lock is waived because post-merge repo truth resolves to `No Active Branch` due to `Release Debt` (FB-037)
 - historical implementation branch:
   - `feature/fb-037-built-in-actions-and-settings-expansion`
@@ -120,6 +123,8 @@ This workstream exists so common Windows, vendor utility, and Nexus-owned destin
 - Successor lane lock: waived because repo truth resolves to `No Active Branch` due to FB-037 release debt
 - Record State: `Promoted` until release packaging marks FB-037 released and closes the workstream
 - Next concern: release packaging; no next implementation lane may begin until release debt is cleared or explicitly waived by canon
+- Active release-packaging branch: `codex/fb-037-release-debt-packaging`
+- Planned public prerelease target: `v1.4.0-prebeta`
 - This workstream must not be treated as an active implementation branch owner after merge
 
 ## Bounded Objective

--- a/Docs/workstreams/index.md
+++ b/Docs/workstreams/index.md
@@ -80,10 +80,11 @@ That may be an executable branch owner or another explicitly promoted current-tr
 Merged / Release Debt Owners are promoted implementation workstreams whose implementation branch is merge-target complete but whose public release packaging has not yet cleared release debt.
 These records are not active implementation branch owners after merge.
 
-- `Docs/workstreams/FB-037_built_in_actions_and_settings_expansion.md`
+- None
 
 ### Closed
 
+- `Docs/workstreams/FB-037_built_in_actions_and_settings_expansion.md`
 - `Docs/workstreams/FB-041_deterministic_callable_group_execution_layer.md`
 - `Docs/workstreams/FB-036_saved_action_authoring.md`
 - `Docs/workstreams/FB-027_interaction_system_baseline.md`

--- a/dev/orin_branch_governance_validation.py
+++ b/dev/orin_branch_governance_validation.py
@@ -205,6 +205,36 @@ PR_READINESS_BLOCKER_PHRASES = (
     "next-workstream",
 )
 
+RELEASE_READINESS_TARGET_DOCS = (
+    Path("Docs/phase_governance.md"),
+    Path("Docs/development_rules.md"),
+    Path("Docs/Main.md"),
+    Path("Docs/codex_modes.md"),
+    Path("Docs/orin_task_template.md"),
+    Path("Docs/codex_user_guide.md"),
+)
+
+RELEASE_READINESS_TARGET_PHRASES = (
+    "Release Target Undefined",
+    "Release Target:",
+    "Release Scope:",
+    "Release Artifacts:",
+    "Release Branch: No",
+)
+
+REQUIRED_RELEASE_BEARING_MARKERS = (
+    "Release Target:",
+    "Release Scope:",
+    "Release Artifacts:",
+)
+
+NON_RELEASE_BRANCH_MARKER = "Release Branch: No"
+RELEASE_BEARING_BRANCH_CLASSES = ("release packaging",)
+NON_RELEASE_WAIVER_BRANCH_CLASSES = (
+    "docs/governance",
+    "emergency canon repair",
+)
+
 BRANCH_RECORD_INDEX = Path("Docs/branch_records/index.md")
 
 NEXT_WORKSTREAM_SELECTION_MARKER = "Next Workstream: Selected"
@@ -648,6 +678,14 @@ def main() -> int:
                 f"{relative_path}: PR Readiness blocker guidance is missing '{required_phrase}'",
             )
 
+    for relative_path in RELEASE_READINESS_TARGET_DOCS:
+        text = _read_text(relative_path)
+        for required_phrase in RELEASE_READINESS_TARGET_PHRASES:
+            require(
+                required_phrase in text,
+                f"{relative_path}: Release Readiness target gate guidance is missing '{required_phrase}'",
+            )
+
     active_index_paths = _collect_active_index_paths(index_text)
     closed_index_paths = _collect_closed_index_paths(index_text)
     release_debt_index_paths = _collect_release_debt_index_paths(index_text)
@@ -928,6 +966,29 @@ def main() -> int:
             str(info["branch_class"]) in BRANCH_CLASSES,
             f"{branch_record_path}: Branch Class '{info['branch_class']}' is not in the canonical branch-class enum",
         )
+        branch_class = str(info["branch_class"])
+        has_non_release_marker = NON_RELEASE_BRANCH_MARKER in record_text
+        if branch_class in RELEASE_BEARING_BRANCH_CLASSES:
+            for required_marker in REQUIRED_RELEASE_BEARING_MARKERS:
+                require(
+                    required_marker in record_text,
+                    f"{branch_record_path}: release-bearing branch record is missing '{required_marker}'",
+                )
+            require(
+                not has_non_release_marker,
+                (
+                    f"{branch_record_path}: release-bearing branch class '{branch_class}' "
+                    f"must not use '{NON_RELEASE_BRANCH_MARKER}'"
+                ),
+            )
+        if has_non_release_marker:
+            require(
+                branch_class in NON_RELEASE_WAIVER_BRANCH_CLASSES,
+                (
+                    f"{branch_record_path}: '{NON_RELEASE_BRANCH_MARKER}' is only allowed for "
+                    "docs/governance or explicitly canon-only / repo-wide source-of-truth update branches"
+                ),
+            )
         require(
             str(info["rollback_target"]) in PHASES,
             f"{branch_record_path}: Rollback Target '{info['rollback_target']}' is not in the canonical phase enum",


### PR DESCRIPTION
## Summary

Finalizes FB-037 release-state canon for v1.4.0-prebeta.

## What Changed

Includes:
- marks FB-037 released and closed
- clears FB-037 release debt
- advances latest public prerelease to v1.4.0-prebeta
- activates the v1.4.0-prebeta rebaseline
- updates closeout index, roadmap, backlog, workstream index, and FB-037 historical truth
- keeps FB-038 selected-only and unbranched

Tag v1.4.0-prebeta already exists and points to commit 6b4b6d7b23d619593aab5e824b05174114724ec1.
No FB-038 branch was created.

Includes:
- marks FB-037 released and closed
- clears FB-037 release debt
- advances latest public prerelease to v1.4.0-prebeta
- activates the v1.4.0-prebeta rebaseline
- updates closeout index, roadmap, backlog, workstream index, and FB-037 historical truth
- keeps FB-038 selected-only and unbranched
