### PR TITLE
FB-030 Blocker-Clearing Canon Repair For FB-029 Post-Merge Drift

### DIFF
--- a/Docs/branch_records/feature_fb_030_orin_voice_audio_direction_refinement.md
+++ b/Docs/branch_records/feature_fb_030_orin_voice_audio_direction_refinement.md
@@ -1,0 +1,59 @@
+# Branch Authority Record: feature/fb-030-orin-voice-audio-direction-refinement
+
+## Branch Identity
+
+- Branch: `feature/fb-030-orin-voice-audio-direction-refinement`
+- Workstream: `FB-030`
+- Branch Class: `implementation`
+
+## Purpose / Why It Exists
+
+This branch exists because escaped FB-029 post-merge canon drift blocked `Release Readiness` for `v1.6.4-prebeta`, and governance routes that repair onto the next active branch's `Branch Readiness` before any new implementation begins.
+
+It keeps FB-030 selected-only / `Registry-only` while the blocker-clearing canon repair is made durable. This branch does not promote FB-030, define its full branch plan, or admit any runtime, release, naming, persona, licensing, or user-facing implementation.
+
+## Current Phase
+
+- Phase: `Branch Readiness`
+
+## Phase Status
+
+- `Active Branch`
+- branch created from updated `main` at `0897fab768dc07385f83fab81434ba7926ecc4a1`
+- PR #76 is merged, and FB-029 no longer owns active implementation truth
+- FB-015 remains the inherited merged-unreleased release-debt owner for `v1.6.4-prebeta`
+- this branch carries the required FB-029 post-merge canon repair before release packaging may resume
+- FB-030 remains selected-only / `Registry-only` on this branch, and no canonical FB-030 workstream doc exists yet
+- FB-030 promotion remains blocked until `v1.6.4-prebeta` is published and validated and an explicit voice/audio design goal with affected-surface map is recorded
+- no runtime, release, naming, persona, licensing, or other implementation-facing work is admitted on this branch
+
+## Blockers
+
+- `Release Debt`
+- `Voice/Audio Design Goal Missing`
+- `Affected-Surface Map Missing`
+
+## Entry Basis
+
+- updated `main` is aligned with `origin/main` at `0897fab768dc07385f83fab81434ba7926ecc4a1`
+- FB-029 merged through PR #76, but merged canon still treated FB-029 as an active PR Readiness workstream
+- `Release Readiness` for `v1.6.4-prebeta` is blocked until that escaped current-state drift is repaired on the next legal branch surface
+- FB-030 was already selected next in canon
+- governance routes the repair to this next active branch's `Branch Readiness` before any implementation begins
+
+## Exit Criteria
+
+- FB-029 no longer appears as an active implementation workstream in backlog, roadmap, workstream index, or its canonical workstream record
+- FB-029 is represented as merged-unreleased scope inside the inherited `v1.6.4-prebeta` package
+- FB-015 remains the sole merged-unreleased release-debt owner
+- current release scope and release artifact truth still include both FB-015 and FB-029
+- this branch preserves FB-030 as selected-only / `Registry-only` with no promotion or implementation admission
+- the remaining blocker to full FB-030 Branch Readiness completion is explicitly limited to open release debt plus the missing voice/audio design goal and affected-surface map
+
+## Rollback Target
+
+- `Release Readiness`
+
+## Next Legal Phase
+
+- `Branch Readiness`

--- a/Docs/branch_records/index.md
+++ b/Docs/branch_records/index.md
@@ -42,7 +42,7 @@ Do not use this layer to replace:
 
 ## Active Branch Authority Records
 
-- None
+- `Docs/branch_records/feature_fb_030_orin_voice_audio_direction_refinement.md`
 
 ## Historical Branch Authority Records
 

--- a/Docs/feature_backlog.md
+++ b/Docs/feature_backlog.md
@@ -36,16 +36,16 @@ Historical note:
 
 ## Active Promoted Workstream
 
-FB-029 ORIN legal-safe rebrand, future ARIA persona option, and repo licensing hardening is the current promoted Workstream authority on `feature/fb-029-orin-identity-licensing-hardening`.
+None. No promoted implementation workstream currently owns active branch execution truth.
 
-Main-facing canon is aligned to merged-unreleased truth: FB-040 is released and closed in `v1.6.0-prebeta`, FB-031 is released and closed in `v1.6.1-prebeta`, FB-032 is released and closed in `v1.6.2-prebeta`, FB-004 is released and closed in `v1.6.3-prebeta`, and FB-015 remains the merged-unreleased release-debt owner on `main` for `v1.6.4-prebeta`. FB-029 Workstream WS-1 through WS-3, H-1, and LV-1 are complete on `feature/fb-029-orin-identity-licensing-hardening`; PR-1, PR-2, and PR-3 are complete, PR #76 is open/non-draft/mergeable clean, the milestone remains docs/canon-only, and explicit product/legal approval still blocks any implementation-facing naming, licensing, release, runtime, or persona-surface change.
+Main-facing canon is aligned to merged-unreleased truth: FB-040 is released and closed in `v1.6.0-prebeta`, FB-031 is released and closed in `v1.6.1-prebeta`, FB-032 is released and closed in `v1.6.2-prebeta`, FB-004 is released and closed in `v1.6.3-prebeta`, FB-015 remains the merged-unreleased release-debt owner on `main` for `v1.6.4-prebeta`, and FB-029 is now merged-unreleased within that inherited pending release package after PR #76 merged into `main` at `0897fab768dc07385f83fab81434ba7926ecc4a1`. The active branch surface is now `feature/fb-030-orin-voice-audio-direction-refinement` through `Docs/branch_records/feature_fb_030_orin_voice_audio_direction_refinement.md`, where FB-029 post-merge canon repair is complete and FB-030 remains selected-only / `Registry-only`.
 FB-039 is released and closed in `v1.5.0-prebeta`.
 FB-038 remains released and closed in `v1.4.1-prebeta`.
 
 ## Merged-Unreleased Release-Debt Owner
 
 Merged-Unreleased Release-Debt Owner: FB-015 Boot and desktop phase-boundary model.
-Repo State: No Active Branch. FB-015 remains the inherited merged-unreleased release-debt owner for `v1.6.4-prebeta`; after FB-029 merges, no active promoted implementation branch remains admitted while that release debt is open.
+Repo State: No Active Branch. FB-015 remains the inherited merged-unreleased release-debt owner for `v1.6.4-prebeta`; FB-029 is merged-unreleased inside that same pending package, and no promoted implementation workstream remains active while release debt is open.
 Latest Public Prerelease: v1.6.3-prebeta.
 Latest Public Release Commit: 9f5ae9a78c7dbff79322089bca370fa49da38598.
 Latest Public Prerelease Publication: https://github.com/GiribaldiTTV/Nexus-Desktop-AI/releases/tag/v1.6.3-prebeta.
@@ -56,23 +56,23 @@ Release Floor: patch prerelease
 Version Rationale: The combined pending delta for `v1.6.4-prebeta` remains docs/canon-only planning and governance work with no new executable, runtime, operator-facing, user-facing, or materially expanded product capability.
 Release Scope: FB-015 boot and desktop phase-boundary inventory, ownership map, lifecycle and state framing, implementation admission contract, hardening corrections, Live Validation waivers, PR package history, post-merge canon repair, and merged-unreleased release-debt framing, plus the FB-029 identity source-of-truth inventory, persona-option boundary framing, licensing boundary framing, implementation admission contract, hardening corrections, Live Validation waivers, and PR Readiness package history.
 Release Artifacts: Tag v1.6.4-prebeta; release title Pre-Beta v1.6.4; rich Markdown release notes summarize the FB-015 boundary model and the FB-029 identity/licensing planning frame without repeating the release title inside the notes body, and GitHub-generated `## What's Changed` plus `**Full Changelog**:` must be included.
-Post-Release Truth: FB-015 and FB-029 are Released / Closed in v1.6.4-prebeta after publication and validation; release debt then clears, and FB-030 Branch Readiness may continue on a later branch after updated-main revalidation and an explicit voice/audio design goal with affected-surface map admits the lane.
+Post-Release Truth: FB-015 and FB-029 are Released / Closed in v1.6.4-prebeta after publication and validation; release debt then clears, and FB-030 Branch Readiness may resume beyond blocker-clearing repair on `feature/fb-030-orin-voice-audio-direction-refinement` only after updated-main revalidation and an explicit voice/audio design goal with affected-surface map admits promotion.
 Selected Next Workstream: FB-030 ORIN voice/audio direction refinement.
-Next-Branch Creation Gate: After FB-029 merges, `v1.6.4-prebeta` is published and validated, updated `main` is revalidated, and an explicit voice/audio design goal with affected-surface map admits FB-030 Branch Readiness.
+Next-Branch Creation Gate: Satisfied only for blocker-clearing Branch Readiness on `feature/fb-030-orin-voice-audio-direction-refinement` after updated-main revalidation. FB-030 remains selected-only and must not be promoted or admitted for Workstream until `v1.6.4-prebeta` is published and validated and an explicit voice/audio design goal with affected-surface map is recorded.
 
 ## Backlog Governance Sync
 
