### PR TITLE
FB-030 Follow-Up Branch-Registry Cleanup

### DIFF
--- a/Docs/branch_records/feature_fb_030_successor_branch_truth_repair.md
+++ b/Docs/branch_records/feature_fb_030_successor_branch_truth_repair.md
@@ -12,18 +12,23 @@ This temporary repair branch exists only to clear the remaining `Release Readine
 
 It does not promote FB-030, create the selected-next FB-030 implementation branch, or admit any runtime, release, naming, persona, licensing, or user-facing implementation work.
 
+This record is now preserved as historical traceability after PR #79 merged; merged current-state canon must not continue to treat it as an active branch owner.
+
 ## Current Phase
 
 - Phase: `PR Readiness`
 
 ## Phase Status
 
-- `Active Branch`
-- temporary blocker-clearing repair branch created from updated `main` at `301cd858b718c743921cd579f16d5b22f8927536`
+- historical traceability record for the successor-branch truth repair lane
+- temporary blocker-clearing repair branch was created from updated `main` at `301cd858b718c743921cd579f16d5b22f8927536`
+- PR #79 merged this repair to `main` at `e841aa18b76458aa0591e20bd4f3ba9790e1f238`
+- merged current-state canon must remain `No Active Branch` while FB-015 owns merged-unreleased release debt for `v1.6.4-prebeta`
 - repo-level current-state canon intentionally remains `No Active Branch` while FB-015 owns merged-unreleased release debt for `v1.6.4-prebeta`
 - FB-030 remains selected-only / `Registry-only`; this branch must not be treated as the selected-next FB-030 implementation branch
-- this branch exists only to repair successor-branch truth so temporary `emergency canon repair` branches are not misread as selected-next implementation-branch creation
-- no runtime, release, naming, persona, licensing, or other implementation-facing work is admitted on this branch
+- this branch existed only to repair successor-branch truth so temporary `emergency canon repair` branches are not misread as selected-next implementation-branch creation
+- no runtime, release, naming, persona, licensing, or other implementation-facing work was admitted on this branch
+- this record is historical only and is not active execution authority
 
 ## Branch Class
 
@@ -47,7 +52,7 @@ It does not promote FB-030, create the selected-next FB-030 implementation branc
 - roadmap, branch-record, and validator truth all agree that FB-030 remains selected-only / `Registry-only`
 - FB-015 remains the sole merged-unreleased release-debt owner for `v1.6.4-prebeta`
 - release-debt scope and post-release truth remain unchanged apart from the successor-branch truth repair
-- a live blocker-clearing PR exists for this branch and validates cleanly
+- PR #79 merges cleanly, and the merged branch record no longer appears under `Active Branch Authority Records`
 
 ## Rollback Target
 
@@ -56,3 +61,5 @@ It does not promote FB-030, create the selected-next FB-030 implementation branc
 ## Next Legal Phase
 
 - `Release Readiness`
+
+Release Branch: No

--- a/Docs/branch_records/index.md
+++ b/Docs/branch_records/index.md
@@ -42,7 +42,7 @@ Do not use this layer to replace:
 
 ## Active Branch Authority Records
 
-- `Docs/branch_records/feature_fb_030_successor_branch_truth_repair.md`
+- None
 
 ## Historical Branch Authority Records
 
@@ -50,3 +50,4 @@ Do not use this layer to replace:
 - `Docs/branch_records/codex_no_active_branch_docs_governance_refinement.md`
 - `Docs/branch_records/feature_fb_030_orin_voice_audio_direction_refinement.md`
 - `Docs/branch_records/feature_fb_030_release_readiness_canon_repair.md`
+- `Docs/branch_records/feature_fb_030_successor_branch_truth_repair.md`

--- a/dev/orin_branch_governance_validation.py
+++ b/dev/orin_branch_governance_validation.py
@@ -1159,7 +1159,7 @@ def _selected_next_ignored_branch_names(
     all_repair_branch_names: set[str],
     active_repair_branch_names: set[str],
 ) -> set[str]:
-    if current_branch == "main" or current_branch in active_repair_branch_names:
+    if current_branch == "main" or current_branch in all_repair_branch_names:
         return set(all_repair_branch_names)
     return set()
 
@@ -1857,6 +1857,17 @@ def main() -> int:
         all_repair_branch_names,
         active_repair_branch_names,
     )
+    merged_no_active_branch_truth = (
+        "Repo State: No Active Branch" in backlog_text or "Repo State: No Active Branch" in roadmap_text
+    )
+    if current_git_branch == "main" and merged_no_active_branch_truth:
+        require(
+            not active_branch_record_paths,
+            (
+                "Docs/branch_records/index.md: merged current-state canon declares `No Active Branch`, "
+                "so `Active Branch Authority Records` must be empty on main"
+            ),
+        )
 
     backlog_entries = _parse_backlog_sections(backlog_text)
     for entry in backlog_entries:


### PR DESCRIPTION
## Summary

Final `Release Readiness` on `main` was still blocked because merged current-state canon said `No Active Branch` while the branch-record index still carried the FB-030 successor-truth repair lane as an active branch authority record.

## What Changed

### What changed
- moves `feature_fb_030_successor_branch_truth_repair.md` out of `Active Branch Authority Records` and into the historical branch-record set
- updates that branch record so merged canon no longer describes it as an active branch owner after PR #79
- hardens `dev/orin_branch_governance_validation.py` so `main` fails when merged `No Active Branch` truth coexists with an active branch-authority record, while a repair branch can still historicalize its own record during PR cleanup without tripping selected-next checks

### Why it changed
Final `Release Readiness` on `main` was still blocked because merged current-state canon said `No Active Branch` while the branch-record index still carried the FB-030 successor-truth repair lane as an active branch authority record.

### Impact
- clears the last known branch-registry blocker for the inherited `v1.6.4-prebeta` package
- preserves FB-015 as the sole release-debt owner
- keeps FB-029 merged-unreleased scope clean and FB-030 selected-only / `Registry-only`

### Root cause
PR #79 repaired successor-branch truth but left its own repair record active in merge-target canon. The validator also lacked an explicit check for merged `No Active Branch` truth coexisting with active branch-authority records on `main`.

### What changed
- moves `feature_fb_030_successor_branch_truth_repair.md` out of `Active Branch Authority Records` and into the historical branch-record set
- updates that branch record so merged canon no longer describes it as an active branch owner after PR #79
- hardens `dev/orin_branch_governance_validation.py` so `main` fails when merged `No Active Branch` truth coexists with an active branch-authority record, while a repair branch can still historicalize its own record during PR cleanup without tripping selected-next checks

### Why it changed
Final `Release Readiness` on `main` was still blocked because merged current-state canon said `No Active Branch` while the branch-record index still carried the FB-030 successor-truth repair lane as an active branch authority record.

### Impact
- clears the last known branch-registry blocker for the inherited `v1.6.4-prebeta` package
- preserves FB-015 as the sole release-debt owner
- keeps FB-029 merged-unreleased scope clean and FB-030 selected-only / `Registry-only`

### Root cause
PR #79 repaired successor-branch truth but left its own repair record active in merge-target canon. The validator also lacked an explicit check for merged `No Active Branch` truth coexisting with active branch-authority records on `main`.
