### PR TITLE
docs: close FB-038 release canon

### DIFF
--- a/Docs/closeout_guidance.md
+++ b/Docs/closeout_guidance.md
@@ -80,6 +80,13 @@ Do not repair directly on `main`; `main` is protected and read-only for Codex wo
 There is no emergency direct-main repair path for Codex.
 Any tracked file mutation while Codex is on `main` is a `Main Write Attempt`.
 
+The public GitHub prerelease title format for Nexus `pre-Beta` releases is:
+
+- `Pre-Beta v<major>.<minor>.<patch>`
+
+Milestone names, user-facing scope, evidence roots, and implementation details belong in the release notes, not in the GitHub release title.
+Post-release confirmation must treat that concise `Pre-Beta v<major>.<minor>.<patch>` title as the expected published title when it matches the tag and release notes carry the scoped summary.
+
 ## Current Policy
 
 - preserve historical closeouts
@@ -89,3 +96,4 @@ Any tracked file mutation while Codex is on `main` is a `Main Write Attempt`.
 - do not let this guidance doc become a live current-state owner
 - create new closeouts or rebaselines only when they materially improve future planning clarity
 - keep escaped post-release canon drift as a protected-main blocker that must be repaired on a legal branch surface, not as a planned governance-only branch or direct-main write
+- prevent recurrence during PR Readiness by carrying the exact release-state closure plan for latest public prerelease, released/closed workstream state, release-debt clearing, and release title format before a release-bearing branch reports PR-ready

--- a/Docs/feature_backlog.md
+++ b/Docs/feature_backlog.md
@@ -26,39 +26,18 @@ Historical note:
 
 ## Promoted Canonical Workstreams
 
-- `Docs/workstreams/FB-038_taskbar_tray_quick_task_ux.md`
+None.
 
 ## Active Promoted Workstream
 
 None.
 
-Main-facing canon is in `No Active Branch` while FB-038 remains merged-unreleased release debt.
-FB-039 is selected only and must not be branched until release debt clears and updated `main` passes the repo-level admission gate.
+Main-facing canon is in steady-state `No Active Branch` after the FB-038 `v1.4.1-prebeta` release.
+FB-039 is selected only and remains `Branch: Not created` until a fresh Branch Readiness admission passes on updated `main`.
 
 ## Merged-Unreleased Release-Debt Owner
 
-### [ID: FB-038] Taskbar / tray quick-task UX and Create Custom Task surface
-
-Status: Merged Unreleased (Release Debt)
-Blocker: Release Debt
-Record State: Promoted
-Priority: Medium
-Release Stage: pre-Beta
-Target Version: v1.4.1-prebeta
-Canonical Workstream Doc: Docs/workstreams/FB-038_taskbar_tray_quick_task_ux.md
-Merged-Unreleased Release-Debt Owner: FB-038
-Repo State: No Active Branch
-Release Target: v1.4.1-prebeta
-Release Floor: patch prerelease
-Version Rationale: FB-038 is tray UX, startup sequencing fix, and governance repair follow-through; it does not open a new feature lane or capability expansion beyond the completed tray/task UX milestone.
-Release Scope: FB-038 tray/task UX milestone only: tray identity/discoverability, tray Open Command Overlay, tray Create Custom Task dialog-open/no-write route, tray-origin create completion through existing FB-036 authoring, catalog reload, exact-match resolution, confirm/result execution, and startup first-visible Core Visualization repair.
-Release Artifacts: tag `v1.4.1-prebeta`; release title `Nexus Desktop AI v1.4.1-prebeta - Tray Quick-Task UX`; release notes summarizing FB-038 user-facing tray/task UX, validation evidence, and retained FB-038 evidence helpers.
-Post-Release Truth: after release, FB-038 can move to `Closed` / `Released (v1.4.1-prebeta)`, release debt clears, and repo-level admission may reconsider FB-039 Branch Readiness from updated `main`.
-Selected Next Workstream: FB-039 External trigger and plugin integration architecture.
-Next-Branch Creation Gate: FB-039 remains selected-only and `Branch: Not created` until FB-038 release debt is cleared and updated `main` passes the repo-level admission gate.
-Minimal Scope: Merged-unreleased release-debt owner for completed FB-038 tray quick-task UX; Release Readiness may validate inherited target/scope/artifacts but must not mutate repository files.
-Summary: Track future taskbar or tray quick-access UX, including a Create Custom Task affordance, as a deliberate shell-facing entry surface into the shared action model.
-Why it matters: Taskbar and tray interaction affect entry, discoverability, and user trust, so they should be planned as an explicit UX lane instead of piggybacking on overlay or authoring work.
+None.
 
 ## Registry Items
 
@@ -155,6 +134,18 @@ Summary: Track future runtime monitoring and HUD surfaces for GPU / CPU thermals
 Why it matters: Monitoring overlays are a separate runtime and status surface and should not be bolted onto the saved-action system without an explicit product boundary.
 
 ## Closed Canonical Workstreams
+
+### [ID: FB-038] Taskbar / tray quick-task UX and Create Custom Task surface
+
+Status: Released (v1.4.1-prebeta)
+Record State: Closed
+Priority: Medium
+Release Stage: pre-Beta
+Target Version: v1.4.1-prebeta
+Release Title: Pre-Beta v1.4.1
+Canonical Workstream Doc: Docs/workstreams/FB-038_taskbar_tray_quick_task_ux.md
+Summary: Released the FB-038 tray quick-task UX milestone, including tray identity/discoverability, tray Open Command Overlay, tray Create Custom Task dialog-open/no-write route, tray-origin create completion through the existing FB-036 authoring path, catalog reload and exact-match resolution, confirm/result execution, and startup first-visible Core Visualization sequencing repair.
+Why it matters: Taskbar and tray interaction now has an explicit released UX lane that remains bounded to the shared action model rather than becoming a parallel authoring or launcher surface.
 
 ### [ID: FB-037] Curated built-in system actions and Nexus settings expansion
 