-Last Reviewed: 2026-04-23 during FB-029 PR-3.
+Last Reviewed: 2026-04-23 during FB-030 Branch Readiness BR-0.
 
 Open-candidate priority review:
 
 - FB-004 is released and closed in `v1.6.3-prebeta`; it is no longer an active or selected-next branch candidate.
-- FB-015 remains `High`, is promoted, and remains the merged-unreleased release-debt owner on `main` for `v1.6.4-prebeta`; no active promoted implementation branch remains admitted after FB-029 merges while that release debt remains open.
-- FB-029 remains `High`, is promoted on `feature/fb-029-orin-identity-licensing-hardening`, and has completed the bounded docs/canon-only Workstream seam chain through WS-3 plus H-1 Hardening plus LV-1 Live Validation; PR-1, PR-2, and PR-3 are complete, and PR #76 is open/non-draft/mergeable clean.
-- FB-030 remains `Medium`, is now selected-next planning only, and still requires an explicit voice/audio design goal before branch admission.
+- FB-015 remains `High`, is promoted, and remains the merged-unreleased release-debt owner on `main` for `v1.6.4-prebeta`; no promoted implementation workstream is active while that release debt remains open.
+- FB-029 remains `High`, is promoted, and is now merged-unreleased inside the inherited `v1.6.4-prebeta` package after PR #76 merged; it no longer owns active implementation-branch truth.
+- FB-030 remains `Medium`, is still selected-next planning only, and now has a blocker-clearing Branch Readiness surface on `feature/fb-030-orin-voice-audio-direction-refinement`; promotion remains blocked by open release debt plus the missing explicit voice/audio design goal and affected-surface map.
 - FB-005 remains `Low` because remaining workspace movement is path-sensitive and requires explicit workspace/path approval.
 
-Next-branch clarity: FB-030 is selected next for planning only. Successor branch creation remains blocked until FB-029 merges, `v1.6.4-prebeta` is published and validated, updated `main` is revalidated, and an explicit voice/audio design goal with affected-surface map admits FB-030 Branch Readiness.
+Next-branch clarity: FB-030 is selected next for planning only. The branch now exists only to carry blocker-clearing Branch Readiness repair; FB-030 remains `Registry-only`, and promotion remains blocked until `v1.6.4-prebeta` is published and validated and an explicit voice/audio design goal with affected-surface map admits the lane.
 
 ## Registry Items
 
@@ -114,16 +114,19 @@ Version Rationale: FB-015 remains a docs/canon-only boundary inventory, ownershi
 Release Scope: Boot and desktop phase-boundary inventory, ownership map, lifecycle/state framing, implementation admission contract, hardening corrections, Live Validation waivers, PR package history, post-merge canon repair, and merged-unreleased release-debt truth.
 Release Artifacts: Tag v1.6.4-prebeta; release title Pre-Beta v1.6.4; rich Markdown release notes summarize the FB-015 boundary model and governance results without repeating the release title inside the notes body, and GitHub-generated `## What's Changed` plus `**Full Changelog**:` must be included.
 Post-Release Truth: FB-015 is Released / Closed in v1.6.4-prebeta after publication and validation; release debt then clears, and FB-029 Workstream may continue on feature/fb-029-orin-identity-licensing-hardening after updated-main revalidation while this milestone stays docs/canon-only and explicit product/legal approval remains required before implementation-facing work.
+Post-Release Truth: FB-015 is Released / Closed in v1.6.4-prebeta after publication and validation; release debt then clears, and FB-030 Branch Readiness may resume on `feature/fb-030-orin-voice-audio-direction-refinement` only after updated-main revalidation and an explicit voice/audio design goal with affected-surface map admits promotion.
 Minimal Scope: Complete the bounded docs/canon seam chain for current boot/desktop phase-boundary ambiguity, starting with current boundary inventory and ownership mapping before lifecycle framing or implementation-admission rules are extended.
 Summary: Preserve the future boot and desktop phase-boundary model above the already-closed milestone taxonomy work.
 Why it matters: Keeps boot-versus-desktop ownership planning explicit without reopening the closed taxonomy milestone by inertia.
 
 ### [ID: FB-029] ORIN legal-safe rebrand, future ARIA persona option, and repo licensing hardening
 
-Status: Active
+Status: Merged unreleased
 Record State: Promoted
 Priority: High
 Release Stage: pre-Beta
+Target Version: v1.6.4-prebeta
+Release Title: Pre-Beta v1.6.4
 Deferred Since: current pre-Beta identity backlog registration before FB-032 promotion.
 Deferred Because: legal-safe naming, ORIN/ARIA persona posture, and licensing hardening need explicit product/legal approval for implementation-facing execution and must not ride along with source-of-truth migration, UI, runtime, or release work.
 Selection / Unblock: FB-029 is admitted only as a docs/canon-only planning milestone on this branch. Any implementation-facing naming, licensing, persona, release, or runtime edit still requires explicit product/legal approval and must remain out of scope unless a later legal surface admits it.
@@ -133,7 +136,14 @@ Branch Readiness: Complete. The branch objective, target end-state, seam familie
 Workstream: WS-1 current identity, persona-option, and licensing source-of-truth inventory, WS-2 canonical vs historical identity, persona-option, and licensing boundary framing, and WS-3 validation and admission contract for future identity and licensing implementation are complete.
 Hardening: H-1 pressure test of identity inventory, persona-option framing, licensing boundary framing, and future implementation admission rules is complete.
 Live Validation: LV-1 repo-truth alignment, user-facing shortcut applicability, User Test Summary applicability, desktop export applicability, cleanup posture, and waiver handling are complete.
-PR Readiness: PR-1 merge-target canon completeness, PR-2 selected-next workstream selection, and PR-3 live PR creation plus authenticated PR state validation are complete; PR #76 is open/non-draft/mergeable clean.
+PR Readiness: PR-1 merge-target canon completeness, PR-2 selected-next workstream selection, and PR-3 live PR creation plus authenticated PR state validation are complete; PR #76 merged cleanly into `main` at `0897fab768dc07385f83fab81434ba7926ecc4a1`.
+Release Readiness: FB-029 is merged-unreleased inside the inherited `v1.6.4-prebeta` package on `main`; FB-015 remains the sole release-debt owner, and no active implementation-branch truth remains for FB-029.
+Release Target: v1.6.4-prebeta
+Release Floor: patch prerelease
+Version Rationale: FB-029 remains a docs/canon-only identity, persona-option, and licensing-planning milestone with no new executable, runtime, operator-facing, user-facing, or materially expanded product capability.
+Release Scope: Identity source-of-truth inventory, persona-option boundary framing, licensing boundary framing, implementation admission contract, hardening corrections, Live Validation waivers, PR package history, merged-unreleased package-state repair, and post-merge current-state cleanup.
+Release Artifacts: Tag v1.6.4-prebeta; release title Pre-Beta v1.6.4; rich Markdown release notes summarize the FB-015 boundary model and the FB-029 identity/licensing planning frame without repeating the release title inside the notes body, and GitHub-generated `## What's Changed` plus `**Full Changelog**:` must be included.
+Post-Release Truth: FB-029 is Released / Closed in v1.6.4-prebeta after publication and validation; release debt then clears, and FB-030 Branch Readiness may resume on `feature/fb-030-orin-voice-audio-direction-refinement` only after updated-main revalidation and an explicit voice/audio design goal with affected-surface map admits promotion.
 Minimal Scope: Define the Branch Readiness frame for legal-safe ORIN naming, optional future ARIA persona posture, and repo licensing hardening before any naming, licensing, release, runtime, or persona-facing edits begin; Workstream remains docs/canon only unless a later legal surface explicitly widens scope.
 Summary: Track future ORIN-era naming, persona, and licensing hardening work without treating the local rebrand overlay as merged truth.
 Why it matters: Product identity, legal posture, and repo ownership still need durable future treatment, but not by accidental carry-forward.
@@ -147,6 +157,8 @@ Release Stage: pre-Beta
 Deferred Since: current pre-Beta voice/persona backlog registration before FB-032 promotion.
 Deferred Because: ORIN voice identity needs a deliberate persona-facing direction pass; current voice harness, shutdown-voice, and source-of-truth work do not admit broader voice redesign or execution behavior.
 Selection / Unblock: Select only with an explicit voice/audio design goal, affected-surface map, validation boundary, and non-goals separating persona direction from runtime execution.
+Branch: feature/fb-030-orin-voice-audio-direction-refinement
+Branch Readiness: BR-0 blocker-clearing surface is active through `Docs/branch_records/feature_fb_030_orin_voice_audio_direction_refinement.md`; FB-029 post-merge canon repair is complete, but FB-030 remains selected-only / `Registry-only` and is blocked from promotion by open release debt plus the missing explicit voice/audio design goal and affected-surface map.
 Next Workstream: Selected
 Minimal Scope: Define the Branch Readiness frame for ORIN voice/audio direction, persona-facing affected surfaces, validation boundaries, and explicit non-goals before any runtime voice behavior, shutdown voice behavior, or public voice-persona change begins.
 Summary: Preserve future ORIN voice-direction refinement as its own bounded persona-facing lane.

