### PR TITLE
docs: enforce FB-038 patch prerelease target

### DIFF
--- a/Docs/Main.md
+++ b/Docs/Main.md
@@ -253,10 +253,11 @@ These are reference layers, not active workstream or roadmap owners.
   13. run the normal branch governance validator and the PR-readiness gate mode
   14. only then allow the current branch to report `PR READY: YES` and enter PR creation
 - PR Readiness also owns `PR Readiness Scope Missed`, `Between-Branch Canon Repair Attempt`, and `Next Branch Created Too Early`; none may be deferred into Release Readiness or a later side branch
-- PR Readiness also owns the merged-unreleased release-debt owner contract when a branch will merge unreleased implementation work; the merge-target canon must already contain `Merged-Unreleased Release-Debt Owner:`, `Repo State: No Active Branch`, `Release Target:`, `Release Scope:`, `Release Artifacts:`, `Post-Release Truth:`, `Selected Next Workstream:`, and `Next-Branch Creation Gate:` before PR green
+- PR Readiness also owns the merged-unreleased release-debt owner contract when a branch will merge unreleased implementation work; the merge-target canon must already contain `Merged-Unreleased Release-Debt Owner:`, `Repo State: No Active Branch`, `Release Target:`, `Release Floor:`, `Version Rationale:`, `Release Scope:`, `Release Artifacts:`, `Post-Release Truth:`, `Selected Next Workstream:`, and `Next-Branch Creation Gate:` before PR green
+- PR Readiness must validate release target semantics from the latest public prerelease and declared `Release Floor:` before green; marker presence is insufficient if the version is wrong
 - the normal `Release Readiness` sequence for a release-bearing branch must clear `Release Target Undefined` before reporting green:
   1. confirm whether the branch is release-bearing or explicitly non-release
-  2. for release-bearing branches, require machine-checkable `Release Target:`, `Release Scope:`, and `Release Artifacts:` markers before Release Readiness can report green
+  2. for release-bearing branches, require machine-checkable `Release Target:`, `Release Floor:`, `Version Rationale:`, `Release Scope:`, and `Release Artifacts:` markers before Release Readiness can report green
   3. for non-release branches, require `Release Branch: No`
   4. allow `Release Branch: No` only for preserved historical records
   5. never use the non-release waiver for `implementation` or `release packaging` branches

--- a/Docs/codex_modes.md
+++ b/Docs/codex_modes.md
@@ -184,9 +184,12 @@ When the approved phase is `PR Readiness`, the output must also explicitly inclu
   - the blocking admission item
   - `Merged-Unreleased Release-Debt Owner:`
   - `Release Target:`
+  - `Release Floor:`
+  - `Version Rationale:`
   - `Release Scope:`
   - `Release Artifacts:`
   - `Post-Release Truth:`
+  - confirmation that the release target is semantically correct from the latest public prerelease and declared release floor
   - confirmation that branch creation remains deferred and no next implementation branch may execute by inertia
 - a required `## Next Branch` section with this exact field shape:
 
@@ -227,8 +230,11 @@ When the approved phase is `Release Readiness`, the output must also explicitly 
 - confirmation that `Release Target Undefined` is clear
 - for release-bearing branches:
   - `Release Target:`
+  - `Release Floor:`
+  - `Version Rationale:`
   - `Release Scope:`
   - `Release Artifacts:`
+  - confirmation that marker presence and semantic target correctness both pass
 - for explicitly non-release branches:
   - `Release Branch: No`
   - confirmation that this is only a historical context, not a new governance-only branch or a direct-main repair path

--- a/Docs/codex_user_guide.md
+++ b/Docs/codex_user_guide.md
@@ -82,6 +82,8 @@ For bounded multi-seam Workstream execution, also include:
 For Release Readiness, also include:
 
 - `Release Target: <version or identifier>` for release-bearing branches
+- `Release Floor: <patch prerelease / minor prerelease / no release>` for release-bearing branches
+- `Version Rationale: <why the target follows the floor>` for release-bearing branches
 - `Release Scope: <bounded release scope>` for release-bearing branches
 - `Release Artifacts: <tag, notes, rebaseline, or other release artifacts>` for release-bearing branches
 - `Release Branch: No` only for preserved historical records
@@ -361,6 +363,8 @@ Required add-ons for release-bearing branches:
 
 - `Phase: Release Readiness`
 - `Release Target: [version or release identifier]`
+- `Release Floor: [patch prerelease / minor prerelease / no release]`
+- `Version Rationale: [why this is patch/minor/no release]`
 - `Release Scope: [bounded release scope]`
 - `Release Artifacts: [tag, notes, rebaseline, or other release artifacts]`
 - `No file changes`
@@ -371,9 +375,10 @@ Required add-on for non-release branches:
 
 Use `Release Branch: No` only for preserved historical records.
 Do not use `Release Branch: No` for `implementation` or `release packaging` branches.