--- a/Docs/incident_patterns.md
+++ b/Docs/incident_patterns.md
@@ -180,6 +180,41 @@ Branch-local "what worked" notes should stay in the canonical workstream doc fir
   - `Docs/workstreams/FB-035_release_context_fallback_hardening.md`
   - `Docs/prebeta_roadmap.md`
 
+## Pattern: Post-Release Canon Must Close Released Release Debt
+
+- symptom:
+  a public prerelease tag and GitHub prerelease exist, but canon still reports the released workstream as merged-unreleased release debt or leaves latest public prerelease at the prior tag
+- layer:
+  post-release confirmation and release-state canon
+- root-cause pattern:
+  PR Readiness defines pre-release target/scope/artifacts but does not include a machine-checkable release-state closure plan that forces latest public prerelease, released/closed workstream state, and release-debt clearing after the tag exists
+- fix pattern:
+  during PR Readiness for release-bearing work, require a release-state closure plan that covers latest public prerelease, released/closed workstream state, release-debt clearing, workstream-index movement to Closed, and successor branch deferral; after a release tag exists, the governance validator must fail stale release-debt canon
+- validation pattern:
+  run `python dev/orin_branch_governance_validation.py`; it must fail if the latest local pre-Beta tag is newer than roadmap latest public prerelease, or if the released workstream remains promoted/merged-unreleased instead of closed/released
+- source references:
+  - `Docs/prebeta_roadmap.md`
+  - `Docs/feature_backlog.md`
+  - `Docs/workstreams/index.md`
+  - `dev/orin_branch_governance_validation.py`
+
+## Pattern: Pre-Beta Release Title Format Is Concise
+
+- symptom:
+  post-release confirmation compares the GitHub release title against a long PR-generated milestone title and treats the published concise title as drift
+- layer:
+  release artifacts and post-release confirmation
+- root-cause pattern:
+  source-of-truth does not record the public GitHub prerelease title format separately from release-note summary content
+- fix pattern:
+  use `Pre-Beta v<major>.<minor>.<patch>` as the public GitHub release title format for Nexus pre-Beta releases; put milestone name, scope, evidence, and exclusions in release notes
+- validation pattern:
+  run `python dev/orin_branch_governance_validation.py`; release artifacts and released-state canon should use the concise title format while release notes carry the scoped milestone summary
+- source references:
+  - `Docs/closeout_guidance.md`
+  - `Docs/prebeta_roadmap.md`
+  - `dev/orin_branch_governance_validation.py`
+
 ## Pattern: Repeated-Identical Recoverable launch_failed Must Stay Bounded
 
 - symptom:

--- a/Docs/prebeta_roadmap.md
+++ b/Docs/prebeta_roadmap.md
@@ -61,46 +61,34 @@ Use these release-state values when relevant:
 
 Current merged truth indicates:
 
-- latest public prerelease: `v1.4.0-prebeta`
-- latest public release commit: the `v1.4.0-prebeta` tag target
-- latest public prerelease publication: `https://github.com/GiribaldiTTV/Nexus-Desktop-AI/releases/tag/v1.4.0-prebeta`
-- merged unreleased non-doc implementation debt exists: yes
-- the latest public released implementation milestone is FB-037 curated built-in system actions and Nexus settings expansion in `v1.4.0-prebeta`
-- current phase: `Release Readiness`
+- latest public prerelease: `v1.4.1-prebeta`
+- latest public release commit: the `v1.4.1-prebeta` tag target
+- latest public prerelease publication: `https://github.com/GiribaldiTTV/Nexus-Desktop-AI/releases/tag/v1.4.1-prebeta`
+- latest public prerelease title: `Pre-Beta v1.4.1`
+- merged unreleased non-doc implementation debt exists: no
+- the latest public released implementation milestone is FB-038 taskbar / tray quick-task UX and Create Custom Task surface in `v1.4.1-prebeta`
+- current phase: `No Active Branch`
 - phase status: `No Active Branch`
-- blocker after release execution: none for FB-037
+- blocker after release execution: none for FB-038
 - current active workstream: none
 - current branch: `No Active Branch`
-- merged-unreleased release-debt owner: FB-038 Taskbar / Tray Quick-Task UX And Create Custom Task Surface
-- next concern: Release Readiness may validate the inherited FB-038 release target, scope, artifacts, and post-release truth without mutating repository files
+- merged-unreleased release-debt owner: none
+- next concern: FB-039 Branch Readiness may be evaluated from updated `main`; FB-039 remains selected-only and unbranched until admitted
 
-That means the released FB-027 interaction baseline, the released FB-036 authoring-and-callable-group milestone, the released FB-041 deterministic callable-group execution milestone, and the released FB-037 built-in catalog milestone are now part of the current public shared pre-Beta baseline.
+That means the released FB-027 interaction baseline, the released FB-036 authoring-and-callable-group milestone, the released FB-041 deterministic callable-group execution milestone, the released FB-037 built-in catalog milestone, and the released FB-038 tray quick-task UX milestone are now part of the current public shared pre-Beta baseline.
 
 ## Current Release Debt Owner
 