--- a/Docs/prebeta_roadmap.md
+++ b/Docs/prebeta_roadmap.md
@@ -67,20 +67,20 @@ Current merged truth indicates:
 - latest public prerelease title: `Pre-Beta v1.6.3`
 - merged unreleased non-doc implementation debt exists: yes
 - the latest public released implementation milestone is FB-004 Future boot orchestrator layer in `v1.6.3-prebeta`
-- current phase after FB-004 release closure: `PR Readiness`
-- phase status after FB-004 release closure: FB-015 remains merged-unreleased release debt on `main` for `v1.6.4-prebeta`; repo-level current active workstream remains none after merge while that release debt is open; FB-029 Workstream WS-1 through WS-3 plus H-1 plus LV-1 are complete on `feature/fb-029-orin-identity-licensing-hardening`; PR-1, PR-2, and PR-3 are complete, and PR #76 is open/non-draft/mergeable clean
-- blocker after FB-004 release: no FB-029 Workstream blocker remains; merge PR #76 and then continue file-frozen Release Readiness on updated `main`
+- current phase after FB-004 release closure: `Branch Readiness`
+- phase status after FB-004 release closure: FB-015 remains merged-unreleased release debt on `main` for `v1.6.4-prebeta`; FB-029 merged through PR #76 into `main` at `0897fab768dc07385f83fab81434ba7926ecc4a1` and is now merged-unreleased inside that inherited pending package; repo-level current active workstream remains none while release debt is open; and blocker-clearing FB-030 Branch Readiness is active on `feature/fb-030-orin-voice-audio-direction-refinement` through `Docs/branch_records/feature_fb_030_orin_voice_audio_direction_refinement.md` while FB-030 remains selected-only / `Registry-only`
+- blocker after FB-004 release: FB-029 post-merge canon drift is repaired, but FB-030 Branch Readiness remains blocked by open `Release Debt` plus the missing explicit voice/audio design goal and affected-surface map
 - current active workstream: none
-- current branch after FB-004 release: `feature/fb-029-orin-identity-licensing-hardening`
+- current branch after FB-004 release: `feature/fb-030-orin-voice-audio-direction-refinement`
 - selected next workstream: FB-030 ORIN voice/audio direction refinement
-- next concern: merge PR #76 and then continue file-frozen Release Readiness for the inherited `v1.6.4-prebeta` release-debt package on updated `main`.
+- next concern: carry the blocker-clearing FB-030 Branch Readiness repair forward cleanly, then rerun file-frozen Release Readiness for the inherited `v1.6.4-prebeta` package on updated `main`.
 
 That means the released FB-027 interaction baseline, the released FB-036 authoring-and-callable-group milestone, the released FB-041 deterministic callable-group execution milestone, the released FB-037 built-in catalog milestone, the released FB-038 tray quick-task UX milestone, the released FB-039 external trigger intake architecture milestone, the released FB-040 monitoring/thermal architecture milestone, the released FB-031 UI/UX architecture milestone, the released FB-032 source-of-truth migration milestone, and the released FB-004 future boot-orchestrator architecture milestone are now part of the current public shared pre-Beta baseline.
 
 ## Current Release Debt Owner
 
 Merged-Unreleased Release-Debt Owner: FB-015 Boot and desktop phase-boundary model.
-Repo State: No Active Branch. FB-015 remains the inherited merged-unreleased release-debt owner for `v1.6.4-prebeta`; after FB-029 merges, no active promoted implementation branch remains admitted while release debt is open.
+Repo State: No Active Branch. FB-015 remains the inherited merged-unreleased release-debt owner for `v1.6.4-prebeta`; FB-029 is merged-unreleased inside that same pending package, and no promoted implementation workstream remains active while release debt is open.
 
 Latest Public Prerelease: v1.6.3-prebeta
 Latest Public Release Commit: 9f5ae9a78c7dbff79322089bca370fa49da38598
@@ -92,53 +92,58 @@ Release Floor: patch prerelease
 Version Rationale: The combined pending delta for `v1.6.4-prebeta` remains docs/canon-only planning and governance work with no new executable, runtime, operator-facing, user-facing, or materially expanded product capability.
 Release Scope: FB-015 boot and desktop phase-boundary inventory, ownership map, lifecycle and state framing, implementation admission contract, hardening corrections, Live Validation waivers, PR package history, post-merge canon repair, and merged-unreleased release-debt framing, plus the FB-029 identity source-of-truth inventory, persona-option boundary framing, licensing boundary framing, implementation admission contract, hardening corrections, Live Validation waivers, and PR Readiness package history.
 Release Artifacts: Tag v1.6.4-prebeta; release title Pre-Beta v1.6.4; rich Markdown release notes summarize the FB-015 boundary model and the FB-029 identity/licensing planning frame without repeating the release title inside the notes body, and GitHub-generated `## What's Changed` plus `**Full Changelog**:` must be included.
-Post-Release Truth: FB-015 and FB-029 are Released / Closed in v1.6.4-prebeta after publication and validation; release debt then clears, and FB-030 Branch Readiness may continue on a later branch after updated-main revalidation and an explicit voice/audio design goal with affected-surface map admits the lane.
+Post-Release Truth: FB-015 and FB-029 are Released / Closed in v1.6.4-prebeta after publication and validation; release debt then clears, and FB-030 Branch Readiness may resume beyond blocker-clearing repair on `feature/fb-030-orin-voice-audio-direction-refinement` only after updated-main revalidation and an explicit voice/audio design goal with affected-surface map admits promotion.
 Selected Next Workstream: FB-030 ORIN voice/audio direction refinement.
-Next-Branch Creation Gate: After FB-029 merges, `v1.6.4-prebeta` is published and validated, updated `main` is revalidated, and an explicit voice/audio design goal with affected-surface map admits FB-030 Branch Readiness.
+Next-Branch Creation Gate: Satisfied only for blocker-clearing Branch Readiness on `feature/fb-030-orin-voice-audio-direction-refinement` after updated-main revalidation. FB-030 remains selected-only and must not be promoted or admitted for Workstream until `v1.6.4-prebeta` is published and validated and an explicit voice/audio design goal with affected-surface map is recorded.
 Current active workstream: none
 Current Active Workstream Before Release: FB-015 Boot and desktop phase-boundary model
 Active Branch Before Release: `feature/fb-015-boot-desktop-phase-boundary-model`
 
 ## Current Active Workstream
 
-None. Merge-target canon now clears repo-level active workstream truth while the inherited `v1.6.4-prebeta` release debt remains open. FB-029 is the current PR Readiness authority on `feature/fb-029-orin-identity-licensing-hardening`, but that package-ready branch truth does not clear the repo-level `No Active Branch` release-debt posture after merge.
+None. Merge-target canon clears repo-level active workstream truth while the inherited `v1.6.4-prebeta` release debt remains open. The active branch surface is the FB-030 blocker-clearing Branch Readiness record on `feature/fb-030-orin-voice-audio-direction-refinement`, but FB-030 remains selected-only / `Registry-only` and no promoted implementation workstream is active.
 
 ## Backlog Priority Review
 
 The 2026-04-23 priority reading is updated during FB-029 PR-2:
 
 - FB-004 is released and closed in `v1.6.3-prebeta`; it is no longer an active or selected-next branch candidate.
-- FB-015 remains `High`, is promoted, and remains the merged-unreleased release-debt owner on `main` for `v1.6.4-prebeta`; no active promoted implementation branch remains admitted after FB-029 merges while that release debt remains open.
-- FB-029 remains `High`, is promoted on `feature/fb-029-orin-identity-licensing-hardening`, and has completed the bounded docs/canon-only Workstream seam chain through WS-3 plus H-1 Hardening plus LV-1 Live Validation; PR-1, PR-2, and PR-3 are complete, and PR #76 is open/non-draft/mergeable clean.
-- FB-030 remains `Medium`, is now selected-next planning only, and still requires an explicit voice/audio design goal before branch admission.
+- FB-015 remains `High`, is promoted, and remains the merged-unreleased release-debt owner on `main` for `v1.6.4-prebeta`; no promoted implementation workstream is active while that release debt remains open.
+- FB-029 remains `High`, is promoted, and is now merged-unreleased inside the inherited `v1.6.4-prebeta` package after PR #76 merged; it no longer owns active implementation-branch truth.
+- FB-030 remains `Medium`, is selected-next planning only, and now has a blocker-clearing Branch Readiness surface on `feature/fb-030-orin-voice-audio-direction-refinement`; promotion remains blocked by open release debt plus the missing explicit voice/audio design goal and affected-surface map.
 - FB-005 remains `Low` and requires explicit path-sensitive workspace approval before selection.
 