-If a release-bearing branch lacks `Release Target:`, `Release Scope:`, or `Release Artifacts:`, Release Readiness is blocked by `Release Target Undefined`.
+If a release-bearing branch lacks `Release Target:`, `Release Floor:`, `Version Rationale:`, `Release Scope:`, or `Release Artifacts:`, Release Readiness is blocked by `Release Target Undefined`.
+If the declared target is semantically wrong for the latest public prerelease and declared release floor, it is also blocked by `Release Target Undefined`.
 If Release Readiness analysis discovers missing, stale, or ambiguous release truth that requires a file update, do not patch in Release Readiness. Return to `PR Readiness` before merge, or defer the repair to the next active branch's `Branch Readiness` after merge. Treat any file mutation while the authority record says `Release Readiness` as `Release Readiness File Mutation Attempt`.
-Release Readiness consumes inherited release truth only; it must not create `Release Target:`, `Release Scope:`, `Release Artifacts:`, merged-unreleased owner, or post-release truth in repository files.
+Release Readiness consumes inherited release truth only; it must not create `Release Target:`, `Release Floor:`, `Version Rationale:`, `Release Scope:`, `Release Artifacts:`, merged-unreleased owner, or post-release truth in repository files.
 
 ### Run A Narrow Fix Pass
 

--- a/Docs/development_rules.md
+++ b/Docs/development_rules.md
@@ -239,7 +239,9 @@ That means:
   - if post-merge truth needs `No Active Branch` handling, release-debt handling, next-workstream planning, next-workstream canon sync, minimal scope, or branch-creation deferral, that handling must already be complete inside PR Readiness
 - no PR-ready with an incomplete merged-unreleased release-debt owner contract:
   - if merge will create unreleased implementation release debt, PR Readiness must leave merge-target canon in the exact post-merge shape
-  - required machine-checkable fields are `Merged-Unreleased Release-Debt Owner:`, `Repo State: No Active Branch`, `Release Target:`, `Release Scope:`, `Release Artifacts:`, `Post-Release Truth:`, `Selected Next Workstream:`, and `Next-Branch Creation Gate:`
+  - required machine-checkable fields are `Merged-Unreleased Release-Debt Owner:`, `Repo State: No Active Branch`, `Release Target:`, `Release Floor:`, `Version Rationale:`, `Release Scope:`, `Release Artifacts:`, `Post-Release Truth:`, `Selected Next Workstream:`, and `Next-Branch Creation Gate:`
+  - release-target correctness is semantic, not marker-only: derive the target from the latest public prerelease and the declared `Release Floor:` before PR green
+  - `patch prerelease` increments patch only, for example `v1.4.0-prebeta` -> `v1.4.1-prebeta`; `minor prerelease` increments minor and resets patch, for example `v1.4.0-prebeta` -> `v1.5.0-prebeta`
   - active-branch truth must be removed from main-facing backlog, roadmap, and workstreams index canon before PR green
   - Release Readiness consumes these inherited fields; it must not create or repair them in files
 - no PR-ready with a dirty branch:
@@ -264,7 +266,8 @@ That means:
   - do not defer that work to Release Readiness, updated `main`, a later governance-only branch, or a between-branch repair window
   - if the next branch already exists before the current branch merged and updated `main` was revalidated, block as `Next Branch Created Too Early`
 - no Release Readiness green with `Release Target Undefined`:
-  - a release-bearing branch must explicitly declare `Release Target:`, `Release Scope:`, and `Release Artifacts:` before Release Readiness can report green
+  - a release-bearing branch must explicitly declare `Release Target:`, `Release Floor:`, `Version Rationale:`, `Release Scope:`, and `Release Artifacts:` before Release Readiness can report green
+  - stale or semantically mismatched release target truth is still `Release Target Undefined`, even when all fields are present
   - Release Readiness is analysis-only for repository files; it may produce release package information in the response, but it must not edit, stage, commit, generate, or refresh source, docs, canon, validator, helper, release-note, or handoff files
   - if Release Readiness analysis discovers missing, stale, or ambiguous release target/scope/artifact truth, do not patch in Release Readiness; return to `PR Readiness` on the active branch if unmerged, or defer the repair to the next active branch's `Branch Readiness` if already merged
   - tracked file changes while the authority record says `Release Readiness` are blocked as `Release Readiness File Mutation Attempt`

--- a/Docs/feature_backlog.md
+++ b/Docs/feature_backlog.md
@@ -44,14 +44,16 @@ Blocker: Release Debt
 Record State: Promoted
 Priority: Medium
 Release Stage: pre-Beta
-Target Version: v1.5.0-prebeta
+Target Version: v1.4.1-prebeta
 Canonical Workstream Doc: Docs/workstreams/FB-038_taskbar_tray_quick_task_ux.md
 Merged-Unreleased Release-Debt Owner: FB-038
 Repo State: No Active Branch
-Release Target: v1.5.0-prebeta
+Release Target: v1.4.1-prebeta
+Release Floor: patch prerelease
+Version Rationale: FB-038 is tray UX, startup sequencing fix, and governance repair follow-through; it does not open a new feature lane or capability expansion beyond the completed tray/task UX milestone.
 Release Scope: FB-038 tray/task UX milestone only: tray identity/discoverability, tray Open Command Overlay, tray Create Custom Task dialog-open/no-write route, tray-origin create completion through existing FB-036 authoring, catalog reload, exact-match resolution, confirm/result execution, and startup first-visible Core Visualization repair.
