### PR TITLE
docs: enforce Release Readiness file freeze

### DIFF
--- a/Docs/Main.md
+++ b/Docs/Main.md
@@ -239,12 +239,14 @@ These are reference layers, not active workstream or roadmap owners.
 - PR Readiness also owns `PR Readiness Scope Missed`, `Between-Branch Canon Repair Attempt`, and `Next Branch Created Too Early`; none may be deferred into Release Readiness or a later side branch
 - the normal `Release Readiness` sequence for a release-bearing branch must clear `Release Target Undefined` before reporting green:
   1. confirm whether the branch is release-bearing or explicitly non-release
-  2. for release-bearing branches, require machine-checkable `Release Target:`, `Release Scope:`, and `Release Artifacts:` markers in the active authority record
+  2. for release-bearing branches, require machine-checkable `Release Target:`, `Release Scope:`, and `Release Artifacts:` markers before Release Readiness can report green
   3. for non-release branches, require `Release Branch: No`
   4. allow `Release Branch: No` only for preserved historical records or explicitly authorized direct-main emergency contexts
   5. never use the non-release waiver for `implementation` or `release packaging` branches
   6. never let the waiver clear `Release Debt`, weaken post-merge truth, weaken validation, or permit premature next-workstream branch creation
-- Release Readiness is not a docs-sync phase; it is restricted to release-target, release-scope, release-artifact, GitHub release package information, final release-execution authorization or confirmation, and release-state confirmation after release execution
+- Release Readiness is not a docs-sync phase and not a file-mutation phase; it is analysis-only for repository files and is restricted to release-target validation, release-scope validation, release-artifact validation, GitHub release package information, final release-execution authorization or confirmation, and release-state confirmation after release execution
+- Release Readiness must not edit, stage, commit, generate, or refresh source, docs, canon, validator, helper, release-note, or handoff files; if such work is discovered before merge, return to `PR Readiness`, and if discovered after merge, defer it to the next active branch's `Branch Readiness`
+- tracked file changes while the authority record says `Release Readiness` are blocked as `Release Readiness File Mutation Attempt`
 - a post-release canon repair is an emergency direct-main action only when merged canon is already stale, no active branch can legally carry the repair, and the user explicitly authorizes that direct-main action
 - returned `UTS`, screenshot, interactive, PR-review, or release-review evidence must be digested into the authority record before phase advancement is recommended
 - while a required User Test Summary handoff is outstanding, the active branch must report `User Test Summary Results Pending`; automated validators and live helper evidence may be green, but final phase advancement is blocked until the filled User Test Summary is submitted or waived, digested into the authority record, and blockers are reevaluated

--- a/Docs/codex_modes.md
+++ b/Docs/codex_modes.md
@@ -229,6 +229,8 @@ When the approved phase is `Release Readiness`, the output must also explicitly 
 - confirmation that the non-release waiver is not being used for an `implementation` or `release packaging` branch
 - confirmation that `Release Debt`, post-merge truth, validation, and successor branch deferral remain governed by their normal blockers
 - confirmation that Release Readiness is not being used as a docs-sync or branch-authority cleanup phase
+- confirmation that Release Readiness is analysis-only for repository files and that no source, docs, canon, validator, helper, release-note, or handoff files were edited, staged, committed, generated, or refreshed
+- if any file change is needed, classification as `Release Readiness File Mutation Attempt`, then return to `PR Readiness` before merge or defer to the next active branch's `Branch Readiness` after merge instead of patching inside Release Readiness
 
 Do not report cleanup as complete unless the pass has explicitly checked for leftover apps, windows, dialogs, helper processes, probe files, or other temporary artifacts it created or opened.
 
@@ -328,6 +330,7 @@ When release-dependent truth changes:
 - carry the canon sync on the active lane when that lane is still open
 - require merge-target canon completeness before PR so merged `main` does not become stale in the first place
 - do not use Release Readiness as a docs-sync phase
+- do not use Release Readiness as a file-mutation phase; release package information may be generated as response text only
 - do not open a governance-only branch or between-branch repair window
 - if a PR Readiness miss escapes after merge, block the next active branch in `Branch Readiness` and repair the miss before implementation begins
 - use direct-main emergency repair only when no active branch can legally carry the fix and the user explicitly authorizes that direct-main action