-Next-branch clarity: FB-030 is selected next for planning only. Successor branch creation remains blocked until FB-029 merges, `v1.6.4-prebeta` is published and validated, updated `main` is revalidated, and an explicit voice/audio design goal with affected-surface map admits FB-030 Branch Readiness.
+Next-branch clarity: FB-030 is selected next for planning only. The branch now exists only to carry blocker-clearing Branch Readiness repair; FB-030 remains `Registry-only`, and promotion remains blocked until `v1.6.4-prebeta` is published and validated and an explicit voice/audio design goal with affected-surface map admits the lane.
 
 ## Selected Next Workstream
 
 Workstream: FB-030 ORIN voice/audio direction refinement
 Record State: Registry-only
 Minimal Scope: Define the Branch Readiness frame for ORIN voice/audio direction, persona-facing affected surfaces, validation boundaries, and explicit non-goals before any runtime voice behavior, shutdown voice behavior, or public voice-persona change begins.
-Branch: Not created
-Creation Gate: After FB-029 merges, `v1.6.4-prebeta` is published and validated, updated `main` is revalidated, and an explicit voice/audio design goal with affected-surface map admits FB-030 Branch Readiness.
+Branch: feature/fb-030-orin-voice-audio-direction-refinement
+Branch Authority Record: `Docs/branch_records/feature_fb_030_orin_voice_audio_direction_refinement.md`
+Creation Gate: Satisfied only for blocker-clearing Branch Readiness after updated-main revalidation. FB-030 remains selected-only and must not be promoted or admitted for Workstream until `v1.6.4-prebeta` is published and validated and an explicit voice/audio design goal with affected-surface map is recorded.
 
-## Promoted PR Readiness Workstream
+## Merged / Pending Release Workstreams
 
 ### FB-029 ORIN Legal-Safe Rebrand, Future ARIA Persona Option, And Repo Licensing Hardening
 
-- status: `Active`
+- status: `Merged unreleased`
 - record state: `Promoted`
 - priority: `High`
 - canonical workstream doc: `Docs/workstreams/FB-029_orin_identity_licensing_hardening.md`
 - selection basis: selected during FB-015 PR Readiness as the highest-priority remaining open backlog candidate, then carried on this branch first for blocker-clearing FB-015 canon repair and now for completed Branch Readiness planning.
 - branch: `feature/fb-029-orin-identity-licensing-hardening`
-- phase status: Workstream WS-1 through WS-3, H-1, and LV-1 are complete; PR-1, PR-2, and PR-3 are complete; PR #76 is open/non-draft/mergeable clean; the milestone remains docs/canon-only; explicit product/legal approval still blocks any implementation-facing naming, licensing, release, runtime, or persona-surface work.
+- phase status: PR #76 merged into `main` at `0897fab768dc07385f83fab81434ba7926ecc4a1`; FB-029 is now merged-unreleased inside the inherited `v1.6.4-prebeta` package, no longer owns active implementation truth, remains docs/canon-only, and explicit product/legal approval still blocks any implementation-facing naming, licensing, release, runtime, or persona-surface work.
 - repo-level post-merge state: `No Active Branch` while the inherited `v1.6.4-prebeta` release debt remains open on `main`.
-- next legal seam: merge PR #76, then continue Release Readiness on updated `main`.
+- next legal seam: rerun file-frozen Release Readiness on updated `main` after this blocker-clearing repair is merged.
+Release Target: v1.6.4-prebeta
+Release Floor: patch prerelease
+Version Rationale: FB-029 remains a docs/canon-only identity, persona-option, and licensing-planning milestone with no new executable, runtime, operator-facing, user-facing, or materially expanded product capability.
+Release Scope: Identity source-of-truth inventory, persona-option boundary framing, licensing boundary framing, implementation admission contract, hardening corrections, Live Validation waivers, PR package history, merged-unreleased package-state repair, and post-merge current-state cleanup.
+Release Artifacts: Tag v1.6.4-prebeta; release title Pre-Beta v1.6.4; rich Markdown release notes summarize the FB-015 boundary model and the FB-029 identity/licensing planning frame without repeating the release title inside the notes body, and GitHub-generated `## What's Changed` plus `**Full Changelog**:` must be included.
+Post-Release Truth: FB-015 and FB-029 are Released / Closed in v1.6.4-prebeta after publication and validation; release debt then clears, and FB-030 Branch Readiness may resume beyond blocker-clearing repair on `feature/fb-030-orin-voice-audio-direction-refinement` only after updated-main revalidation and an explicit voice/audio design goal with affected-surface map admits promotion.
 - Minimal Scope: Define the legal-safe ORIN naming, optional future ARIA persona posture, and licensing-hardening planning frame before any naming, licensing, release, runtime, or persona-facing edits begin.
-
-## Merged / Release Debt Owner Workstream
 
 ### FB-015 Boot And Desktop Phase-Boundary Model
 
@@ -155,9 +160,9 @@ Release Floor: patch prerelease
 Version Rationale: FB-015 remains a docs/canon-only boot and desktop phase-boundary architecture plus admission milestone with no new executable, runtime, operator-facing, user-facing, or materially expanded product capability.
 Release Scope: FB-015 boot and desktop phase-boundary inventory, ownership map, lifecycle and state framing, implementation admission contract, hardening corrections, Live Validation waivers, PR package history, post-merge canon repair, and merged-unreleased release-debt framing, plus the FB-029 identity source-of-truth inventory, persona-option boundary framing, licensing boundary framing, implementation admission contract, hardening corrections, Live Validation waivers, and PR Readiness package history.
 Release Artifacts: Tag v1.6.4-prebeta; release title Pre-Beta v1.6.4; rich Markdown release notes summarize the FB-015 boundary model and the FB-029 identity/licensing planning frame without repeating the release title inside the notes body, and GitHub-generated `## What's Changed` plus `**Full Changelog**:` must be included.
-Post-Release Truth: FB-015 and FB-029 are Released / Closed in v1.6.4-prebeta after publication and validation; release debt then clears, and FB-030 Branch Readiness may continue on a later branch after updated-main revalidation and an explicit voice/audio design goal with affected-surface map admits the lane.
+Post-Release Truth: FB-015 and FB-029 are Released / Closed in v1.6.4-prebeta after publication and validation; release debt then clears, and FB-030 Branch Readiness may resume beyond blocker-clearing repair on `feature/fb-030-orin-voice-audio-direction-refinement` only after updated-main revalidation and an explicit voice/audio design goal with affected-surface map admits promotion.
 Selected Next Workstream: FB-030 ORIN voice/audio direction refinement
-Next-Branch Creation Gate: After FB-029 merges, `v1.6.4-prebeta` is published and validated, updated `main` is revalidated, and an explicit voice/audio design goal with affected-surface map admits FB-030 Branch Readiness.
+Next-Branch Creation Gate: Satisfied only for blocker-clearing Branch Readiness on `feature/fb-030-orin-voice-audio-direction-refinement` after updated-main revalidation. FB-030 remains selected-only and must not be promoted or admitted for Workstream until `v1.6.4-prebeta` is published and validated and an explicit voice/audio design goal with affected-surface map is recorded.
 - Minimal Scope: Complete the bounded docs/canon seam chain for current boot/desktop phase-boundary ambiguity, starting with current boundary inventory and ownership mapping before lifecycle framing or implementation-admission rules are extended.
 
 ## Latest Released Workstream Context
@@ -172,7 +177,7 @@ Next-Branch Creation Gate: After FB-029 merges, `v1.6.4-prebeta` is published an
 - release title: `Pre-Beta v1.6.3`
 - canonical workstream doc: `Docs/workstreams/FB-004_future_boot_orchestrator_layer.md`
 - sequencing note: released the docs/canon-only future boot-orchestrator architecture milestone, including source map, lifecycle/state framing, ownership boundaries, diagnostics evidence-root correction, rollback boundaries, stale helper caveat, implementation admission contract, hardening, Live Validation waivers, backlog governance sync, and PR Readiness merge-target canon.
-- successor note: FB-015 remains merged-unreleased on `main` for `v1.6.4-prebeta`; the pending release scope now includes FB-029, which has completed the bounded docs/canon-only Workstream seam chain through WS-3 plus H-1 plus LV-1 on `feature/fb-029-orin-identity-licensing-hardening` and is now PR-ready on open PR #76.
+- successor note: FB-015 remains merged-unreleased on `main` for `v1.6.4-prebeta`; the pending release scope now includes FB-029, which is now merged-unreleased inside that package after PR #76 merged into `main` at `0897fab768dc07385f83fab81434ba7926ecc4a1`; blocker-clearing FB-030 Branch Readiness now rides on `feature/fb-030-orin-voice-audio-direction-refinement` while FB-030 remains selected-only.
 
 ## Prior Released Workstream Context
 
@@ -186,7 +191,7 @@ Next-Branch Creation Gate: After FB-029 merges, `v1.6.4-prebeta` is published an
 - release title: `Pre-Beta v1.6.2`
 - canonical workstream doc: `Docs/workstreams/FB-032_nexus_era_vision_and_source_of_truth_migration.md`
 - sequencing note: released the architecture-only Nexus-era source-of-truth migration foundation, including current-vs-historical source inventory, naming policy, canonical-vs-historical surface classification, controlled migration admission contract, governance repairs, hardening, Live Validation waivers, and PR Readiness merge-target canon.