-### FB-038 Taskbar / Tray Quick-Task UX And Create Custom Task Surface
-
-Status: `Merged Unreleased (Release Debt)`
-canonical workstream doc: `Docs/workstreams/FB-038_taskbar_tray_quick_task_ux.md`
-Merged-Unreleased Release-Debt Owner: FB-038
-Repo State: No Active Branch
-Release Target: v1.4.1-prebeta
-Release Floor: patch prerelease
-Version Rationale: FB-038 is tray UX, startup sequencing fix, and governance repair follow-through; it does not open a new feature lane or capability expansion beyond the completed tray/task UX milestone.
-Release Scope: FB-038 tray/task UX milestone only: tray identity/discoverability, tray Open Command Overlay, tray Create Custom Task dialog-open/no-write route, tray-origin create completion through existing FB-036 authoring, catalog reload, exact-match resolution, confirm/result execution, and startup first-visible Core Visualization repair.
-Release Artifacts: tag `v1.4.1-prebeta`; release title `Nexus Desktop AI v1.4.1-prebeta - Tray Quick-Task UX`; release notes summarizing FB-038 user-facing tray/task UX, validation evidence, and retained FB-038 evidence helpers.
-Post-Release Truth: after release, FB-038 should be represented as `Released (v1.4.1-prebeta)` / `Closed`; release debt clears; the latest public prerelease advances from `v1.4.0-prebeta` to `v1.4.1-prebeta`.
-Selected Next Workstream: FB-039 External Trigger And Plugin Integration Architecture.
-Next-Branch Creation Gate: FB-039 remains selected-only and `Branch: Not created` until FB-038 release debt is cleared and updated `main` passes the repo-level admission gate.
+None.
 
 ## Current Active Workstream
 
 ### None
 
 - repo state: `No Active Branch`
-- blocker: `Release Debt`
-- current owner: FB-038 is merged-unreleased release debt, not an active implementation branch
-- release readiness rule: Release Readiness is analysis-only and may consume inherited FB-038 release target/scope/artifacts; any required file mutation must be repaired on a legal branch surface, not on `main` and not inside Release Readiness
+- blocker: none
+- current owner: none
+- release readiness rule: Release Readiness remains analysis-only; post-release canon is already expected to represent latest public prerelease and closed workstream truth before any later release review reports green
 
 ## Selected Next Workstream
 
@@ -110,9 +98,22 @@ Next-Branch Creation Gate: FB-039 remains selected-only and `Branch: Not created
 - Minimal Scope: Branch Readiness only for external trigger and plugin integration architecture; define the source map, lifecycle ownership, trust/safety boundaries, validation contract, and explicit non-goals for external trigger surfaces such as Stream Deck or other installed integration points before any implementation. No plugin runtime implementation, Stream Deck integration, protocol handling, installer work, settings surface, taskbar/tray expansion, monitoring HUD work, or release packaging is admitted during Branch Readiness.
 - Branch: Not created
 - Selection Basis: FB-039 is the nearest canon successor after FB-038 because it plans external trigger ownership and plugin integration boundaries without expanding the completed tray/task UX branch. FB-040 remains deferred because monitoring, thermals, and HUD surfaces are a separate runtime/status lane.
-- Successor Deferral: FB-039 remains selected in canon only. Its branch may not be created until FB-038 release debt clears, updated `main` is revalidated, and the repo-level admission gate passes.
+- Successor Deferral: FB-039 remains selected in canon only. Its branch may not be created until updated `main` is revalidated during Branch Readiness and the repo-level admission gate passes.
 
 ## Most Recent Released Workstream Context
+
+### FB-038 Taskbar / Tray Quick-Task UX And Create Custom Task Surface
+
+- status: `released`
+- lane type: `implementation`
+- release floor: `patch prerelease`
+- target version: `v1.4.1-prebeta`
+- release state: `released`
+- release title: `Pre-Beta v1.4.1`
+- canonical workstream doc: `Docs/workstreams/FB-038_taskbar_tray_quick_task_ux.md`
+- sequencing note: released the tray quick-task UX milestone, including tray identity/discoverability, tray Open Command Overlay, tray Create Custom Task dialog-open/no-write route, tray-origin create completion through existing FB-036 authoring, catalog reload, exact-match resolution, confirm/result execution, and startup first-visible Core Visualization sequencing repair
+
+## Prior Released Workstream Context
 
 ### FB-037 Curated Built-In System Actions And Nexus Settings Expansion
 
@@ -123,8 +124,6 @@ Next-Branch Creation Gate: FB-039 remains selected-only and `Branch: Not created
 - release state: `released`
 - canonical workstream doc: `Docs/workstreams/FB-037_built_in_actions_and_settings_expansion.md`
 - sequencing note: released the curated built-in Windows utility catalog for Task Manager, Calculator, Notepad, and Paint while preserving saved-action override authority, authoring collision protection, confirm/result surfaces, and callable-group behavior
-
-## Prior Released Workstream Context
 
 ### FB-041 Deterministic Callable-Group Execution Layer
 
@@ -213,19 +212,20 @@ Current merged truth indicates:
 - the released FB-036 authoring-and-callable-group milestone is now part of the locked current pre-Beta baseline
 - the released FB-041 deterministic callable-group execution milestone is now part of the locked current pre-Beta baseline
 - the released FB-037 built-in catalog milestone is now part of the locked current pre-Beta baseline
+- the released FB-038 tray quick-task UX milestone is now part of the locked current pre-Beta baseline
 - the released FB-035 lane is closed
 - the recent released workstreams above remain part of the locked current baseline