--- a/Docs/codex_user_guide.md
+++ b/Docs/codex_user_guide.md
@@ -85,6 +85,7 @@ For Release Readiness, also include:
 - `Release Scope: <bounded release scope>` for release-bearing branches
 - `Release Artifacts: <tag, notes, rebaseline, or other release artifacts>` for release-bearing branches
 - `Release Branch: No` only for preserved historical records or explicitly authorized direct-main emergency contexts
+- `No file changes` because Release Readiness is analysis-only for repository files
 
 ## What Codex Should Do Automatically
 
@@ -352,7 +353,7 @@ Do not prompt Codex to treat Workstream completion as direct `PR Readiness`.
 
 Use:
 
-- `Workflow mode on current branch: execute Release Readiness target validation`
+- `Analyze and Report on current branch: execute Release Readiness target validation without file changes`
 
 Required add-ons for release-bearing branches:
 
@@ -360,6 +361,7 @@ Required add-ons for release-bearing branches:
 - `Release Target: [version or release identifier]`
 - `Release Scope: [bounded release scope]`
 - `Release Artifacts: [tag, notes, rebaseline, or other release artifacts]`
+- `No file changes`
 
 Required add-on for non-release branches:
 
@@ -368,6 +370,7 @@ Required add-on for non-release branches:
 Use `Release Branch: No` only for preserved historical records or explicitly authorized direct-main emergency contexts.
 Do not use `Release Branch: No` for `implementation` or `release packaging` branches.
 If a release-bearing branch lacks `Release Target:`, `Release Scope:`, or `Release Artifacts:`, Release Readiness is blocked by `Release Target Undefined`.
+If Release Readiness analysis discovers missing, stale, or ambiguous release truth that requires a file update, do not patch in Release Readiness. Return to `PR Readiness` before merge, or defer the repair to the next active branch's `Branch Readiness` after merge. Treat any file mutation while the authority record says `Release Readiness` as `Release Readiness File Mutation Attempt`.
 
 ### Run A Narrow Fix Pass
 

--- a/Docs/development_rules.md
+++ b/Docs/development_rules.md
@@ -256,6 +256,9 @@ That means:
   - if the next branch already exists before the current branch merged and updated `main` was revalidated, block as `Next Branch Created Too Early`
 - no Release Readiness green with `Release Target Undefined`:
   - a release-bearing branch must explicitly declare `Release Target:`, `Release Scope:`, and `Release Artifacts:` before Release Readiness can report green
+  - Release Readiness is analysis-only for repository files; it may produce release package information in the response, but it must not edit, stage, commit, generate, or refresh source, docs, canon, validator, helper, release-note, or handoff files
+  - if Release Readiness analysis discovers missing, stale, or ambiguous release target/scope/artifact truth, do not patch in Release Readiness; return to `PR Readiness` on the active branch if unmerged, or defer the repair to the next active branch's `Branch Readiness` if already merged
+  - tracked file changes while the authority record says `Release Readiness` are blocked as `Release Readiness File Mutation Attempt`
   - release-bearing includes `release packaging` branches and any branch that creates, prepares, validates, tags, publishes, or transitions release-facing artifacts or release-state canon
   - the only non-release waiver is `Release Branch: No`
   - `Release Branch: No` is limited to preserved historical records or explicitly authorized direct-main emergency contexts
@@ -268,6 +271,7 @@ That means:
   - between-branch canon repair is blocked
   - direct writes to `main` are blocked unless the user explicitly authorizes an emergency direct-main action
   - Release Readiness must not absorb docs sync or canon cleanup that PR Readiness should have completed
+  - Release Readiness must not mutate files to repair a discovered gap; use `PR Readiness` before merge or the next active branch's `Branch Readiness` after merge
 - do not use canon sync as an excuse for broad unrelated documentation churn
 
 Local docs overlays are reference material only until revalidated against updated `origin/main`.

--- a/Docs/incident_patterns.md
+++ b/Docs/incident_patterns.md
@@ -44,6 +44,23 @@ Branch-local "what worked" notes should stay in the canonical workstream doc fir
 - validation pattern:
   run the branch governance validator; it must fail release-packaging branch records that omit release target markers or branch records that use the non-release waiver outside preserved historical records or explicitly authorized direct-main emergency contexts
 