-- successor note: FB-004 is released and closed in `v1.6.3-prebeta`; FB-015 remains merged-unreleased on `main` for `v1.6.4-prebeta`, and FB-029 has completed the bounded docs/canon-only Workstream seam chain through WS-3 plus H-1 plus LV-1 on `feature/fb-029-orin-identity-licensing-hardening` with PR-1, PR-2, and PR-3 complete on open PR #76.
+- successor note: FB-004 is released and closed in `v1.6.3-prebeta`; FB-015 remains merged-unreleased on `main` for `v1.6.4-prebeta`, FB-029 is merged-unreleased inside that pending package after PR #76 merged into `main`, and blocker-clearing FB-030 Branch Readiness now rides on `feature/fb-030-orin-voice-audio-direction-refinement` while FB-030 remains selected-only.
 
 ## Prior Released Workstream Context
 
@@ -200,7 +205,7 @@ Next-Branch Creation Gate: After FB-029 merges, `v1.6.4-prebeta` is published an
 - release title: `Pre-Beta v1.6.1`
 - canonical workstream doc: `Docs/workstreams/FB-031_nexus_desktop_ai_ui_ux_overhaul_planning.md`
 - sequencing note: released the architecture-only UI/UX planning milestone, including source map, visual-language ownership vocabulary, lifecycle and interaction-state framing, future UI implementation admission contract, Hardening pressure test, Live Validation waivers, PR Readiness merge-target canon, and PR-R1 release-floor validator repair.
-- successor note: FB-032 is released and closed in `v1.6.2-prebeta`; FB-004 is released and closed in `v1.6.3-prebeta`; FB-015 remains merged-unreleased on `main` for `v1.6.4-prebeta`, and FB-029 has completed the bounded docs/canon-only Workstream seam chain through WS-3 plus H-1 plus LV-1 on `feature/fb-029-orin-identity-licensing-hardening` with PR-1, PR-2, and PR-3 complete on open PR #76.
+- successor note: FB-032 is released and closed in `v1.6.2-prebeta`; FB-004 is released and closed in `v1.6.3-prebeta`; FB-015 remains merged-unreleased on `main` for `v1.6.4-prebeta`, FB-029 is merged-unreleased inside that pending package after PR #76 merged into `main`, and blocker-clearing FB-030 Branch Readiness now rides on `feature/fb-030-orin-voice-audio-direction-refinement` while FB-030 remains selected-only.
 
 ## Prior Released Workstream Context
 
@@ -356,7 +361,7 @@ Current merged truth indicates:
 - remaining open backlog candidates now explicitly recorded in the backlog include:
   - FB-004 for future boot orchestrator layer, released and closed in `v1.6.3-prebeta`
   - FB-015 for boot and desktop phase-boundary model, merged-unreleased on `main` for `v1.6.4-prebeta`, `High`, and carrying release debt until prerelease publication plus post-release canon closure
-  - FB-029 for ORIN legal-safe rebrand, future ARIA persona option, and repo licensing hardening, `High`, promoted on `feature/fb-029-orin-identity-licensing-hardening`, with the bounded docs/canon-only Workstream seam chain complete through WS-3 plus H-1 plus LV-1 and PR Readiness next while implementation-facing admission remains explicitly product/legal-gated
+  - FB-029 for ORIN legal-safe rebrand, future ARIA persona option, and repo licensing hardening, `High`, promoted on `feature/fb-029-orin-identity-licensing-hardening`, merged-unreleased inside the inherited `v1.6.4-prebeta` package, and still implementation-gated for any later naming, licensing, release, runtime, or persona-facing execution
   - FB-030 for ORIN voice/audio direction refinement, `Medium` and gated by an explicit voice/audio design goal
   - FB-005 for workspace and folder organization, `Low` and gated by explicit path-sensitive workspace approval
 - those candidate lanes must be selected deliberately rather than bundled together as one implicit interaction continuation

--- a/Docs/workstreams/FB-015_boot_and_desktop_phase_boundary_model.md
+++ b/Docs/workstreams/FB-015_boot_and_desktop_phase_boundary_model.md
@@ -46,7 +46,7 @@
 - PR-1 merge-target canon completeness is complete.
 - PR-2 selected-next workstream selection is complete with FB-029 planning-only.
 - PR-3 live PR creation and validation is complete, and PR #75 is now merged.
-- `feature/fb-029-orin-identity-licensing-hardening` is now the promoted FB-029 PR Readiness authority; the bounded docs/canon-only WS-1 through WS-3 seam chain plus H-1 plus LV-1 are complete there, PR-1, PR-2, and PR-3 are complete, PR #76 is open/non-draft/mergeable clean, and explicit product/legal approval still blocks any implementation-facing naming, licensing, release, runtime, or persona-surface work.
+- FB-029 merged through PR #76 into `main` at `0897fab768dc07385f83fab81434ba7926ecc4a1` and is now merged-unreleased inside the inherited `v1.6.4-prebeta` package; it no longer owns active implementation truth, and explicit product/legal approval still blocks any implementation-facing naming, licensing, release, runtime, or persona-surface work.
 - Hardening clarified launcher-owned `STARTUP_READY_OBSERVED`, `normal exit complete`, and `failure flow complete` as explicit boundary states and tightened later shortcut-proof classification so direct repository launch-shim invocation is not treated as real user-facing shortcut proof by default.
 - Live Validation confirmed the completed FB-015 delta remains docs/canon only, so user-facing shortcut validation and User Test Summary results are both waived for this milestone.
 - PR Readiness derived `v1.6.4-prebeta` / `Pre-Beta v1.6.4` as the semantic post-merge release target because FB-015 remains a docs/canon-only architecture/admission milestone with `patch prerelease` release-floor semantics.
@@ -119,8 +119,8 @@
 - Confirm `Docs/workstreams/index.md` lists FB-015 under Merged / Release Debt Owners and not under Active.
 - Confirm `Docs/feature_backlog.md`, `Docs/prebeta_roadmap.md`, and `Docs/workstreams/index.md` record FB-015 as the merged-unreleased release-debt owner with `Repo State: No Active Branch`.
 - Confirm `Docs/prebeta_roadmap.md` records `merged unreleased non-doc implementation debt exists: yes` and `current active workstream: none`.
-- Confirm `Docs/feature_backlog.md`, `Docs/prebeta_roadmap.md`, `Docs/workstreams/index.md`, and `Docs/Main.md` route FB-029 as `Promoted`, `Active`, Workstream-complete-through-WS-3 truth on `feature/fb-029-orin-identity-licensing-hardening` with a canonical workstream doc.
-- Confirm FB-029 Hardening is the next legal phase, while the milestone remains docs/canon-only and implementation-facing admission stays explicitly product/legal-gated.
+- Confirm `Docs/feature_backlog.md`, `Docs/prebeta_roadmap.md`, `Docs/workstreams/index.md`, and `Docs/Main.md` route FB-029 as `Promoted`, `Merged unreleased`, and included in the inherited `v1.6.4-prebeta` package with no active implementation truth.
+- Confirm blocker-clearing FB-030 Branch Readiness is active on `feature/fb-030-orin-voice-audio-direction-refinement` through `Docs/branch_records/feature_fb_030_orin_voice_audio_direction_refinement.md` while FB-030 remains selected-only / `Registry-only`.
 - Confirm the validator rejects active implementation workstream truth on `main` when the canonical branch is not `main`.
 - Confirm FB-004 remains Released / Closed in `v1.6.3-prebeta`.
 - Confirm the previously recorded supporting canon sync remains limited to active FB-015 branch authority wording, `Docs/workstreams/FB-040_monitoring_thermals_performance_hud_surface.md`, and `Docs/validation_helper_registry.md`, and does not reopen FB-040 or change the admitted FB-015 seam chain.
@@ -616,15 +616,15 @@ Release Floor: patch prerelease
 Version Rationale: FB-015 remains a docs/canon-only boot and desktop phase-boundary architecture plus admission milestone with no new executable, runtime, operator-facing, user-facing, or materially expanded product capability
 Release Scope: FB-015 boot and desktop phase-boundary inventory, ownership map, lifecycle and state framing, implementation admission contract, hardening corrections, Live Validation waivers, PR Readiness package history, post-merge canon repair, and merged-unreleased release-debt framing, plus the FB-029 identity source-of-truth inventory, persona-option boundary framing, licensing boundary framing, implementation admission contract, hardening corrections, Live Validation waivers, and PR Readiness package history
 Release Artifacts: Tag v1.6.4-prebeta; release title Pre-Beta v1.6.4; rich Markdown release notes summarize the FB-015 boundary model and the FB-029 identity/licensing planning frame without repeating the release title inside the notes body, and GitHub-generated `## What's Changed` plus `**Full Changelog**:` must be included
-Post-Release Truth: FB-015 and FB-029 are Released / Closed in v1.6.4-prebeta after publication and validation; release debt then clears, and FB-030 Branch Readiness may continue on a later branch after updated-main revalidation and an explicit voice/audio design goal with affected-surface map admits the lane
+Post-Release Truth: FB-015 and FB-029 are Released / Closed in v1.6.4-prebeta after publication and validation; release debt then clears, and FB-030 Branch Readiness may resume beyond blocker-clearing repair on `feature/fb-030-orin-voice-audio-direction-refinement` only after updated-main revalidation and an explicit voice/audio design goal with affected-surface map admits promotion
 Selected Next Workstream: FB-030 ORIN voice/audio direction refinement