-Release Artifacts: tag `v1.5.0-prebeta`; release title `Nexus Desktop AI v1.5.0-prebeta - Tray Quick-Task UX`; release notes summarizing FB-038 user-facing tray/task UX, validation evidence, and retained FB-038 evidence helpers.
-Post-Release Truth: after release, FB-038 can move to `Closed` / `Released (v1.5.0-prebeta)`, release debt clears, and repo-level admission may reconsider FB-039 Branch Readiness from updated `main`.
+Release Artifacts: tag `v1.4.1-prebeta`; release title `Nexus Desktop AI v1.4.1-prebeta - Tray Quick-Task UX`; release notes summarizing FB-038 user-facing tray/task UX, validation evidence, and retained FB-038 evidence helpers.
+Post-Release Truth: after release, FB-038 can move to `Closed` / `Released (v1.4.1-prebeta)`, release debt clears, and repo-level admission may reconsider FB-039 Branch Readiness from updated `main`.
 Selected Next Workstream: FB-039 External trigger and plugin integration architecture.
 Next-Branch Creation Gate: FB-039 remains selected-only and `Branch: Not created` until FB-038 release debt is cleared and updated `main` passes the repo-level admission gate.
 Minimal Scope: Merged-unreleased release-debt owner for completed FB-038 tray quick-task UX; Release Readiness may validate inherited target/scope/artifacts but must not mutate repository files.

--- a/Docs/incident_patterns.md
+++ b/Docs/incident_patterns.md
@@ -34,15 +34,15 @@ Branch-local "what worked" notes should stay in the canonical workstream doc fir
 ## Pattern: Release Readiness Green Must Require Explicit Release Target
 
 - symptom:
-  Release Readiness can appear green while the branch has not yet named the release version, bounded release scope, or release artifacts it is supposed to package
+  Release Readiness can appear green while the branch has not yet named the release version, release floor, version rationale, bounded release scope, or release artifacts it is supposed to package, or while the named target is semantically wrong
 - layer:
   branch governance and release-facing canon
 - root-cause pattern:
-  release-debt truth is present, but release-bearing branch records lack machine-checkable markers that prove the release target is explicit before green status
+  release-debt truth is present, but release-bearing branch records lack machine-checkable markers that prove the release target is explicit and semantically correct before green status
 - fix pattern:
-  require release-bearing branches to declare `Release Target:`, `Release Scope:`, and `Release Artifacts:`; allow `Release Branch: No` only for preserved historical records
+  require release-bearing branches to declare `Release Target:`, `Release Floor:`, `Version Rationale:`, `Release Scope:`, and `Release Artifacts:`; validate target semantics from the latest public prerelease and declared floor; allow `Release Branch: No` only for preserved historical records
 - validation pattern:
-  run the branch governance validator; it must fail release-packaging branch records that omit release target markers or branch records that use the non-release waiver outside preserved historical records
+  run the branch governance validator; it must fail release-packaging branch records that omit release target markers, declare a semantically wrong target, or use the non-release waiver outside preserved historical records
 
 ## Pattern: Release Readiness File Mutation Must Backflow
 
@@ -86,9 +86,10 @@ Branch-local "what worked" notes should stay in the canonical workstream doc fir
 - root-cause pattern:
   PR Readiness recorded future post-merge prose but did not leave machine-checkable merged-unreleased release-debt fields in the exact post-merge shape that `main` needs after merge
 - fix pattern:
-  require `Merged-Unreleased Release-Debt Owner:`, `Repo State: No Active Branch`, `Release Target:`, `Release Scope:`, `Release Artifacts:`, `Post-Release Truth:`, `Selected Next Workstream:`, and `Next-Branch Creation Gate:` before PR green when a branch will merge unreleased implementation work
+  require `Merged-Unreleased Release-Debt Owner:`, `Repo State: No Active Branch`, `Release Target:`, `Release Floor:`, `Version Rationale:`, `Release Scope:`, `Release Artifacts:`, `Post-Release Truth:`, `Selected Next Workstream:`, and `Next-Branch Creation Gate:` before PR green when a branch will merge unreleased implementation work
+  validate release target semantics from the latest public prerelease and declared release floor before PR green
 - validation pattern:
-  run `python dev/orin_branch_governance_validation.py` plus the PR-readiness gate mode; the validator must fail if a promoted merged-unreleased workstream remains under Active, lacks release target/scope/artifacts, or if `main` carries tracked file mutation during Codex work
+  run `python dev/orin_branch_governance_validation.py` plus the PR-readiness gate mode; the validator must fail if a promoted merged-unreleased workstream remains under Active, lacks release target/floor/rationale/scope/artifacts, carries a semantically wrong release target, or if `main` carries tracked file mutation during Codex work
 - source references:
   - `Docs/phase_governance.md`
   - `Docs/prebeta_roadmap.md`