+## Pattern: Release Readiness File Mutation Must Backflow
+
+- symptom:
+  Release Readiness discovers missing release target, scope, artifact, canon, helper, or release-note truth and patches files while the authority record still says `Release Readiness`
+- layer:
+  release readiness boundary and phase backflow
+- root-cause pattern:
+  canon treated release target/scope/artifact definition as something Release Readiness could repair in-place instead of analysis-only output or a blocker that returns to the owning earlier phase
+- fix pattern:
+  treat Release Readiness as analysis-only for repository files; it may produce release package information in the response, but any required source, docs, canon, validator, helper, release-note, or handoff-file mutation must return to `PR Readiness` before merge or defer to the next active branch's `Branch Readiness` after merge
+- validation pattern:
+  run `python dev/orin_branch_governance_validation.py`; it must enforce `Release Readiness File Mutation Attempt` file-freeze language in governance docs and fail if tracked files are dirty while an active authority record says `Release Readiness`
+- source references:
+  - `Docs/phase_governance.md`
+  - `Docs/development_rules.md`
+  - `dev/orin_branch_governance_validation.py`
+
 ## Pattern: Escaped PR Work Blocks Next Branch Readiness
 
 - Trigger:

--- a/Docs/orin_task_template.md
+++ b/Docs/orin_task_template.md
@@ -98,6 +98,8 @@ Add `Validation Contract`, `Timeout Contract`, and `Current active seam` when th
 Add `Seam Sequence` when the Workstream prompt may use bounded multi-seam workflow.
 If `Seam Sequence` is present, Codex must execute one active seam at a time, validate after each seam, and report a continue-or-stop decision before starting the next seam.
 For `Release Readiness`, a release-bearing branch must include `Release Target:`, `Release Scope:`, and `Release Artifacts:` before green status is allowed.
+`Release Readiness` is analysis-only for repository files. It may produce release package information in the response, but it must not edit, stage, commit, generate, or refresh source, docs, canon, validator, helper, release-note, or handoff files.
+If a file change is needed during `Release Readiness`, classify `Release Readiness File Mutation Attempt`, return to `PR Readiness` before merge, or defer to the next active branch's `Branch Readiness` after merge.
 Use `Release Branch: No` only for preserved historical records or explicitly authorized direct-main emergency contexts.
 Do not use `Release Branch: No` for `implementation` or `release packaging` branches.
 If a required User Test Summary handoff is outstanding, use `User Test Summary Results: PENDING`, list `User Test Summary Results Pending` under blockers, and do not report final phase advancement as green until the filled User Test Summary is submitted or waived, digested, and blockers are reevaluated.
@@ -296,7 +298,7 @@ If an execution task is too broad for one approved pass, explain the cleaner exe
 5. If in `Branch Readiness`, explain the whole-branch execution plan before Workstream admission.
 6. If in `Workstream`, explain whether bounded multi-seam workflow is safe; if it is, list the seam sequence, per-seam gates, and stop conditions.
 7. If in `PR Readiness`, explicitly plan the stale-canon check, post-merge-state handling, next-workstream selection/canon/minimal-scope/no-branch-exists check, required `Next Workstream: Selected`, `Minimal Scope:`, `## Selected Next Workstream`, and `Branch: Not created` markers, dirty-branch/durable-commit check, docs-sync/drift-audit check, `PR Readiness Scope Missed`, `Between-Branch Canon Repair Attempt`, `Next Branch Created Too Early`, normal governance validator, PR-readiness gate mode, required `## Next Branch` response block, and copy-ready `## PR Creation Details` package.
-8. If in `Release Readiness`, explicitly plan the `Release Target Undefined` check, required `Release Target:`, `Release Scope:`, and `Release Artifacts:` markers for release-bearing branches, and confirm Release Readiness is not being used for broad docs sync or branch-authority cleanup.
+8. If in `Release Readiness`, explicitly plan the `Release Target Undefined` check, required `Release Target:`, `Release Scope:`, and `Release Artifacts:` markers for release-bearing branches, confirm Release Readiness is not being used for broad docs sync or branch-authority cleanup, and confirm no repository file mutation will occur in the phase.
 9. Explain the validation plan.
 10. If a User Test Summary handoff is relevant, explicitly state whether returned results are `PENDING`, `PASS`, `FAIL`, or `WAIVED`; `PENDING` is the hard blocker `User Test Summary Results Pending`.
 