-Next-Branch Creation Gate: After FB-029 merges, `v1.6.4-prebeta` is published and validated, updated `main` is revalidated, and an explicit voice/audio design goal with affected-surface map admits FB-030 Branch Readiness
+Next-Branch Creation Gate: Satisfied only for blocker-clearing Branch Readiness on `feature/fb-030-orin-voice-audio-direction-refinement` after updated-main revalidation. FB-030 remains selected-only and must not be promoted or admitted for Workstream until `v1.6.4-prebeta` is published and validated and an explicit voice/audio design goal with affected-surface map is recorded
 
 ## Post-Merge State
 
 - PR #75 merged cleanly into `main` at `3e821e07ff91d814fd7aba9b50819f97d700a301`, and FB-015 is now the merged-unreleased release-debt owner for `v1.6.4-prebeta`.
 - After merge, repo state is `No Active Branch` until `v1.6.4-prebeta` is published, validated, and post-release canon closure is completed on the next legal branch surface.
-- FB-029 is the selected next workstream; `feature/fb-029-orin-identity-licensing-hardening` now carries promoted Workstream truth with WS-1 through WS-3 plus H-1 plus LV-1 complete, PR Readiness next, and explicit product/legal approval still controls any later implementation-facing admission.
+- FB-029 is merged-unreleased inside the inherited `v1.6.4-prebeta` package after PR #76 merged into `main`, and blocker-clearing FB-030 Branch Readiness now rides on `feature/fb-030-orin-voice-audio-direction-refinement` while FB-030 remains selected-only and explicit product/legal approval still controls any later implementation-facing admission.
 
 ## PR Readiness Record
 
@@ -716,7 +716,7 @@ PR Readiness validates the completed docs/canon-only FB-015 milestone for merge 
 - The ownership map across the current user-facing launch shim, production launcher, production renderer, dev-only boot prototype, shared single-instance primitives, and evidence/state roots is recorded.
 - `## User Test Summary` records `User-Facing Shortcut Validation: WAIVED`, `User-Facing Shortcut Waiver Reason:`, `User Test Summary Results: WAIVED`, and `User Test Summary Waiver Reason:` for the docs/canon-only milestone.
 - `Docs/Main.md`, `Docs/feature_backlog.md`, `Docs/prebeta_roadmap.md`, and `Docs/workstreams/index.md` route FB-015 as the merged-unreleased release-debt owner with `Repo State: No Active Branch`, `Release Target: v1.6.4-prebeta`, and no stale active-workstream truth.
-- Backlog, roadmap, and workstreams index route FB-029 as the promoted Workstream authority on `feature/fb-029-orin-identity-licensing-hardening` with WS-1 through WS-3 plus H-1 plus LV-1 complete and PR Readiness next for the docs/canon-only milestone.
+- Backlog, roadmap, and workstreams index route FB-029 as promoted and merged-unreleased inside the inherited `v1.6.4-prebeta` package, with no stale active implementation truth remaining after PR #76 merged.
 - FB-004 remains Released / Closed, and the latest public prerelease remains `v1.6.3-prebeta`.
 - Requested future-lane `FB-042 Stream Deck Integration via Elgato MCP` admission remains deferred and no out-of-scope backlog, roadmap, workstream, or auxiliary planning-reference canon was added on this branch.
 - No runtime, launcher, shortcut, renderer lifecycle, UI, installer, source-tree, release, helper-code, or desktop-export surface changed during WS-1 through WS-3, H-1, or LV-1.

--- a/Docs/workstreams/FB-029_orin_identity_licensing_hardening.md
+++ b/Docs/workstreams/FB-029_orin_identity_licensing_hardening.md
@@ -11,11 +11,15 @@
 
 ## Status
 
-- `Active`
+- `Merged unreleased`
 
 ## Release Stage
 
 - `pre-Beta`
+
+## Target Version
+
+- `v1.6.4-prebeta`
 
 ## Canonical Branch
 
@@ -23,15 +27,16 @@
 
 ## Current Phase
 
-- Phase: `PR Readiness`
+- Phase: `Release Readiness`
 
 ## Phase Status
 
-- `PR Readiness is complete; PR-1 merge-target canon completeness, PR-2 selected-next workstream selection, and PR-3 live PR creation plus validation are complete, and PR #76 is open/non-draft/mergeable clean`
+- `Release Readiness pending on updated main after PR #76 merged cleanly into main at 0897fab768dc07385f83fab81434ba7926ecc4a1`
 - FB-015 remains the merged-unreleased release-debt owner on `main` for `v1.6.4-prebeta`.
 - FB-015 pending `v1.6.4-prebeta` release scope now includes the completed FB-029 docs/canon-only identity, persona-option, and licensing-planning milestone.
-- Repo-level current active workstream remains `none` after merge while the inherited `v1.6.4-prebeta` release debt remains unresolved.
-- FB-029 is the current promoted PR Readiness authority on `feature/fb-029-orin-identity-licensing-hardening`.
+- Repo State is `No Active Branch` while the inherited `v1.6.4-prebeta` release debt remains unresolved.
+- FB-029 is merged-unreleased inside the inherited `v1.6.4-prebeta` package and no longer owns active implementation truth.
+- Blocker-clearing FB-030 Branch Readiness now rides on `feature/fb-030-orin-voice-audio-direction-refinement` through `Docs/branch_records/feature_fb_030_orin_voice_audio_direction_refinement.md` while FB-030 remains selected-only / `Registry-only`.
 - This milestone remains docs/canon-only planning and governance work.
 - WS-1 current identity, persona-option, and licensing source-of-truth inventory is complete and durably recorded.
 - WS-2 canonical vs historical identity, persona-option, and licensing boundary framing is complete and durably recorded.
@@ -40,7 +45,7 @@
 - LV-1 repo-truth alignment, user-facing shortcut applicability, User Test Summary applicability, desktop export applicability, cleanup posture, and waiver handling are complete and durably recorded.
 - PR-1 merge-target canon completeness is complete with inherited `v1.6.4-prebeta` release-debt truth aligned to include FB-029 in pending release scope.
 - PR-2 selected-next workstream selection is complete with FB-030 planning-only.
-- PR-3 live PR creation and validation are complete, and PR #76 is open/non-draft/mergeable clean.
+- PR-3 live PR creation and validation are complete, and PR #76 is now merged.
 - Dormant ARIA registry presence remains non-shipping and non-default; any release-gating, runtime-selection, UI-exposure, or public-claim change still requires a later explicitly admitted implementation surface.
 - Licensing authority remains centralized in `LICENSE` plus `Docs/ownership_ip_plan.md`; `README.md`, release notes, and other public identity summaries remain downstream explanatory surfaces only.
 - Live Validation confirms this milestone remains docs/canon-only, so user-facing shortcut validation and User Test Summary results are both waived for this pass.
@@ -53,7 +58,7 @@
 
 ## Blockers
 
-None. PR Readiness is green for this docs/canon-only milestone.
+- `Release Debt`
 
 ## Entry Basis
 
@@ -109,13 +114,13 @@ None. PR Readiness is green for this docs/canon-only milestone.
 - Run `python dev\orin_branch_governance_validation.py`.
 - Run `git diff --check`.
 - Confirm `Docs/Main.md` routes this workstream record.
-- Confirm `Docs/feature_backlog.md` marks FB-029 as `Promoted`, `Active`, cites this doc, and records WS-1 through WS-3, H-1, and LV-1 complete with PR Readiness next.
-- Confirm `Docs/workstreams/index.md` lists FB-029 under Active while FB-015 remains under Merged / Release Debt Owners.
-- Confirm `Docs/prebeta_roadmap.md` preserves FB-015 merged-unreleased release-debt truth with `current active workstream: none` while also recording FB-029 Workstream plus Hardening and Live Validation complete with PR Readiness next.
-- Confirm `Docs/feature_backlog.md`, `Docs/prebeta_roadmap.md`, `Docs/workstreams/index.md`, and `Docs/workstreams/FB-015_boot_and_desktop_phase_boundary_model.md` agree that FB-029 is promoted on this branch, WS-1 through WS-3, H-1, and LV-1 are complete, and PR Readiness is next.
+- Confirm `Docs/feature_backlog.md` marks FB-029 as `Promoted`, `Merged unreleased`, cites this doc, and records PR #76 merged plus inherited `v1.6.4-prebeta` package participation.
+- Confirm `Docs/workstreams/index.md` lists FB-029 under Merged / Release Debt Owners and not under Active.
+- Confirm `Docs/prebeta_roadmap.md` preserves FB-015 merged-unreleased release-debt ownership with `current active workstream: none` while also recording FB-029 as merged-unreleased package scope.
+- Confirm `Docs/feature_backlog.md`, `Docs/prebeta_roadmap.md`, `Docs/workstreams/index.md`, and `Docs/workstreams/FB-015_boot_and_desktop_phase_boundary_model.md` agree that FB-029 is promoted, merged-unreleased, and no longer active implementation truth.
 - Confirm `assistant_personas.py` still keeps `RELEASED_PERSONA_IDS = ("orin",)` and `DEFAULT_PERSONA_ID = "orin"`.
 - Confirm `LICENSE` and `Docs/ownership_ip_plan.md` remain aligned on current proprietor and restrictive proprietary posture.