--- a/Docs/orin_task_template.md
+++ b/Docs/orin_task_template.md
@@ -56,6 +56,12 @@ Release Branch:
 Release Target:
 [required for release-bearing branches]
 
+Release Floor:
+[patch prerelease / minor prerelease / no release]
+
+Version Rationale:
+[required for release-bearing branches; explain why the floor matches the work]
+
 Release Scope:
 [required for release-bearing branches]
 
@@ -99,7 +105,8 @@ If a governance or canon update is directly required to keep the active current 
 Add `Validation Contract`, `Timeout Contract`, and `Current active seam` when the governed task needs them.
 Add `Seam Sequence` when the Workstream prompt may use bounded multi-seam workflow.
 If `Seam Sequence` is present, Codex must execute one active seam at a time, validate after each seam, and report a continue-or-stop decision before starting the next seam.
-For `Release Readiness`, a release-bearing branch must include `Release Target:`, `Release Scope:`, and `Release Artifacts:` before green status is allowed.
+For `Release Readiness`, a release-bearing branch must include `Release Target:`, `Release Floor:`, `Version Rationale:`, `Release Scope:`, and `Release Artifacts:` before green status is allowed.
+For `PR Readiness`, release-bearing merge-target canon must prove the target is semantically correct from the latest public prerelease and declared release floor before green status is allowed.
 `Release Readiness` is analysis-only for repository files. It may produce release package information in the response, but it must not edit, stage, commit, generate, or refresh source, docs, canon, validator, helper, release-note, or handoff files.
 If a file change is needed during `Release Readiness`, classify `Release Readiness File Mutation Attempt`, return to `PR Readiness` before merge, or defer to the next active branch's `Branch Readiness` after merge.
 Use `Release Branch: No` only for preserved historical records.
@@ -299,8 +306,8 @@ If an execution task is too broad for one approved pass, explain the cleaner exe
 4. Explain the next legal phase or say explicitly that repo state is `No Active Branch`.
 5. If in `Branch Readiness`, explain the whole-branch execution plan before Workstream admission.
 6. If in `Workstream`, explain whether bounded multi-seam workflow is safe; if it is, list the seam sequence, per-seam gates, and stop conditions.
-7. If in `PR Readiness`, explicitly plan the stale-canon check, post-merge-state handling, next-workstream selection/canon/minimal-scope/no-branch-exists check, required `Next Workstream: Selected`, `Minimal Scope:`, `## Selected Next Workstream`, and `Branch: Not created` markers, dirty-branch/durable-commit check, docs-sync/drift-audit check, `PR Readiness Scope Missed`, `Between-Branch Canon Repair Attempt`, `Next Branch Created Too Early`, normal governance validator, PR-readiness gate mode, required `## Next Branch` response block, and copy-ready `## PR Creation Details` package.
-8. If in `Release Readiness`, explicitly plan the `Release Target Undefined` check, required inherited `Release Target:`, `Release Scope:`, and `Release Artifacts:` markers for release-bearing branches, confirm Release Readiness is not being used for broad docs sync or branch-authority cleanup, and confirm no repository file mutation will occur in the phase.
+7. If in `PR Readiness`, explicitly plan the stale-canon check, post-merge-state handling, release-target semantic check from latest public prerelease plus `Release Floor:`, next-workstream selection/canon/minimal-scope/no-branch-exists check, required `Next Workstream: Selected`, `Minimal Scope:`, `## Selected Next Workstream`, and `Branch: Not created` markers, dirty-branch/durable-commit check, docs-sync/drift-audit check, `PR Readiness Scope Missed`, `Between-Branch Canon Repair Attempt`, `Next Branch Created Too Early`, normal governance validator, PR-readiness gate mode, required `## Next Branch` response block, and copy-ready `## PR Creation Details` package.
+8. If in `Release Readiness`, explicitly plan the `Release Target Undefined` check, required inherited `Release Target:`, `Release Floor:`, `Version Rationale:`, `Release Scope:`, and `Release Artifacts:` markers for release-bearing branches, confirm Release Readiness is not being used for broad docs sync or branch-authority cleanup, and confirm no repository file mutation will occur in the phase.
 9. Explain the validation plan.
 10. If a User Test Summary handoff is relevant, explicitly state whether returned results are `PENDING`, `PASS`, `FAIL`, or `WAIVED`; `PENDING` is the hard blocker `User Test Summary Results Pending`.
 

--- a/Docs/phase_governance.md
+++ b/Docs/phase_governance.md
@@ -314,6 +314,8 @@ Required machine-checkable fields:
 - `Merged-Unreleased Release-Debt Owner:`
 - `Repo State: No Active Branch`
 - `Release Target:`
+- `Release Floor:`
+- `Version Rationale:`
 - `Release Scope:`
 - `Release Artifacts:`
 - `Post-Release Truth:`
@@ -329,6 +331,14 @@ Required owner docs:
 
 Release Readiness consumes this inherited release truth.
 Release Readiness may validate target, scope, artifacts, and post-release truth, but it must not create or repair those fields in repository files.