-- merged unreleased non-doc implementation debt exists: yes
-- FB-038 is the merged-unreleased release-debt owner for the completed tray/task UX milestone; H1 identity/discoverability repair, H2 shortcut-launch tray readback validation, H3 window initialization sequencing, H4 post-fix startup visibility validation, fresh post-H4 technical/live validation, user-facing desktop shortcut validation, and UTS waiver digestion are green
-- FB-039 is selected in canon only as the next workstream for Branch Readiness after FB-038 release debt clears and updated `main` is revalidated; no FB-039 branch exists
-- FB-039 branch creation remains blocked while FB-038 release debt remains unresolved
-- post-release repo truth after the FB-037 release branch merge resolved to no FB-037 release-debt blocker
+- merged unreleased non-doc implementation debt exists: no
+- FB-038 is released and closed in `v1.4.1-prebeta`; H1 identity/discoverability repair, H2 shortcut-launch tray readback validation, H3 window initialization sequencing, H4 post-fix startup visibility validation, fresh post-H4 technical/live validation, user-facing desktop shortcut validation, and UTS waiver digestion are preserved as historical evidence
+- FB-039 is selected in canon only as the next workstream for Branch Readiness after updated `main` is revalidated; no FB-039 branch exists
+- FB-039 branch creation remains deferred until Branch Readiness passes; it is no longer blocked by FB-038 release debt
+- post-release repo truth after the FB-038 release resolves to no FB-038 release-debt blocker
 - successor-lane branch creation for FB-038 is historical; FB-038 is now merged and no longer an executable active implementation branch
 - if a branch changes release-facing canon, those canon updates must land on that same branch before PR readiness is allowed
 - escaped post-merge canon repair must ride a legal branch surface; `main` is protected and must not be patched directly by Codex
 - the released FB-027 baseline does not authorize further saved-action authoring, resolution, voice, Action Studio, routines, profiles, hotkey cleanup, or shutdown-confirmation work by inertia
 - remaining future candidate spaces now explicitly recorded in the backlog include:
-  - FB-038 for taskbar or tray quick-task UX including Create Custom Task, now merged-unreleased release debt with H3/H4 startup visibility re-entry green, `User-Facing Shortcut Validation: PASS`, UTS handling resolved by documented waiver, and Release Readiness allowed only as file-frozen analysis of inherited release target/scope/artifacts
+  - FB-038 for taskbar or tray quick-task UX including Create Custom Task, now released and closed in `v1.4.1-prebeta` with H3/H4 startup visibility re-entry green, `User-Facing Shortcut Validation: PASS`, and UTS handling resolved by documented waiver
   - FB-039 for external trigger and plugin integration architecture, selected in canon only with `Branch: Not created`
   - FB-040 for monitoring, thermals, and performance HUD surfaces
 - those candidate lanes must be selected deliberately rather than bundled together as one implicit interaction continuation

--- a/Docs/workstreams/FB-038_taskbar_tray_quick_task_ux.md
+++ b/Docs/workstreams/FB-038_taskbar_tray_quick_task_ux.md
@@ -7,11 +7,11 @@
 
 ## Record State
 
-- `Promoted`
+- `Closed`
 
 ## Status
 
-- `Merged Unreleased (Release Debt)`
+- `Released (v1.4.1-prebeta)`
 
 ## Release Stage
 
@@ -33,17 +33,19 @@ This workstream exists so taskbar or tray access and Create Custom Task entry ar
 
 ## Current Phase
 
-- Phase: `PR Readiness`
+- None. FB-038 is `Closed` after `v1.4.1-prebeta`; no active execution phase remains for this workstream.
 
 ## Phase Status
 
-- `Active Branch`
-- current active implementation/repair branch: `feature/fb-038-taskbar-tray-quick-task-ux`
-- legal repair surface for this governance repair: `feature/fb-038-taskbar-tray-quick-task-ux`
+- `Closed historical workstream record`
+- repo state: `No Active Branch`
+- latest public prerelease: `v1.4.1-prebeta`
+- release title: `Pre-Beta v1.4.1`
 - protected-main rule: `main` is read-only for Codex work; no editing, staging, committing, generation, refresh, or direct repair on `main`
 - FB-038 has been squash-merged to `main`
-- FB-038 is now the merged-unreleased release-debt owner until release packaging clears `v1.4.1-prebeta`
-- PR Readiness re-entry is active on the still-available prior branch to correct inherited release-target truth before a follow-up PR/squash merge
+- FB-038 release execution completed for `v1.4.1-prebeta`
+- FB-038 release debt is cleared
+- FB-039 remains selected-only and `Branch: Not created` until fresh Branch Readiness admission passes on updated `main`
 - Branch Readiness is complete and durably checkpointed in commit `766ff67`
 - Workstream seam chain and helper governance are complete and durably checkpointed in commit `ef05ab2`
 - Hardening execution pass completed on 2026-04-21; branch-wide validator and helper sweep is green
@@ -60,6 +62,8 @@ This workstream exists so taskbar or tray access and Create Custom Task entry ar
 - FB-037 is released and closed in `v1.4.0-prebeta`
 - FB-037 release publication exists at `https://github.com/GiribaldiTTV/Nexus-Desktop-AI/releases/tag/v1.4.0-prebeta`
 - no FB-037 release-debt blocker remains
+- FB-038 release publication exists at `https://github.com/GiribaldiTTV/Nexus-Desktop-AI/releases/tag/v1.4.1-prebeta`
+- no FB-038 release-debt blocker remains
 - no active release-packaging branch remains
 
 ## Branch Class
@@ -72,10 +76,9 @@ This workstream exists so taskbar or tray access and Create Custom Task entry ar
 
 ## Entry Basis
 
-- local `main` and `origin/main` are aligned after the FB-038 squash merge
+- local `main` and `origin/main` were aligned after the FB-038 squash merge and release execution
 - main-facing repo state is `No Active Branch`
-- current legal repair surface is the still-available prior branch `feature/fb-038-taskbar-tray-quick-task-ux`
-- this governance repair must be PR/squash-merged; it must not be applied directly to `main`
+- this workstream is closed historical truth after the `v1.4.1-prebeta` release
 - Branch Readiness governance/canon repair plus FB-038 admission setup is durable in commit `766ff67`
 - Workstream seam chain completion, Workstream evidence finalization, User Test Summary finalization, and helper-governance registry integration are durable in commit `ef05ab2`
 - FB-037 is `Released (v1.4.0-prebeta)` and `Closed`
@@ -88,14 +91,15 @@ This workstream exists so taskbar or tray access and Create Custom Task entry ar
 - H3/H4 Hardening re-entry is green after the returned User Test Summary failure that reported a black placeholder window before Core Visualization on desktop shortcut launch
 - fresh post-H4 Live Validation technical/live evidence is green
 - User Test Summary result digestion is complete by documented waiver; `User Test Summary Results Pending` is cleared