-- Confirm FB-015 merged-unreleased release-debt truth still routes Release Readiness to updated `main`.
+- Confirm FB-015 merged-unreleased release-debt truth still routes Release Readiness to updated `main` and remains the sole release-debt owner.
 - Confirm explicit product/legal approval remains required before any implementation-facing naming, licensing, release, runtime, or persona-surface change.
 - Confirm no naming changes, license-file edits, runtime changes, release edits, UI copy edits, asset edits, or other user-facing or operator-facing implementation occurred in this pass.
 
@@ -165,7 +170,7 @@ Seam 3: Validation and admission contract for future identity and licensing impl
 
 ## Active Seam
 
-Active seam: None after LV-1 completion under bounded multi-seam governance; PR Readiness is next.
+Active seam: None after merge; Release Readiness on updated `main` is next while blocker-clearing FB-030 Branch Readiness is the current legal repair surface.
 
 - BR-1 Status: Completed in the prior Branch Readiness pass.
 - BR-1 Boundary: promote FB-029, define branch objective, target end-state, seam families, validation contract, User Test Summary strategy, later-phase expectations, and the first Workstream seam.
@@ -376,12 +381,25 @@ Governance Drift Found: Yes, resolved before PR green.
 - Repair: PR-1 expands the inherited `v1.6.4-prebeta` release-debt scope, artifacts, and post-release truth to include the completed FB-029 milestone while preserving FB-015 as the active merged-unreleased release-debt owner on `main`; PR-2 selects FB-030 as the next planning-only workstream and keeps branch creation deferred; current-state canon is synchronized to PR Readiness package-ready truth.
 - No unresolved contradiction remains across backlog priority, deferred-context fields, semantic release-target derivation, selected-next gating, docs/canon-only validation posture, or product/legal implementation gates.
 
+## Merged-Unreleased Package State
+
+Merged-Unreleased Release-Debt Owner: FB-015 Boot and desktop phase-boundary model
+Repo State: No Active Branch
+Release Target: v1.6.4-prebeta
+Release Floor: patch prerelease
+Version Rationale: FB-029 remains a docs/canon-only identity, persona-option, and licensing-planning milestone with no new executable, runtime, operator-facing, user-facing, or materially expanded product capability
+Release Scope: FB-015 boot and desktop phase-boundary inventory, ownership map, lifecycle and state framing, implementation admission contract, hardening corrections, Live Validation waivers, PR package history, post-merge canon repair, and merged-unreleased release-debt framing, plus the FB-029 identity source-of-truth inventory, persona-option boundary framing, licensing boundary framing, implementation admission contract, hardening corrections, Live Validation waivers, PR package history, and merged-unreleased package-state repair
+Release Artifacts: Tag v1.6.4-prebeta; release title Pre-Beta v1.6.4; rich Markdown release notes summarize the FB-015 boundary model and the FB-029 identity/licensing planning frame without repeating the release title inside the notes body, and GitHub-generated `## What's Changed` plus `**Full Changelog**:` must be included
+Post-Release Truth: FB-015 and FB-029 are Released / Closed in v1.6.4-prebeta after publication and validation; release debt then clears, and FB-030 Branch Readiness may resume beyond blocker-clearing repair on `feature/fb-030-orin-voice-audio-direction-refinement` only after updated-main revalidation and an explicit voice/audio design goal with affected-surface map admits promotion
+Selected Next Workstream: FB-030 ORIN voice/audio direction refinement
+Next-Branch Creation Gate: Satisfied only for blocker-clearing Branch Readiness on `feature/fb-030-orin-voice-audio-direction-refinement` after updated-main revalidation. FB-030 remains selected-only and must not be promoted or admitted for Workstream until `v1.6.4-prebeta` is published and validated and an explicit voice/audio design goal with affected-surface map is recorded
+
 ## Post-Merge State
 
 - After merge, repo state remains `No Active Branch` because the inherited `v1.6.4-prebeta` release debt remains open on `main`.
 - FB-015 remains the merged-unreleased release-debt owner for `v1.6.4-prebeta`, and the pending release scope now includes both the FB-015 boot/desktop boundary model and the completed FB-029 identity, persona-option, and licensing-planning milestone.
-- FB-029 no longer owns active branch execution truth after merge; its completed docs/canon-only planning milestone becomes part of the pending `v1.6.4-prebeta` release package.
-- FB-030 is the selected next planning-only workstream, and branch creation remains deferred until FB-029 merges, `v1.6.4-prebeta` is published and validated, updated `main` is revalidated, and an explicit voice/audio design goal with affected-surface map admits FB-030 Branch Readiness.
+- FB-029 no longer owns active branch execution truth after merge; its completed docs/canon-only planning milestone is now merged-unreleased inside the pending `v1.6.4-prebeta` release package.
+- FB-030 is the selected next planning-only workstream, and blocker-clearing Branch Readiness now rides on `feature/fb-030-orin-voice-audio-direction-refinement` while FB-030 remains selected-only and blocked from promotion by open release debt plus the missing explicit voice/audio design goal and affected-surface map.
 
 ## PR Readiness Record
 
@@ -399,7 +417,7 @@ PR Readiness validates the completed docs/canon-only FB-029 milestone for merge 
 - Version Rationale: `patch prerelease` remains required because the combined pending delta is still docs/canon-only planning and governance work with no new executable, runtime, operator-facing, user-facing, or materially expanded product capability.
 - Release Scope: FB-015 boot and desktop phase-boundary inventory, ownership map, lifecycle/state framing, implementation admission contract, hardening corrections, Live Validation waivers, PR package history, post-merge canon repair, and merged-unreleased release-debt framing, plus the FB-029 identity source-of-truth inventory, persona-option boundary framing, licensing boundary framing, implementation admission contract, hardening corrections, Live Validation waivers, and PR Readiness package history.
 - Release Artifacts: Tag `v1.6.4-prebeta`; release title `Pre-Beta v1.6.4`; rich Markdown release notes summarize the FB-015 boundary model and the FB-029 identity/licensing planning frame without repeating the release title inside the notes body, and GitHub-generated `## What's Changed` plus `**Full Changelog**:` must be included.
-- Post-Release Truth: FB-015 and FB-029 are Released / Closed in `v1.6.4-prebeta` after publication and validation; release debt then clears, and FB-030 Branch Readiness may continue on a later branch after updated `main` revalidation and an explicit voice/audio design goal with affected-surface map admits the lane.
+- Post-Release Truth: FB-015 and FB-029 are Released / Closed in `v1.6.4-prebeta` after publication and validation; release debt then clears, and FB-030 Branch Readiness may resume beyond blocker-clearing repair on `feature/fb-030-orin-voice-audio-direction-refinement` only after updated `main` revalidation and an explicit voice/audio design goal with affected-surface map admits promotion.
 
 ### PR-2 Selected-Next Workstream Findings
 
@@ -417,9 +435,9 @@ PR Readiness validates the completed docs/canon-only FB-029 milestone for merge 
 - Head Branch: `feature/fb-029-orin-identity-licensing-hardening`
 - PR Summary: Promote the docs/canon-only FB-029 identity, persona-option, and licensing hardening planning milestone, align the inherited `v1.6.4-prebeta` release-debt package to include that completed scope, preserve implementation-facing product/legal gates, and select FB-030 as the next planning-only workstream.
 - PR URL: https://github.com/GiribaldiTTV/Nexus-Desktop-AI/pull/76
-- PR State: OPEN, base `main`, head `feature/fb-029-orin-identity-licensing-hardening`, non-draft.
+- PR State: MERGED, base `main`, head `feature/fb-029-orin-identity-licensing-hardening`, merge commit `0897fab768dc07385f83fab81434ba7926ecc4a1`.
 - Review Thread State: PASS. Authenticated PR validation found zero review threads and zero submitted reviews.
-- Merge Readiness: PASS. GitHub reports `MERGEABLE`.
+- Merge Readiness: PASS. GitHub reported `MERGEABLE` with merge state `CLEAN`, and the PR then merged successfully.
 
 ### PR Readiness Completion Decision
 
@@ -427,7 +445,7 @@ PR Readiness validates the completed docs/canon-only FB-029 milestone for merge 
 - PR-2 Result: Complete / green.
 - PR-3 Result: Complete / green.
 - User-facing impact: none. FB-029 remains docs/canon-only.
-- Continue/Stop Decision: stop at the PR Readiness phase boundary because the live PR exists, is open, non-draft, conflict-free, and review-thread state is inspectable.
+- Continue/Stop Decision: stop at the PR Readiness phase boundary because the live PR existed, was open/non-draft/mergeable at validation time, and then merged cleanly into `main`.
 
 ### PR Readiness Validation Results
 