@@ -434,6 +436,7 @@ Stop and explicitly report if:
 - critical evidence is missing
 - the task would require reopening locked architecture
 - safe verification is not possible
+- the task is in `Release Readiness` and requires any source, docs, canon, validator, helper, release-note, or handoff-file mutation; return to `PR Readiness` before merge or defer to the next active branch's `Branch Readiness` after merge
 - the task needs a new branch basis because the current one is stale, merged, or no longer the right execution base
 - `User Test Summary Results Pending` remains active while the task attempts to advance phase, PR readiness, merge readiness, or final green status
 

--- a/Docs/phase_governance.md
+++ b/Docs/phase_governance.md
@@ -172,6 +172,7 @@ The default named blockers are:
 - `Docs Sync Incomplete`
 - `Release Debt`
 - `Release Target Undefined`
+- `Release Readiness File Mutation Attempt`
 - `User-Facing Shortcut Validation Pending`
 - `User Test Summary Results Pending`
 - `PR Readiness Scope Missed`
@@ -466,6 +467,8 @@ Routing after digestion:
 
 Release Readiness must not report green while any release target blocker remains unresolved.
 
+Release Readiness is an analysis-only file-freeze phase. Required release target, scope, and artifact truth must already exist before entering Release Readiness, normally as PR-owned merge-target canon or a PR-ready response package. If Release Readiness analysis discovers that those fields are missing, ambiguous, stale, or require source-file changes, do not patch files inside Release Readiness. Return the active branch to `PR Readiness` if it has not merged; if the branch has already merged, defer the repair to the next active branch's `Branch Readiness`.
+
 Hard blocker:
 
 - `Release Target Undefined`:
@@ -490,10 +493,18 @@ It does not waive `Release Debt`, merge-target canon completeness, post-merge tr
 
 If release target markers are missing on a release-bearing branch, the branch is blocked by `Release Target Undefined`.
 If `Release Branch: No` appears outside a preserved historical record or explicitly authorized direct-main emergency context, the branch is blocked by `Phase Waiver Missing`.
+If any source, docs, canon, validator, helper, or release-note file is modified while the active phase remains `Release Readiness`, the branch is blocked by `Release Readiness File Mutation Attempt` and must return to `PR Readiness` or defer to the next active branch's `Branch Readiness` before the change can be made.
 
 ### Release Readiness Scope Boundary
 
-Release Readiness is not a docs-sync phase.
+Release Readiness is not a docs-sync phase. It is also not a file-mutation phase.
+
+Release Readiness is analysis-only for repository files:
+
+- it may inspect repo truth, branches, tags, releases, validator output, and release evidence
+- it may produce release package information in the response, including tag, title, release notes, and release-execution instructions
+- it may run validation commands that do not mutate tracked source files
+- it must not edit, stage, commit, generate, or refresh source, docs, canon, validator, helper, release-note, or desktop handoff files
 
 Allowed in `Release Readiness`:
 
@@ -510,9 +521,11 @@ Forbidden in `Release Readiness`:
 - branch-authority cleanup that should have been merge-safe before PR green
 - next-workstream selection, planning, or branch creation
 - between-branch canon repair
+- any source, docs, canon, validator, helper, release-note, or handoff-file mutation
 - direct writes to `main` unless the user explicitly authorizes an emergency direct-main action
 
 If Release Readiness discovers missing PR-owned canon or docs work, stop immediately and classify the issue as `PR Readiness Scope Missed` and `Release Readiness Scope Drift`.
+If the branch has not merged, return to `PR Readiness` and repair the miss there before any Release Readiness output can be treated as green.
 If the branch has already merged, the next active branch's `Branch Readiness` must repair the miss before implementation begins and must update governance or validator coverage so the miss cannot recur.
 
 ### Governance Drift Audit
@@ -604,6 +617,7 @@ That validator should verify at minimum:
 - stale merge-era wording does not remain in active current-state owners
 - Governance Drift Audit output exists before `Release Readiness`
 - release-bearing branches carry `Release Target:`, `Release Scope:`, and `Release Artifacts:` markers before Release Readiness can report green