-- FB-038 merge created merged-unreleased implementation release debt that must be released before FB-039 implementation Branch Readiness may begin
+- FB-038 release debt is cleared; FB-039 implementation Branch Readiness remains a separate future admission and must not begin by inertia
 
 ## Exit Criteria
 
-- Release Readiness consumes the inherited FB-038 release target, scope, artifacts, and post-release truth without mutating repository files
-- any missing release truth discovered during Release Readiness routes back to this still-available prior branch before another PR, or to the next active branch's `Branch Readiness` if this branch is unavailable
+- FB-038 is represented as `Released (v1.4.1-prebeta)` / `Closed` in durable canon
+- latest public prerelease truth advances to `v1.4.1-prebeta`
+- release debt is cleared in backlog, roadmap, and workstream index canon
 - `main` remains protected and file-frozen for Codex work
-- FB-039 remains selected-only and branch-not-created while FB-038 release debt remains unresolved
+- FB-039 remains selected-only and branch-not-created until fresh Branch Readiness admission passes
 - H1 tray identity and discoverability refinement is implemented without new tray actions, new entrypoints, taskbar pinning, jump lists, protocol handling, or changes to Create Custom Task behavior
 - tray tooltip/title, tray menu identity, and any startup discovery cue clearly identify `Nexus Desktop AI` and document that Windows may place the icon in hidden tray overflow
 - H2 shortcut-launch tray readback validates the user-facing desktop shortcut path after the H1 repair
@@ -108,15 +112,15 @@ This workstream exists so taskbar or tray access and Create Custom Task entry ar
 
 ## Rollback Target
 
-- `PR Readiness`
+- None. Closed historical record; reopen only through a new approved governance or implementation branch if future canon requires it.
 
 ## Next Legal Phase
 
-- `Release Readiness`
+- `Branch Readiness` for the next admitted branch only after updated `main` is revalidated; FB-039 remains selected-only and not created in this record.
 
 Live Validation was previously admitted after validating Workstream closure, Hardening GREEN evidence, User Test Summary alignment, helper registry compliance, and clean branch truth. Returned User Test Summary evidence first routed to bounded tray discoverability Hardening and then to bounded window initialization Hardening.
 
-Fresh post-Hardening Live Validation produced a returned User Test Summary failure: desktop shortcut launch briefly showed a black placeholder window before Core Visualization. H3/H4 Hardening re-entry is now green. Fresh post-H4 Live Validation technical/live evidence is green and a new User Test Summary handoff was exported. The UTS result was resolved by operator-confirmed waiver artifact on 2026-04-21, so `User Test Summary Results Pending` is cleared. PR Readiness completed and FB-038 was squash-merged to `main`. FB-038 is now merged-unreleased release debt; PR Readiness re-entry is correcting the inherited release target before Release Readiness may be rerun from durable merged truth.
+Fresh post-Hardening Live Validation produced a returned User Test Summary failure: desktop shortcut launch briefly showed a black placeholder window before Core Visualization. H3/H4 Hardening re-entry is now green. Fresh post-H4 Live Validation technical/live evidence is green and a new User Test Summary handoff was exported. The UTS result was resolved by operator-confirmed waiver artifact on 2026-04-21, so `User Test Summary Results Pending` is cleared. PR Readiness completed, FB-038 was squash-merged to `main`, and `v1.4.1-prebeta` release execution completed. FB-038 is now released and closed; release debt is cleared.
 
 ## Governance Drift Audit
 
@@ -125,48 +129,53 @@ Fresh post-Hardening Live Validation produced a returned User Test Summary failu
 - Audit Scope:
   PR Readiness review of FB-038 branch truth, merge-target canon, post-merge state, next-workstream selection, helper registry obligations, desktop shortcut/UTS gates, and dirty-branch durability.
 - Findings:
-  - stale-canon blocker is clear after this PR Readiness canon update because current branch truth, Live Validation waiver digestion, helper-retention truth, and selected-next workstream truth are explicitly recorded.
-  - post-merge blocker is clear because the Post-Merge State section below records `No Active Branch`, FB-038 `Release Debt`, and selected FB-039 branch deferral after merge.
-  - dirty blocker must be evaluated by the PR-readiness validator after this update is committed.
+  - stale-canon blocker is clear after this post-release canon repair because current released truth, Live Validation waiver digestion, helper-retention truth, and selected-next workstream truth are explicitly recorded.
+  - post-release blocker is clear because the Released-State Closure section below records `Released (v1.4.1-prebeta)`, cleared FB-038 release debt, and selected FB-039 branch deferral after release.
+  - dirty blocker must be evaluated by the governance validator after this update is committed.
   - docs-sync blocker is clear after this update because backlog, roadmap, helper registry, and this authority record carry the same PR Readiness truth.
   - next-workstream blocker is clear after FB-039 is selected in backlog and roadmap with `Record State: Registry-only`, `Minimal Scope:`, and `Branch: Not created`.
   - desktop-shortcut blocker is clear because `User-Facing Shortcut Validation: PASS` is recorded with fresh post-H4 evidence.
   - uts-results blocker is clear because `User Test Summary Results: WAIVED` is recorded with operator-confirmed waiver digestion.
-  - PR Readiness scope-miss blockers are clear: no branch-authority cleanup is required for this backlog-backed implementation branch, no between-branch canon repair is planned, no successor branch exists, and no PR-owned docs work is deferred into Release Readiness.
+  - PR Readiness scope-miss blockers are clear for the closed FB-038 record: no branch-authority cleanup remains, no direct-main repair occurred, no successor branch exists, and no PR-owned docs work is deferred into Release Readiness.
   - Release Readiness file-mutation boundary drift was found and repaired during PR Readiness re-entry: Release Readiness is now analysis-only for repository files, and any required file mutation must return to PR Readiness before merge or defer to the next active branch's Branch Readiness after merge.