+
+Release target correctness is semantic, not marker-only.
+PR Readiness must derive the target from the latest public prerelease and the declared `Release Floor:` before green:
+
+- `patch prerelease` increments only the patch number, for example `v1.4.0-prebeta` -> `v1.4.1-prebeta`
+- `minor prerelease` increments the minor number and resets patch to zero, for example `v1.4.0-prebeta` -> `v1.5.0-prebeta`
+
+If the declared target, artifacts, or post-release truth do not match the semantic release floor, keep `Release Target Undefined` active and repair the mismatch in PR Readiness before Release Readiness.
 
 ### Successor Lane Lock Gate
 
@@ -524,8 +534,12 @@ Hard blocker:
 - `Release Target Undefined`:
   Release Readiness fails for a release-bearing branch unless the active branch authority record or active workstream authority record explicitly identifies all required release-bearing markers:
   - `Release Target:`
+  - `Release Floor:`
+  - `Version Rationale:`
   - `Release Scope:`
   - `Release Artifacts:`
+
+  The target must also be semantically correct from the latest public prerelease and declared release floor; marker presence alone is not enough.
 
 A branch is release-bearing when:
 
@@ -666,7 +680,8 @@ That validator should verify at minimum:
 - backlog, roadmap, workstreams index, and active workstream docs agree on active or merged-unreleased posture
 - stale merge-era wording does not remain in active current-state owners
 - Governance Drift Audit output exists before `Release Readiness`
-- release-bearing branches carry `Release Target:`, `Release Scope:`, and `Release Artifacts:` markers before Release Readiness can report green
+- release-bearing branches carry `Release Target:`, `Release Floor:`, `Version Rationale:`, `Release Scope:`, and `Release Artifacts:` markers before Release Readiness can report green
+- release-target semantics match the latest public prerelease and declared release floor before PR Readiness or Release Readiness can report green
 - Release Readiness is analysis-only and cannot mutate files; dirty tracked files while the authority record says `Release Readiness` are a `Release Readiness File Mutation Attempt`
 - non-release waiver records use `Release Branch: No` only for preserved historical records
 - unresolved blockers prevent phase advancement
@@ -1212,7 +1227,7 @@ Forbidden:
 Required evidence:
 
 - merged or legitimately merge-ready truth
-- explicit `Release Target:`, `Release Scope:`, and `Release Artifacts:` markers for release-bearing branches
+- explicit `Release Target:`, `Release Floor:`, `Version Rationale:`, `Release Scope:`, and `Release Artifacts:` markers for release-bearing branches
 - or explicit `Release Branch: No` only for preserved historical records
 - release-context verification
 - clean tracked-file state; any required file update must be routed back to `PR Readiness` before merge or to the next active branch's `Branch Readiness` after merge

--- a/Docs/prebeta_roadmap.md
+++ b/Docs/prebeta_roadmap.md
@@ -84,10 +84,12 @@ Status: `Merged Unreleased (Release Debt)`
 canonical workstream doc: `Docs/workstreams/FB-038_taskbar_tray_quick_task_ux.md`
 Merged-Unreleased Release-Debt Owner: FB-038
 Repo State: No Active Branch
-Release Target: v1.5.0-prebeta
+Release Target: v1.4.1-prebeta
+Release Floor: patch prerelease
+Version Rationale: FB-038 is tray UX, startup sequencing fix, and governance repair follow-through; it does not open a new feature lane or capability expansion beyond the completed tray/task UX milestone.
 Release Scope: FB-038 tray/task UX milestone only: tray identity/discoverability, tray Open Command Overlay, tray Create Custom Task dialog-open/no-write route, tray-origin create completion through existing FB-036 authoring, catalog reload, exact-match resolution, confirm/result execution, and startup first-visible Core Visualization repair.
-Release Artifacts: tag `v1.5.0-prebeta`; release title `Nexus Desktop AI v1.5.0-prebeta - Tray Quick-Task UX`; release notes summarizing FB-038 user-facing tray/task UX, validation evidence, and retained FB-038 evidence helpers.
-Post-Release Truth: after release, FB-038 should be represented as `Released (v1.5.0-prebeta)` / `Closed`; release debt clears; the latest public prerelease advances from `v1.4.0-prebeta` to `v1.5.0-prebeta`.
+Release Artifacts: tag `v1.4.1-prebeta`; release title `Nexus Desktop AI v1.4.1-prebeta - Tray Quick-Task UX`; release notes summarizing FB-038 user-facing tray/task UX, validation evidence, and retained FB-038 evidence helpers.
+Post-Release Truth: after release, FB-038 should be represented as `Released (v1.4.1-prebeta)` / `Closed`; release debt clears; the latest public prerelease advances from `v1.4.0-prebeta` to `v1.4.1-prebeta`.
 Selected Next Workstream: FB-039 External Trigger And Plugin Integration Architecture.
 Next-Branch Creation Gate: FB-039 remains selected-only and `Branch: Not created` until FB-038 release debt is cleared and updated `main` passes the repo-level admission gate.
 