@@ -435,8 +453,8 @@ PR Readiness validates the completed docs/canon-only FB-029 milestone for merge 
 - `git diff --check`: PASS with line-ending normalization warnings only and no whitespace errors.
 - User-facing shortcut gate: WAIVED with exact markers in `## User Test Summary`.
 - User Test Summary results gate: WAIVED with exact markers in `## User Test Summary`.
-- Successor branch containment at PR package time: PASS; no FB-030 branch exists and successor branch creation remains prohibited during FB-029 PR Readiness.
-- Live PR state: PASS; PR #76 is open, non-draft, base/head aligned, and mergeable.
+- Successor branch containment at PR package time: PASS; no FB-030 branch existed during FB-029 PR Readiness.
+- Live PR state: PASS; PR #76 merged cleanly into `main` at `0897fab768dc07385f83fab81434ba7926ecc4a1`.
 - Review-thread state: PASS; zero review threads and zero submitted reviews are present.
 - Scope validation: PASS; PR Readiness remained docs/canon only.
 
@@ -453,7 +471,7 @@ PR Readiness validates the completed docs/canon-only FB-029 milestone for merge 
 Continue Decision: `stop`
 Next Active Seam: `none`
 Stop Condition: `phase boundary reached`
-Continuation Action: merge PR #76, then continue file-frozen Release Readiness for the inherited `v1.6.4-prebeta` release-debt package on updated `main`.
+Continuation Action: rerun file-frozen Release Readiness for the inherited `v1.6.4-prebeta` release-debt package on updated `main` after this merged-state canon repair is durably carried forward.
 
 ## Reuse Baseline
 
@@ -482,7 +500,7 @@ Continuation Action: merge PR #76, then continue file-frozen Release Readiness f
 ## Exit Criteria
 
 - The branch objective, target end-state, seam families, validation contract, User Test Summary strategy, later-phase expectations, and bounded Workstream seam chain are recorded.
-- `Docs/Main.md`, `Docs/feature_backlog.md`, `Docs/prebeta_roadmap.md`, and `Docs/workstreams/index.md` route FB-029 as the active PR Readiness authority on `feature/fb-029-orin-identity-licensing-hardening`.
+- `Docs/Main.md`, `Docs/feature_backlog.md`, `Docs/prebeta_roadmap.md`, and `Docs/workstreams/index.md` route FB-029 as promoted merged-unreleased package scope with no stale active implementation truth.
 - FB-015 remains the merged-unreleased release-debt owner on `main` for `v1.6.4-prebeta`, and the pending release scope now includes the completed FB-029 docs/canon-only milestone.
 - WS-1 current identity, persona-option, and licensing source-of-truth inventory is complete.
 - WS-2 canonical vs historical identity, persona-option, and licensing boundary framing is complete.
@@ -500,8 +518,8 @@ Continuation Action: merge PR #76, then continue file-frozen Release Readiness f
 
 ## Rollback Target
 
-- `Live Validation`
-- Revert the FB-029 PR Readiness docs/canon commit(s) and return FB-029 to Live-Validation-complete / PR-Readiness-next truth with WS-1 through WS-3, H-1, and LV-1 recorded and PR-1 through PR-3 absent.
+- `PR Readiness`
+- Revert the merged-state repair commit(s) and return FB-029 to the pre-repair post-merge truth only if a later legal surface needs to rework the merged-unreleased package framing.
 
 ## Next Legal Phase
 

--- a/Docs/workstreams/index.md
+++ b/Docs/workstreams/index.md
@@ -78,9 +78,9 @@ For an active or recently closed canonical workstream, keep these durable tracea
 Active here means the current promoted truth owner.
 That may be an executable branch owner or another explicitly promoted current-truth owner.
 
-- `Docs/workstreams/FB-029_orin_identity_licensing_hardening.md`
+- None
 
-FB-029 is the current promoted PR Readiness authority on `feature/fb-029-orin-identity-licensing-hardening`. The bounded WS-1 through WS-3 docs/canon seam chain plus H-1 Hardening plus LV-1 Live Validation are complete; PR-1, PR-2, and PR-3 are complete; PR #76 is open/non-draft/mergeable clean; the milestone remains docs/canon-only; and explicit product/legal approval still blocks any implementation-facing naming, licensing, release, runtime, or persona-surface work.
+No promoted implementation workstream currently owns active branch execution truth. The active branch surface is `feature/fb-030-orin-voice-audio-direction-refinement` through `Docs/branch_records/feature_fb_030_orin_voice_audio_direction_refinement.md`, where blocker-clearing Branch Readiness repair is active while FB-030 remains selected-only / `Registry-only`.
 
 ### Merged / Release Debt Owners
 
@@ -88,8 +88,11 @@ Merged / Release Debt Owners are promoted implementation workstreams whose imple
 These records are not active implementation branch owners after merge.
 
 - `Docs/workstreams/FB-015_boot_and_desktop_phase_boundary_model.md`
+- `Docs/workstreams/FB-029_orin_identity_licensing_hardening.md`
 
-FB-015 merged through PR #75 into `main` at `3e821e07ff91d814fd7aba9b50819f97d700a301` and remains the merged-unreleased release-debt owner for `v1.6.4-prebeta`. The pending release scope now includes the completed FB-029 docs/canon-only identity, persona-option, and licensing-planning milestone. No repo-level active workstream is admitted after merge while that release debt remains open. FB-029 has completed the bounded docs/canon-only Workstream seam chain through WS-3 plus H-1 plus LV-1 on `feature/fb-029-orin-identity-licensing-hardening`; PR-1, PR-2, and PR-3 are complete on open PR #76. FB-030 is selected next planning-only, and its branch remains uncreated.
+FB-015 merged through PR #75 into `main` at `3e821e07ff91d814fd7aba9b50819f97d700a301` and remains the merged-unreleased release-debt owner for `v1.6.4-prebeta`. The pending release scope now includes the completed FB-029 docs/canon-only identity, persona-option, and licensing-planning milestone. No repo-level active workstream is admitted while that release debt remains open. Blocker-clearing FB-030 Branch Readiness now rides on `feature/fb-030-orin-voice-audio-direction-refinement`, but FB-030 remains selected-only / `Registry-only`.
+
+FB-029 merged through PR #76 into `main` at `0897fab768dc07385f83fab81434ba7926ecc4a1` and is now merged-unreleased inside the inherited `v1.6.4-prebeta` package owned by FB-015. It no longer owns active implementation-branch truth; the milestone remains docs/canon-only, and explicit product/legal approval still blocks any implementation-facing naming, licensing, release, runtime, or persona-surface work.
 
 ### Closed
 


### PR DESCRIPTION
## Summary

`Release Readiness` on `main` is currently blocked because `main` does not contain commit `f0d8a3cac458aadec8c5bc565c8411d475da84ea`, so canon still reports stale FB-029 active-branch truth and stale FB-030 branch-creation truth.

## What Changed

### What Changed
- lands the blocker-clearing canon repair required after PR #76 merged without its merged-state cleanup on `main`
- moves FB-029 from stale active PR-readiness truth to merged-unreleased package truth for `v1.6.4-prebeta`
- records the FB-030 repair branch as a branch-authority surface only, while keeping FB-030 selected-only / `Registry-only`
- preserves FB-015 as the sole merged-unreleased release-debt owner for `v1.6.4-prebeta`

### Why
`Release Readiness` on `main` is currently blocked because `main` does not contain commit `f0d8a3cac458aadec8c5bc565c8411d475da84ea`, so canon still reports stale FB-029 active-branch truth and stale FB-030 branch-creation truth.

### Impact
- unblocks a clean rerun of file-frozen `Release Readiness` for `v1.6.4-prebeta` after this PR merges
- does not promote FB-030
- does not admit FB-030 Workstream implementation
- does not change runtime, release artifacts, or user-facing behavior

### Root Cause
The FB-029 merged-state canon repair was correctly prepared on the next legal branch surface, but it has not been merged back to `main` yet, so `main` still carries pre-repair current-state claims.

### What Changed
- lands the blocker-clearing canon repair required after PR #76 merged without its merged-state cleanup on `main`
- moves FB-029 from stale active PR-readiness truth to merged-unreleased package truth for `v1.6.4-prebeta`
- records the FB-030 repair branch as a branch-authority surface only, while keeping FB-030 selected-only / `Registry-only`
- preserves FB-015 as the sole merged-unreleased release-debt owner for `v1.6.4-prebeta`

### Why
`Release Readiness` on `main` is currently blocked because `main` does not contain commit `f0d8a3cac458aadec8c5bc565c8411d475da84ea`, so canon still reports stale FB-029 active-branch truth and stale FB-030 branch-creation truth.

### Impact
- unblocks a clean rerun of file-frozen `Release Readiness` for `v1.6.4-prebeta` after this PR merges
- does not promote FB-030
- does not admit FB-030 Workstream implementation
- does not change runtime, release artifacts, or user-facing behavior

### Root Cause
The FB-029 merged-state canon repair was correctly prepared on the next legal branch surface, but it has not been merged back to `main` yet, so `main` still carries pre-repair current-state claims.