-  - Post-merge release-debt drift was found after FB-038 was squash-merged: main-facing canon still carried active PR Readiness wording, workstreams index did not list FB-038 under merged/release debt, and release target/scope/artifacts were not durable enough for file-frozen Release Readiness. This governance repair reclassifies FB-038 as merged-unreleased release debt, adds the inherited release contract, and codifies protected-main repair routing.
+  - Post-release release-closure drift was found after `v1.4.1-prebeta` was tagged and published: main-facing canon still carried latest public prerelease `v1.4.0-prebeta`, FB-038 remained represented as merged-unreleased release debt, release debt was not cleared, and the published GitHub release title followed the established concise `Pre-Beta vX.Y.Z` format. This repair closes FB-038 as released, advances latest public prerelease truth, clears release debt, and codifies the release title format as accepted current truth.
 - Helper Governance Finding:
   FB-038 workstream-scoped helpers remain registered and are intentionally retained as FB-038 evidence helpers after merge. They are not promoted to reusable helpers in this branch because reuse would prematurely generalize tray-origin authoring proof before a second branch needs it. Future tray-origin or authoring work must consolidate these helpers into a reusable tray/Create Custom Task live helper or the saved-action interactive suite before creating another helper.
 
-## Post-Merge State
+## Released-State Closure
 
-- Merge Target:
-  FB-038 was squash-merged as the completed tray quick-task UX implementation branch.
-- Post-Merge Repo State:
-  `No Active Branch` until a release-packaging or later admitted branch passes the repo-level admission gate.
+- Release:
+  FB-038 is released as `v1.4.1-prebeta`.
+- Release Title:
+  `Pre-Beta v1.4.1`.
+- Release URL:
+  `https://github.com/GiribaldiTTV/Nexus-Desktop-AI/releases/tag/v1.4.1-prebeta`.
+- Post-Release Repo State:
+  `No Active Branch`.
 - Release Debt:
-  FB-038 is merged-unreleased non-doc implementation debt and must remain the release-debt owner until release packaging clears it.
+  Cleared for FB-038.
 - Workstream Index Target:
-  FB-038 is listed under `Merged / Release Debt Owners`; it must not remain an active implementation branch authority on updated `main`.
+  FB-038 is listed under `Closed`; it must not remain under `Merged / Release Debt Owners` or `Active`.
 - Backlog / Roadmap Target:
-  FB-038 is represented as merged-unreleased release debt, while FB-039 remains selected in canon only.
+  FB-038 is represented as `Released (v1.4.1-prebeta)` / `Closed`, while FB-039 remains selected in canon only.
 - Successor Handling:
-  FB-039 `External trigger and plugin integration architecture` is selected as the next workstream with `Record State: Registry-only`, bounded Branch Readiness minimal scope, and `Branch: Not created`. Its branch creation is deferred until FB-038 release debt clears, updated `main` is revalidated, and the repo-level admission gate passes.
+  FB-039 `External trigger and plugin integration architecture` is selected as the next workstream with `Record State: Registry-only`, bounded Branch Readiness minimal scope, and `Branch: Not created`. Its branch creation is deferred until updated `main` is revalidated and the repo-level admission gate passes.
 - Release Readiness Boundary:
-  Release Readiness may validate inherited release target/scope/artifacts, but it must not absorb PR-owned docs sync, helper-retention decisions, next-workstream selection, post-merge canon repair, or any repository file mutation.
+  Release Readiness remains analysis-only and file-frozen. Any future stale release-state canon discovered after release must be repaired on a legal branch surface, not on protected `main`.
 
-## Merged-Unreleased Release-Debt Owner Contract
+## Released-State Canon Contract
 
-Merged-Unreleased Release-Debt Owner: FB-038
+Released Workstream: FB-038
 Repo State: No Active Branch
-Release Target: v1.4.1-prebeta
+Latest Public Prerelease: v1.4.1-prebeta
+Release Title: Pre-Beta v1.4.1
 Release Floor: patch prerelease
 Version Rationale: FB-038 is tray UX, startup sequencing fix, and governance repair follow-through; it does not open a new feature lane or capability expansion beyond the completed tray/task UX milestone.
 Release Scope: FB-038 tray/task UX milestone only: tray identity/discoverability, tray Open Command Overlay, tray Create Custom Task dialog-open/no-write route, tray-origin create completion through existing FB-036 authoring, catalog reload, exact-match resolution, confirm/result execution, and startup first-visible Core Visualization repair.
-Release Artifacts: tag `v1.4.1-prebeta`; release title `Nexus Desktop AI v1.4.1-prebeta - Tray Quick-Task UX`; release notes summarizing FB-038 user-facing tray/task UX, validation evidence, and retained FB-038 evidence helpers.
-Post-Release Truth: after release, FB-038 moves to `Closed` / `Released (v1.4.1-prebeta)`, release debt clears, roadmap latest public prerelease advances to `v1.4.1-prebeta`, and repo-level admission may reconsider FB-039 Branch Readiness from updated `main`.
+Release Artifacts: tag `v1.4.1-prebeta`; release title `Pre-Beta v1.4.1`; release notes summarizing FB-038 user-facing tray/task UX, validation evidence, and retained FB-038 evidence helpers.
+Post-Release Truth: FB-038 is `Closed` / `Released (v1.4.1-prebeta)`, release debt is clear, roadmap latest public prerelease is `v1.4.1-prebeta`, and repo-level admission may reconsider FB-039 Branch Readiness from updated `main`.
 Selected Next Workstream: FB-039 External trigger and plugin integration architecture.