+- Release Readiness is analysis-only and cannot mutate files; dirty tracked files while the authority record says `Release Readiness` are a `Release Readiness File Mutation Attempt`
 - non-release waiver records use `Release Branch: No` only for preserved historical records or explicitly authorized direct-main emergency contexts
 - unresolved blockers prevent phase advancement
 - active-branch governance and canon updates remain the primary path when tightly coupled to the active branch's truth, phase, readiness, validation, closeout, or release state
@@ -911,8 +925,8 @@ The canonical rule is narrower:
 - `Workstream` -> `Hardening` only after the approved same-risk Workstream seam sequence is complete, direct validation is green, User Test Summary obligations are current for user-facing changes, and no same-slice correctness gap remains
 - `Hardening` -> `Live Validation` only after repo-side hardening proof is sufficient for interactive or manual closeout work
 - `Live Validation` -> `PR Readiness` only after branch-local proof is sufficient for closeout, returned evidence has been digested into the authority record, and `User Test Summary Results Pending` is absent or cleared by a documented waiver
-- `PR Readiness` -> `Release Readiness` only after merge-target canon completeness passes, the Governance Drift Audit passes, the next-workstream selection gate passes, and branch creation remains deferred to `Branch Readiness`
-- `Release Readiness` stays restricted to release target, scope, artifact, release-execution authorization, and release-state confirmation work; it does not transition into a docs-sync phase
+- `PR Readiness` -> `Release Readiness` only after merge-target canon completeness passes, the Governance Drift Audit passes, the next-workstream selection gate passes, branch creation remains deferred to `Branch Readiness`, and any release target/scope/artifact truth needed for release review is already available without file mutation
+- `Release Readiness` stays restricted to analysis-only release target, scope, artifact, release-execution authorization, and release-state confirmation work; it does not transition into a docs-sync phase or a file-mutation phase
 
 There is no default direct `Workstream` -> `PR Readiness` transition.
 If Workstream appears complete, the next normal phase is `Hardening` unless an explicit authority-record waiver says otherwise.
@@ -1143,6 +1157,7 @@ Forbidden:
 - hidden next-lane planning
 - branch-authority cleanup that should have been merge-safe in PR Readiness
 - between-branch canon repair
+- source, docs, canon, validator, helper, release-note, or handoff-file mutation
 
 Required evidence:
 
@@ -1150,6 +1165,7 @@ Required evidence:
 - explicit `Release Target:`, `Release Scope:`, and `Release Artifacts:` markers for release-bearing branches
 - or explicit `Release Branch: No` only for preserved historical records or explicitly authorized direct-main emergency contexts
 - release-context verification
+- clean tracked-file state; any required file update must be routed back to `PR Readiness` before merge or to the next active branch's `Branch Readiness` after merge
 - no unresolved blocker
 
 Exit:

--- a/Docs/workstreams/FB-038_taskbar_tray_quick_task_ux.md
+++ b/Docs/workstreams/FB-038_taskbar_tray_quick_task_ux.md
@@ -109,7 +109,7 @@ Fresh post-Hardening Live Validation produced a returned User Test Summary failu
 
 ## Governance Drift Audit
 
-- Governance Drift Found: No.
+- Governance Drift Found: Yes, repaired in PR Readiness.
 - Audit Date: 2026-04-21.
 - Audit Scope:
   PR Readiness review of FB-038 branch truth, merge-target canon, post-merge state, next-workstream selection, helper registry obligations, desktop shortcut/UTS gates, and dirty-branch durability.
@@ -122,6 +122,7 @@ Fresh post-Hardening Live Validation produced a returned User Test Summary failu
   - desktop-shortcut blocker is clear because `User-Facing Shortcut Validation: PASS` is recorded with fresh post-H4 evidence.
   - uts-results blocker is clear because `User Test Summary Results: WAIVED` is recorded with operator-confirmed waiver digestion.
   - PR Readiness scope-miss blockers are clear: no branch-authority cleanup is required for this backlog-backed implementation branch, no between-branch canon repair is planned, no successor branch exists, and no PR-owned docs work is deferred into Release Readiness.