--- a/Docs/workstreams/FB-038_taskbar_tray_quick_task_ux.md
+++ b/Docs/workstreams/FB-038_taskbar_tray_quick_task_ux.md
@@ -19,7 +19,7 @@
 
 ## Target Version
 
-- `v1.5.0-prebeta`
+- `v1.4.1-prebeta`
 
 ## Canonical Branch
 
@@ -33,16 +33,17 @@ This workstream exists so taskbar or tray access and Create Custom Task entry ar
 
 ## Current Phase
 
-- Phase: `Release Readiness`
+- Phase: `PR Readiness`
 
 ## Phase Status
 
-- `No Active Branch`
-- current active implementation branch: none
+- `Active Branch`
+- current active implementation/repair branch: `feature/fb-038-taskbar-tray-quick-task-ux`
 - legal repair surface for this governance repair: `feature/fb-038-taskbar-tray-quick-task-ux`
 - protected-main rule: `main` is read-only for Codex work; no editing, staging, committing, generation, refresh, or direct repair on `main`
 - FB-038 has been squash-merged to `main`
-- FB-038 is now the merged-unreleased release-debt owner until release packaging clears `v1.5.0-prebeta`
+- FB-038 is now the merged-unreleased release-debt owner until release packaging clears `v1.4.1-prebeta`
+- PR Readiness re-entry is active on the still-available prior branch to correct inherited release-target truth before a follow-up PR/squash merge
 - Branch Readiness is complete and durably checkpointed in commit `766ff67`
 - Workstream seam chain and helper governance are complete and durably checkpointed in commit `ef05ab2`
 - Hardening execution pass completed on 2026-04-21; branch-wide validator and helper sweep is green
@@ -67,7 +68,7 @@ This workstream exists so taskbar or tray access and Create Custom Task entry ar
 
 ## Blockers
 
-- `Release Debt`
+- None.
 
 ## Entry Basis
 
@@ -115,7 +116,7 @@ This workstream exists so taskbar or tray access and Create Custom Task entry ar
 
 Live Validation was previously admitted after validating Workstream closure, Hardening GREEN evidence, User Test Summary alignment, helper registry compliance, and clean branch truth. Returned User Test Summary evidence first routed to bounded tray discoverability Hardening and then to bounded window initialization Hardening.
 
-Fresh post-Hardening Live Validation produced a returned User Test Summary failure: desktop shortcut launch briefly showed a black placeholder window before Core Visualization. H3/H4 Hardening re-entry is now green. Fresh post-H4 Live Validation technical/live evidence is green and a new User Test Summary handoff was exported. The UTS result was resolved by operator-confirmed waiver artifact on 2026-04-21, so `User Test Summary Results Pending` is cleared. PR Readiness completed and FB-038 was squash-merged to `main`. FB-038 is now merged-unreleased release debt; Release Readiness may be rerun only after this repaired release-debt truth is durable.
+Fresh post-Hardening Live Validation produced a returned User Test Summary failure: desktop shortcut launch briefly showed a black placeholder window before Core Visualization. H3/H4 Hardening re-entry is now green. Fresh post-H4 Live Validation technical/live evidence is green and a new User Test Summary handoff was exported. The UTS result was resolved by operator-confirmed waiver artifact on 2026-04-21, so `User Test Summary Results Pending` is cleared. PR Readiness completed and FB-038 was squash-merged to `main`. FB-038 is now merged-unreleased release debt; PR Readiness re-entry is correcting the inherited release target before Release Readiness may be rerun from durable merged truth.
 
 ## Governance Drift Audit
 
@@ -158,10 +159,12 @@ Fresh post-Hardening Live Validation produced a returned User Test Summary failu
 
 Merged-Unreleased Release-Debt Owner: FB-038
 Repo State: No Active Branch
-Release Target: v1.5.0-prebeta
+Release Target: v1.4.1-prebeta
+Release Floor: patch prerelease
+Version Rationale: FB-038 is tray UX, startup sequencing fix, and governance repair follow-through; it does not open a new feature lane or capability expansion beyond the completed tray/task UX milestone.
 Release Scope: FB-038 tray/task UX milestone only: tray identity/discoverability, tray Open Command Overlay, tray Create Custom Task dialog-open/no-write route, tray-origin create completion through existing FB-036 authoring, catalog reload, exact-match resolution, confirm/result execution, and startup first-visible Core Visualization repair.
-Release Artifacts: tag `v1.5.0-prebeta`; release title `Nexus Desktop AI v1.5.0-prebeta - Tray Quick-Task UX`; release notes summarizing FB-038 user-facing tray/task UX, validation evidence, and retained FB-038 evidence helpers.
-Post-Release Truth: after release, FB-038 moves to `Closed` / `Released (v1.5.0-prebeta)`, release debt clears, roadmap latest public prerelease advances to `v1.5.0-prebeta`, and repo-level admission may reconsider FB-039 Branch Readiness from updated `main`.
+Release Artifacts: tag `v1.4.1-prebeta`; release title `Nexus Desktop AI v1.4.1-prebeta - Tray Quick-Task UX`; release notes summarizing FB-038 user-facing tray/task UX, validation evidence, and retained FB-038 evidence helpers.
+Post-Release Truth: after release, FB-038 moves to `Closed` / `Released (v1.4.1-prebeta)`, release debt clears, roadmap latest public prerelease advances to `v1.4.1-prebeta`, and repo-level admission may reconsider FB-039 Branch Readiness from updated `main`.
 Selected Next Workstream: FB-039 External trigger and plugin integration architecture.
 Next-Branch Creation Gate: FB-039 remains selected-only and `Branch: Not created` until FB-038 release debt is cleared and updated `main` passes the repo-level admission gate.
 