-Next-Branch Creation Gate: FB-039 remains selected-only and `Branch: Not created` until FB-038 release debt is cleared and updated `main` passes the repo-level admission gate.
+Next-Branch Creation Gate: FB-039 remains selected-only and `Branch: Not created` until updated `main` passes the repo-level admission gate.
 
 ## Bounded Objective
 
@@ -895,6 +904,6 @@ Fresh post-H4 User Test Summary handoff checklist:
 - Create Custom Task flow:
   confirm tray `Create Custom Task` opens the existing overlay entry path and existing dialog, cancel/close does not write `saved_actions.json`, and a deliberate submit can create, reload, resolve, execute, and clean up a test task through the existing FB-036 path
 - response status:
-  returned User Test Summary handling is `WAIVED`; PR Readiness is admitted, and PR Readiness owns merge-target canon, helper-retention, successor-lock, post-merge, drift-audit, and dirty-branch gates before Release Readiness
+  returned User Test Summary handling is `WAIVED`; PR Readiness completed before merge, release execution completed for `v1.4.1-prebeta`, and FB-038 is now a closed historical workstream.
 
-The desktop `User Test Summary.txt` export was refreshed during fresh post-H4 Live Validation because FB-038 remains a user-facing desktop workstream. Returned UTS handling is resolved by documented waiver. PR Readiness completed before the FB-038 squash merge, and FB-038 is now the merged-unreleased release-debt owner; Release Readiness may consume the inherited release target/scope/artifacts only after this repaired truth is durable.
+The desktop `User Test Summary.txt` export was refreshed during fresh post-H4 Live Validation because FB-038 was a user-facing desktop workstream. Returned UTS handling is resolved by documented waiver. PR Readiness completed before the FB-038 squash merge, `v1.4.1-prebeta` has been published, and FB-038 release debt is cleared.

--- a/Docs/workstreams/index.md
+++ b/Docs/workstreams/index.md
@@ -84,10 +84,11 @@ That may be an executable branch owner or another explicitly promoted current-tr
 Merged / Release Debt Owners are promoted implementation workstreams whose implementation branch is merge-target complete but whose public release packaging has not yet cleared release debt.
 These records are not active implementation branch owners after merge.
 
-- `Docs/workstreams/FB-038_taskbar_tray_quick_task_ux.md`
+None.
 
 ### Closed
 
+- `Docs/workstreams/FB-038_taskbar_tray_quick_task_ux.md`
 - `Docs/workstreams/FB-037_built_in_actions_and_settings_expansion.md`
 - `Docs/workstreams/FB-041_deterministic_callable_group_execution_layer.md`
 - `Docs/workstreams/FB-036_saved_action_authoring.md`

--- a/dev/orin_branch_governance_validation.py
+++ b/dev/orin_branch_governance_validation.py
@@ -424,6 +424,20 @@ REQUIRED_MERGED_UNRELEASED_MARKERS = (
 PATCH_PRERELEASE_FLOOR = "patch prerelease"
 MINOR_PRERELEASE_FLOOR = "minor prerelease"
 SEMANTIC_RELEASE_FLOORS = (PATCH_PRERELEASE_FLOOR, MINOR_PRERELEASE_FLOOR)
+PREBETA_RELEASE_TITLE_TEMPLATE = "Pre-Beta v<major>.<minor>.<patch>"
+FB038_RELEASE_TAG = "v1.4.1-prebeta"
+FB038_RELEASE_TITLE = "Pre-Beta v1.4.1"
+FB038_CANONICAL_PATH = "Docs/workstreams/FB-038_taskbar_tray_quick_task_ux.md"
+
+RELEASE_TITLE_FORMAT_DOCS = (
+    Path("Docs/closeout_guidance.md"),
+    Path("Docs/incident_patterns.md"),
+)
+
+RELEASE_TITLE_FORMAT_PHRASES = (
+    PREBETA_RELEASE_TITLE_TEMPLATE,
+    "release notes",
+)
 
 NON_RELEASE_BRANCH_MARKER = "Release Branch: No"
 RELEASE_BEARING_BRANCH_CLASSES = ("release packaging",)
@@ -557,6 +571,46 @@ def _expected_prerelease_target(latest_public: str, release_floor: str) -> str:
     if normalized_floor == MINOR_PRERELEASE_FLOOR:
         return f"v{major}.{minor + 1}.0-prebeta"
     return ""
+
+
+def _expected_prebeta_release_title(release_tag: str) -> str:
+    parsed = _parse_prebeta_version(release_tag)
+    if parsed is None:
+        return ""
+    major, minor, patch = parsed
+    return f"Pre-Beta v{major}.{minor}.{patch}"
+
+
+def _entry_by_id(entries: list[dict[str, str]], workstream_id: str) -> dict[str, str] | None:
+    for entry in entries:
+        if entry.get("id") == workstream_id:
+            return entry
+    return None
+
+
+def _git_prebeta_tags() -> list[str]:
+    completed = subprocess.run(
+        ("git", "tag", "--list", "v*-prebeta"),
+        cwd=ROOT_DIR,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        check=False,
+    )
+    if completed.returncode != 0:
+        return []
+    return [
+        line.strip()
+        for line in completed.stdout.splitlines()
+        if _parse_prebeta_version(line.strip()) is not None
+    ]
+
+
+def _highest_local_prebeta_tag() -> str:
+    tags = _git_prebeta_tags()
+    if not tags:
+        return ""
+    return max(tags, key=lambda tag: _parse_prebeta_version(tag) or (0, 0, 0))
 
 
 def _workstream_target_version(workstream_text: str) -> str:
@@ -1157,6 +1211,14 @@ def main() -> int:
                 f"{relative_path}: Release Readiness file-freeze guidance is missing '{required_phrase}'",
             )
 