+  - Release Readiness file-mutation boundary drift was found and repaired during PR Readiness re-entry: Release Readiness is now analysis-only for repository files, and any required file mutation must return to PR Readiness before merge or defer to the next active branch's Branch Readiness after merge.
 - Helper Governance Finding:
   FB-038 workstream-scoped helpers remain registered and are intentionally retained as FB-038 evidence helpers after merge. They are not promoted to reusable helpers in this branch because reuse would prematurely generalize tray-origin authoring proof before a second branch needs it. Future tray-origin or authoring work must consolidate these helpers into a reusable tray/Create Custom Task live helper or the saved-action interactive suite before creating another helper.
 

--- a/dev/orin_branch_governance_validation.py
+++ b/dev/orin_branch_governance_validation.py
@@ -346,6 +346,23 @@ RELEASE_READINESS_SCOPE_PHRASES = (
     "docs-sync",
 )
 
+RELEASE_READINESS_FILE_FREEZE_DOCS = (
+    Path("Docs/phase_governance.md"),
+    Path("Docs/development_rules.md"),
+    Path("Docs/Main.md"),
+    Path("Docs/codex_modes.md"),
+    Path("Docs/orin_task_template.md"),
+    Path("Docs/codex_user_guide.md"),
+    Path("Docs/incident_patterns.md"),
+)
+
+RELEASE_READINESS_FILE_FREEZE_PHRASES = (
+    "Release Readiness File Mutation Attempt",
+    "analysis-only",
+    "return to `PR Readiness`",
+    "next active branch's `Branch Readiness`",
+)
+
 REQUIRED_RELEASE_BEARING_MARKERS = (
     "Release Target:",
     "Release Scope:",
@@ -1040,6 +1057,14 @@ def main() -> int:
                 f"{relative_path}: Release Readiness docs-sync scope boundary is missing '{required_phrase}'",
             )
 
+    for relative_path in RELEASE_READINESS_FILE_FREEZE_DOCS:
+        text = _read_text(relative_path).casefold()
+        for required_phrase in RELEASE_READINESS_FILE_FREEZE_PHRASES:
+            require(
+                required_phrase.casefold() in text,
+                f"{relative_path}: Release Readiness file-freeze guidance is missing '{required_phrase}'",
+            )
+
     active_index_paths = _collect_active_index_paths(index_text)
     closed_index_paths = _collect_closed_index_paths(index_text)
     release_debt_index_paths = _collect_release_debt_index_paths(index_text)
@@ -1374,6 +1399,16 @@ def main() -> int:
                 f"{canonical_path}: Governance Drift Audit is missing 'Governance Drift Found:'",
             )
 
+        if current_phase == "Release Readiness":
+            status_output = _git_status_porcelain()
+            require(
+                not status_output,
+                (
+                    f"{canonical_path}: Release Readiness File Mutation Attempt blocker is active; "
+                    "tracked files are dirty while Current Phase is Release Readiness"
+                ),
+            )
+
         if current_phase == "PR Readiness":
             post_merge_state = _section(workstream_text, "Post-Merge State")
             require(
@@ -1528,6 +1563,15 @@ def main() -> int:
             str(info["next_legal_phase"]) in PHASES,
             f"{branch_record_path}: Next Legal Phase '{info['next_legal_phase']}' is not in the canonical phase enum",
         )
+        if branch_record_path in active_branch_record_paths and str(info["current_phase"]) == "Release Readiness":
+            status_output = _git_status_porcelain()
+            require(
+                not status_output,
+                (
+                    f"{branch_record_path}: Release Readiness File Mutation Attempt blocker is active; "
+                    "tracked files are dirty while Current Phase is Release Readiness"
+                ),
+            )
         if branch_record_path in active_branch_record_paths:
             require(
                 "`Active Branch`" in phase_status_section,


### PR DESCRIPTION
## Summary

Includes governance repair enforcing Release Readiness as analysis-only (file-freeze).

## What Changed

No detailed branch evidence was preserved in the original PR body.

Historical metadata preserved for traceability:
- Base: `main`
- Head: `feature/fb-038-taskbar-tray-quick-task-ux`
- Head commit: `0049602a4aa1f127106224ec08fa52f71b958eab`

Historical metadata preserved for traceability:
- Base: `main`
- Head: `feature/fb-038-taskbar-tray-quick-task-ux`
- Head commit: `0049602a4aa1f127106224ec08fa52f71b958eab`