--- a/dev/orin_branch_governance_validation.py
+++ b/dev/orin_branch_governance_validation.py
@@ -329,6 +329,8 @@ RELEASE_READINESS_TARGET_DOCS = (
 RELEASE_READINESS_TARGET_PHRASES = (
     "Release Target Undefined",
     "Release Target:",
+    "Release Floor:",
+    "Version Rationale:",
     "Release Scope:",
     "Release Artifacts:",
     "Release Branch: No",
@@ -391,6 +393,8 @@ MERGED_UNRELEASED_CONTRACT_PHRASES = (
     "Merged-Unreleased Release-Debt Owner:",
     "Repo State: No Active Branch",
     "Release Target:",
+    "Release Floor:",
+    "Version Rationale:",
     "Release Scope:",
     "Release Artifacts:",
     "Post-Release Truth:",
@@ -408,12 +412,18 @@ REQUIRED_MERGED_UNRELEASED_MARKERS = (
     "Merged-Unreleased Release-Debt Owner:",
     "Repo State: No Active Branch",
     "Release Target:",
+    "Release Floor:",
+    "Version Rationale:",
     "Release Scope:",
     "Release Artifacts:",
     "Post-Release Truth:",
     "Selected Next Workstream:",
     "Next-Branch Creation Gate:",
 )
+
+PATCH_PRERELEASE_FLOOR = "patch prerelease"
+MINOR_PRERELEASE_FLOOR = "minor prerelease"
+SEMANTIC_RELEASE_FLOORS = (PATCH_PRERELEASE_FLOOR, MINOR_PRERELEASE_FLOOR)
 
 NON_RELEASE_BRANCH_MARKER = "Release Branch: No"
 RELEASE_BEARING_BRANCH_CLASSES = ("release packaging",)
@@ -518,6 +528,39 @@ def _parse_backlog_sections(text: str) -> list[dict[str, str]]:
 def _extract_colon_value(block: str, label: str) -> str:
     match = re.search(rf"^{re.escape(label)}:\s*(.+)$", block, flags=re.M)
     return match.group(1).strip() if match else ""
+
+
+def _clean_release_value(value: str) -> str:
+    return value.strip().strip("`").strip()
+
+
+def _latest_public_prerelease(roadmap_text: str) -> str:
+    return _clean_release_value(_extract_colon_value(roadmap_text, "- latest public prerelease"))
+
+
+def _parse_prebeta_version(value: str) -> tuple[int, int, int] | None:
+    match = re.fullmatch(r"v(\d+)\.(\d+)\.(\d+)-prebeta", _clean_release_value(value))
+    if not match:
+        return None
+    return tuple(int(part) for part in match.groups())
+
+
+def _expected_prerelease_target(latest_public: str, release_floor: str) -> str:
+    parsed = _parse_prebeta_version(latest_public)
+    if parsed is None:
+        return ""
+
+    major, minor, patch = parsed
+    normalized_floor = _clean_release_value(release_floor).casefold()
+    if normalized_floor == PATCH_PRERELEASE_FLOOR:
+        return f"v{major}.{minor}.{patch + 1}-prebeta"
+    if normalized_floor == MINOR_PRERELEASE_FLOOR:
+        return f"v{major}.{minor + 1}.0-prebeta"
+    return ""
+
+
+def _workstream_target_version(workstream_text: str) -> str:
+    return _clean_release_value(_extract_first_backtick_value(_section(workstream_text, "Target Version")))
 
 
 def _parse_workstream_doc(text: str) -> dict[str, object]:
@@ -1519,6 +1562,7 @@ def main() -> int:
 
         normalized_workstream_status = _normalize_status(str(workstream_info["status"]))
         if normalized_workstream_status == "merged unreleased":
+            roadmap_section = _roadmap_section_for_id(roadmap_text, workstream_id)
             for required_marker in REQUIRED_MERGED_UNRELEASED_MARKERS:
                 require(
                     required_marker in workstream_text,
@@ -1551,6 +1595,109 @@ def main() -> int:
                     required_marker in backlog_text,
                     f"Docs/feature_backlog.md: merged-unreleased release-debt state is missing '{required_marker}'",
                 )
+            latest_public_prerelease = _latest_public_prerelease(roadmap_text)
+            require(
+                bool(latest_public_prerelease),
+                "Docs/prebeta_roadmap.md: latest public prerelease is missing",
+            )
+            require(
+                _parse_prebeta_version(latest_public_prerelease) is not None,
+                (
+                    "Docs/prebeta_roadmap.md: latest public prerelease must use "
+                    "v<major>.<minor>.<patch>-prebeta"
+                ),
+            )
+
+            release_sources = (
+                ("Docs/feature_backlog.md", entry["block"]),
+                ("Docs/prebeta_roadmap.md", roadmap_section),
+                (canonical_path, workstream_text),
+            )
+            release_floors = [
+                _clean_release_value(_extract_colon_value(source_text, "Release Floor")).casefold()
+                for _, source_text in release_sources
+            ]
+            release_floor = release_floors[0] if release_floors else ""
+            for source_name, source_text in release_sources:
+                source_floor = _clean_release_value(_extract_colon_value(source_text, "Release Floor")).casefold()
+                source_rationale = _clean_release_value(_extract_colon_value(source_text, "Version Rationale"))
+                require(
+                    source_floor in SEMANTIC_RELEASE_FLOORS,
+                    (
+                        f"{source_name}: Release Target Undefined blocker is active; "
+                        f"Release Floor must be one of {', '.join(SEMANTIC_RELEASE_FLOORS)}"
+                    ),
+                )
+                require(
+                    bool(source_rationale),
+                    (
+                        f"{source_name}: Release Target Undefined blocker is active; "
+                        "Version Rationale is required for semantic release target validation"
+                    ),
+                )
+                require(
+                    source_floor == release_floor,
+                    (
+                        f"{source_name}: Release Target Undefined blocker is active; "
+                        "Release Floor must match backlog release floor"
+                    ),
+                )
+
+            expected_release_target = _expected_prerelease_target(latest_public_prerelease, release_floor)
+            require(
+                bool(expected_release_target),
+                (
+                    f"{canonical_path}: Release Target Undefined blocker is active; "
+                    "cannot derive semantic release target from latest public prerelease and Release Floor"
+                ),
+            )
+
+            if expected_release_target:
+                backlog_target_version = _clean_release_value(
+                    _extract_colon_value(entry["block"], "Target Version")
+                )
+                require(
+                    backlog_target_version == expected_release_target,
+                    (
+                        "Docs/feature_backlog.md: Release Target Undefined blocker is active; "
+                        f"Target Version '{backlog_target_version}' must be '{expected_release_target}'"
+                    ),
+                )
+                workstream_target_version = _workstream_target_version(workstream_text)
+                require(
+                    workstream_target_version == expected_release_target,
+                    (
+                        f"{canonical_path}: Release Target Undefined blocker is active; "
+                        f"Target Version '{workstream_target_version}' must be '{expected_release_target}'"
+                    ),
+                )
+
+                for source_name, source_text in release_sources:
+                    source_target = _clean_release_value(_extract_colon_value(source_text, "Release Target"))
+                    source_artifacts = _extract_colon_value(source_text, "Release Artifacts")
+                    source_post_release = _extract_colon_value(source_text, "Post-Release Truth")
+                    require(
+                        source_target == expected_release_target,
+                        (
+                            f"{source_name}: Release Target Undefined blocker is active; "
+                            f"Release Target '{source_target}' must be '{expected_release_target}' "
+                            f"for {release_floor}"
+                        ),
+                    )
+                    require(
+                        expected_release_target in source_artifacts,
+                        (
+                            f"{source_name}: Release Target Undefined blocker is active; "
+                            f"Release Artifacts must reference '{expected_release_target}'"
+                        ),
+                    )
+                    require(
+                        expected_release_target in source_post_release,
+                        (
+                            f"{source_name}: Release Target Undefined blocker is active; "
+                            f"Post-Release Truth must reference '{expected_release_target}'"
+                        ),
+                    )
             require(
                 canonical_path in release_debt_index_paths,
                 (


### PR DESCRIPTION
## Summary

Correct FB-038 release target truth from `v1.5.0-prebeta` to `v1.4.1-prebeta`.

## What Changed

### Changes

Adds machine-checkable `Release Floor` and `Version Rationale` fields for merged-unreleased release-debt truth, updates PR/Release Readiness governance so target correctness is semantic rather than marker-only, and extends the branch governance validator to derive the expected prerelease target from the latest public prerelease plus release floor.

### Governance / Canon
- FB-038 release target corrected to `v1.4.1-prebeta`
- `Release Floor: patch prerelease`
- `Version Rationale` added
- validator now enforces semantic prerelease target correctness
- no product/runtime changes

### Post-Merge Truth
After merge, `main` should carry FB-038 as merged-unreleased release debt targeting `v1.4.1-prebeta`, and Release Readiness can be rerun from corrected truth.

### Changes

### Governance / Canon
- FB-038 release target corrected to `v1.4.1-prebeta`
- `Release Floor: patch prerelease`
- `Version Rationale` added
- validator now enforces semantic prerelease target correctness
- no product/runtime changes

### Post-Merge Truth
After merge, `main` should carry FB-038 as merged-unreleased release debt targeting `v1.4.1-prebeta`, and Release Readiness can be rerun from corrected truth.