+    for relative_path in RELEASE_TITLE_FORMAT_DOCS:
+        text = _read_text(relative_path)
+        for required_phrase in RELEASE_TITLE_FORMAT_PHRASES:
+            require(
+                required_phrase in text,
+                f"{relative_path}: Pre-Beta release title format guidance is missing '{required_phrase}'",
+            )
+
     for relative_path in PROTECTED_MAIN_DOCS:
         text = _read_text(relative_path).casefold()
         for required_phrase in PROTECTED_MAIN_PHRASES:
@@ -1185,6 +1247,77 @@ def main() -> int:
     release_debt_index_paths = _collect_release_debt_index_paths(index_text)
 
     backlog_entries = _parse_backlog_sections(backlog_text)
+    latest_public_prerelease = _latest_public_prerelease(roadmap_text)
+    highest_local_prebeta_tag = _highest_local_prebeta_tag()
+    if highest_local_prebeta_tag:
+        require(
+            latest_public_prerelease == highest_local_prebeta_tag,
+            (
+                "Docs/prebeta_roadmap.md: latest public prerelease must match the latest "
+                f"local prebeta tag '{highest_local_prebeta_tag}', found '{latest_public_prerelease}'"
+            ),
+        )
+
+    fb038_entry = _entry_by_id(backlog_entries, "FB-038")
+    require(bool(fb038_entry), "Docs/feature_backlog.md: FB-038 backlog entry is missing")
+    if highest_local_prebeta_tag == FB038_RELEASE_TAG and fb038_entry:
+        require(
+            fb038_entry["record_state"] == "Closed",
+            f"Docs/feature_backlog.md: FB-038 must be Closed after {FB038_RELEASE_TAG} release",
+        )
+        require(
+            _normalize_status(fb038_entry["status"]) == "released",
+            f"Docs/feature_backlog.md: FB-038 must be Released after {FB038_RELEASE_TAG} release",
+        )
+        require(
+            _clean_release_value(_extract_colon_value(fb038_entry["block"], "Target Version")) == FB038_RELEASE_TAG,
+            f"Docs/feature_backlog.md: FB-038 Target Version must remain {FB038_RELEASE_TAG}",
+        )
+        require(
+            _clean_release_value(_extract_colon_value(fb038_entry["block"], "Release Title")) == FB038_RELEASE_TITLE,
+            f"Docs/feature_backlog.md: FB-038 Release Title must be '{FB038_RELEASE_TITLE}'",
+        )
+        require(
+            FB038_CANONICAL_PATH in closed_index_paths,
+            "Docs/workstreams/index.md: FB-038 must be listed under Closed after v1.4.1-prebeta release",
+        )
+        require(
+            FB038_CANONICAL_PATH not in release_debt_index_paths,
+            "Docs/workstreams/index.md: FB-038 must not remain under Merged / Release Debt Owners after release",
+        )
+        require(
+            "merged unreleased non-doc implementation debt exists: no" in roadmap_text,
+            "Docs/prebeta_roadmap.md: FB-038 release must clear merged-unreleased implementation debt",
+        )
+        require(
+            "merged-unreleased release-debt owner: none" in roadmap_text,
+            "Docs/prebeta_roadmap.md: FB-038 release must clear the release-debt owner",
+        )
+        fb038_workstream_path = ROOT_DIR / Path(FB038_CANONICAL_PATH)
+        require(
+            fb038_workstream_path.is_file(),
+            f"{FB038_CANONICAL_PATH}: FB-038 workstream doc does not exist",
+        )
+        if fb038_workstream_path.is_file():
+            fb038_text = _read_text(Path(FB038_CANONICAL_PATH))
+            fb038_info = _parse_workstream_doc(fb038_text)
+            require(
+                fb038_info["record_state"] == "Closed",
+                f"{FB038_CANONICAL_PATH}: Record State must be Closed after {FB038_RELEASE_TAG} release",
+            )
+            require(
+                _normalize_status(str(fb038_info["status"])) == "released",
+                f"{FB038_CANONICAL_PATH}: Status must be Released after {FB038_RELEASE_TAG} release",
+            )
+            require(
+                f"Latest Public Prerelease: {FB038_RELEASE_TAG}" in fb038_text,
+                f"{FB038_CANONICAL_PATH}: released-state canon must record latest public prerelease {FB038_RELEASE_TAG}",
+            )
+            require(
+                f"Release Title: {FB038_RELEASE_TITLE}" in fb038_text,
+                f"{FB038_CANONICAL_PATH}: released-state canon must record release title '{FB038_RELEASE_TITLE}'",
+            )
+
     if pr_readiness_gate:
         _run_pr_readiness_gate(require, backlog_entries, roadmap_text)
 
@@ -1653,6 +1786,7 @@ def main() -> int:
             )
 
             if expected_release_target:
+                expected_release_title = _expected_prebeta_release_title(expected_release_target)
                 backlog_target_version = _clean_release_value(
                     _extract_colon_value(entry["block"], "Target Version")
                 )
@@ -1689,6 +1823,14 @@ def main() -> int:
                         (
                             f"{source_name}: Release Target Undefined blocker is active; "
                             f"Release Artifacts must reference '{expected_release_target}'"
+                        ),
+                    )
+                    require(
+                        expected_release_title in source_artifacts,
+                        (
+                            f"{source_name}: Release Target Undefined blocker is active; "
+                            "Release Artifacts must use the canonical Pre-Beta release title "
+                            f"'{expected_release_title}'"
                         ),
                     )
                     require(


### PR DESCRIPTION
## Summary

Mark FB-038 as Released/Closed for v1.4.1-prebeta and clear release debt.

## What Changed

Advances latest public prerelease truth to v1.4.1-prebeta, moves FB-038 from merged-unreleased release debt to closed workstream canon, preserves FB-039 as selected-only and unbranched, and records the established Pre-Beta release title format.

Extends branch governance validation so stale post-release canon cannot recur after a pre-Beta tag exists.

No product/runtime code changes.
