### PR TITLE
FB-042 Blocker-Clearing Canon Repair For FB-005 Post-Merge Drift

### DIFF
--- a/Docs/branch_records/feature_fb_042_step5_entrypoint_planning.md
+++ b/Docs/branch_records/feature_fb_042_step5_entrypoint_planning.md
@@ -1,0 +1,63 @@
+# Branch Authority Record: feature/fb-042-step5-entrypoint-planning
+
+## Branch Identity
+
+- Branch: `feature/fb-042-step5-entrypoint-planning`
+- Workstream: `FB-042`
+- Branch Class: `implementation`
+
+## Purpose / Why It Exists
+
+This branch exists because escaped FB-005 post-merge canon drift is blocking `Release Readiness` for `v1.6.6-prebeta`, and governance routes that blocker-clearing repair onto the next legal branch surface before any new FB-042 implementation can begin.
+
+It keeps FB-042 selected-only / `Registry-only` while the blocker-clearing canon repair is made durable and while planning-first Branch Readiness is defined. This branch does not promote FB-042, admit a canonical workstream, or authorize any Step 5, root-entrypoint, launcher/VBS, runtime, audio, log-root, visual-asset, or user-facing implementation slice yet.
+
+## Current Phase
+
+- Phase: `Branch Readiness`
+
+## Phase Status
+
+- `Active Branch`: `feature/fb-042-step5-entrypoint-planning`
+- Active selected-only / pre-promotion branch-readiness authority for `feature/fb-042-step5-entrypoint-planning`.
+- Branch was created from updated `origin/main` at `873c9b6801802a05bbcef074595e632c0ec9f1d2`.
+- FB-005 merged through PR #83, but merged canon still carried stale PR-open and merge-PR wording instead of merged-unreleased release-debt truth.
+- Repo-level merge-target canon intentionally remains `No Active Branch` while FB-005 owns merged-unreleased release debt for `v1.6.6-prebeta`.
+- FB-042 remains selected-next planning-only / `Registry-only`; no Workstream seam or implementation slice is admitted on this branch.
+- The first blocker-clearing seam on this branch is FB-005 post-merge canon repair; planning-first FB-042 Branch Readiness continues only after release packaging is clean again.
+- No root-owned entrypoint, launcher/VBS, runtime, audio, log-root, visual-asset, or user-facing desktop-path implementation is admitted here.
+
+## Branch Class
+
+- `implementation`
+
+## Blockers
+
+- `Release Readiness blocked by escaped FB-005 post-merge canon drift`
+- `FB-042 branch objective missing`
+- `FB-042 affected-surface ownership map missing`
+- `FB-042 bounded planning seam chain not yet admitted`
+
+## Entry Basis
+
+- Updated `origin/main` is aligned at `873c9b6801802a05bbcef074595e632c0ec9f1d2`.
+- PR #83 merged, but backlog, roadmap, and FB-005 current-state canon still reported PR-open / merge-PR truth.
+- `Release Readiness` for `v1.6.6-prebeta` cannot proceed until that escaped merged-state drift is repaired on the next legal branch surface.
+- FB-042 was already selected next in canon as a planning-first Step 5 / top-level entrypoint lane.
+- Governance allows the next legal branch surface to clear inherited blockers before any new implementation admission begins.
+
+## Exit Criteria
+
+- Stale FB-005 PR-open / merge-PR wording is converted to merged-unreleased release-debt truth.
+- `Repo State: No Active Branch` remains intact for merge-target canon.
+- FB-042 remains selected-next planning-only / `Registry-only` with no promoted workstream or admitted implementation slice.
+- The canonical FB-042 branch name is recorded as `feature/fb-042-step5-entrypoint-planning`.
+- Branch-local authority is durable through a blocker-clearing PR without widening into FB-042 implementation.
+
+## Rollback Target
+
+- `Release Readiness`
+
+## Next Legal Phase
+
+- `Release Readiness`

--- a/Docs/branch_records/index.md
+++ b/Docs/branch_records/index.md
@@ -42,7 +42,7 @@ Do not use this layer to replace:
 
 ## Active Branch Authority Records
 
-None.
+- `Docs/branch_records/feature_fb_042_step5_entrypoint_planning.md`
 
 ## Historical Branch Authority Records
 

--- a/Docs/feature_backlog.md
+++ b/Docs/feature_backlog.md
@@ -35,9 +35,9 @@ Historical note:
 
 ## Active Promoted Workstream
 
-No active promoted implementation branch remains in merge-target truth after FB-005 PR packaging. FB-005 Workspace and folder organization becomes the merged-unreleased release-debt owner for `v1.6.6-prebeta`; repo state becomes `No Active Branch`; release packaging is next; and FB-042 Top-level experience entrypoint and broader workspace follow-through is selected next planning-only with branch not created.
+No active promoted implementation branch remains in merge-target truth after FB-005 merged. FB-005 Workspace and folder organization is the merged-unreleased release-debt owner for `v1.6.6-prebeta`; repo state remains `No Active Branch`; release packaging is blocked only by escaped FB-005 post-merge canon drift; and FB-042 Top-level experience entrypoint and broader workspace follow-through remains selected next planning-only on `feature/fb-042-step5-entrypoint-planning`, where Branch Readiness is active and no Workstream slice is admitted.
 
-Main-facing canon is aligned to released truth: FB-040 is released and closed in `v1.6.0-prebeta`, FB-031 is released and closed in `v1.6.1-prebeta`, FB-032 is released and closed in `v1.6.2-prebeta`, FB-004 is released and closed in `v1.6.3-prebeta`, FB-015 plus FB-029 are released and closed in `v1.6.4-prebeta`, and FB-030 is now released and closed in `v1.6.5-prebeta`. Latest public prerelease truth is `v1.6.5-prebeta`, merged-unreleased release debt is active for `v1.6.6-prebeta`, FB-005 is the release-debt owner, repo state becomes `No Active Branch` after merge, and FB-042 is selected next planning-only with branch not created.
+Main-facing canon is aligned to released truth: FB-040 is released and closed in `v1.6.0-prebeta`, FB-031 is released and closed in `v1.6.1-prebeta`, FB-032 is released and closed in `v1.6.2-prebeta`, FB-004 is released and closed in `v1.6.3-prebeta`, FB-015 plus FB-029 are released and closed in `v1.6.4-prebeta`, and FB-030 is now released and closed in `v1.6.5-prebeta`. Latest public prerelease truth is `v1.6.5-prebeta`, merged-unreleased release debt is active for `v1.6.6-prebeta`, FB-005 is the release-debt owner, repo state remains `No Active Branch`, and FB-042 remains selected next planning-only on `feature/fb-042-step5-entrypoint-planning`, where Branch Readiness is active and no Workstream slice is admitted.
 FB-039 is released and closed in `v1.5.0-prebeta`.
 FB-038 remains released and closed in `v1.4.1-prebeta`.
 
@@ -57,7 +57,7 @@ Historical Branch Readiness State: Complete on `feature/fb-005-workspace-path-pl
 Historical Workstream State: WS-1 `desktop/orin_desktop_test.py` -> `dev/desktop/orin_desktop_test.py` is complete.
 Historical Hardening State: Complete on `feature/fb-005-workspace-path-planning`.
 Historical Live Validation State: Complete on `feature/fb-005-workspace-path-planning`.
-PR Readiness State: Complete on `feature/fb-005-workspace-path-planning`; PR #83 is open, non-draft, mergeable, and clean against `main`.
+PR Readiness State: Complete on `feature/fb-005-workspace-path-planning`; PR #83 merged into `main` at `873c9b6801802a05bbcef074595e632c0ec9f1d2`, and merged-unreleased release-debt truth now owns current merge-target state.
 Admitted Workstream Chain: Complete for current approval; no WS-2 is admitted.
 
 ## Backlog Governance Sync
@@ -73,7 +73,7 @@ Open-candidate priority review:
 - FB-005 remains `Low` as historical workspace priority, but it is now the merged-unreleased release-debt owner for `v1.6.6-prebeta` and no longer remains the selected-next candidate.
 - FB-042 is now the selected-next planning-only candidate for future Step 5 / top-level experience entrypoint and broader workspace follow-through after `v1.6.6-prebeta` clears release debt.
 
-Current-branch clarity: merge-target canon now resolves to `No Active Branch`; latest public prerelease remains `v1.6.5-prebeta`; FB-005 is `Merged unreleased` and owns release debt for `v1.6.6-prebeta`; the completed delta remains bounded to WS-1 `desktop/orin_desktop_test.py` -> `dev/desktop/orin_desktop_test.py`; the residual visual-path mismatch remains dev-only and non-user-facing; and FB-042 is selected next planning-only with branch not created.
+Current-branch clarity: merge-target canon now resolves to `No Active Branch`; latest public prerelease remains `v1.6.5-prebeta`; FB-005 is `Merged unreleased` and owns release debt for `v1.6.6-prebeta`; the completed delta remains bounded to WS-1 `desktop/orin_desktop_test.py` -> `dev/desktop/orin_desktop_test.py`; the residual visual-path mismatch remains dev-only and non-user-facing; and FB-042 is selected next planning-only on `feature/fb-042-step5-entrypoint-planning`, where Branch Readiness is active and no Workstream slice is admitted.
 
 ## Registry Items
 
@@ -92,15 +92,15 @@ Branch: feature/fb-005-workspace-path-planning
 Canonical Workstream Doc: Docs/workstreams/FB-005_workspace_and_folder_organization.md
 Branch Readiness: Complete. The branch objective, target end-state, approved workspace/path slice, validation contract, User Test Summary strategy, later-phase expectations, and first Workstream seam are recorded in the canonical workstream doc.
 Workstream: WS-1 `desktop/orin_desktop_test.py` -> `dev/desktop/orin_desktop_test.py` is complete. H-1 is complete. LV-1 is complete. No WS-2 is admitted yet; later slices remain explicit approval gates.
-PR Readiness: Complete. PR-1 merge-target canon completeness, PR-2 selected-next workstream selection, and PR-3 live PR creation plus validation are complete; PR #83 is open, non-draft, mergeable, and clean against `main`.
+PR Readiness: Complete. PR-1 merge-target canon completeness, PR-2 selected-next workstream selection, and PR-3 live PR creation plus validation are complete; PR #83 merged into `main` at `873c9b6801802a05bbcef074595e632c0ec9f1d2`, and FB-005 now owns merged-unreleased release debt for `v1.6.6-prebeta`.
 Release Target: v1.6.6-prebeta
 Release Floor: patch prerelease
 Version Rationale: FB-005 delivers a bounded dev-only workspace/path implementation slice and direct path-truth sync with no change to shipped runtime entrypoints, launcher paths, audio paths, logs, visual assets, installer behavior, or user-facing desktop behavior, so patch prerelease remains the correct floor.
 Release Scope: WS-1 dev-only desktop test harness relocation from `desktop/orin_desktop_test.py` to `dev/desktop/orin_desktop_test.py`, local path-math preservation, direct workspace-layout truth sync, hardening corrections, Live Validation waivers, PR package history, and merged-unreleased release-debt truth for the first admitted FB-005 slice only.
 Release Artifacts: Tag v1.6.6-prebeta; release title Pre-Beta v1.6.6; rich Markdown release notes summarize the bounded FB-005 WS-1 workspace slice, validation evidence, non-user-facing release posture, and selected-next planning lane without repeating the release title inside the notes body, and GitHub-generated `## What's Changed` plus `**Full Changelog**:` must be included.
-Post-Release Truth: FB-005 is Released / Closed in v1.6.6-prebeta; release debt is clear; and FB-042 remains selected next planning-only with branch not created until Branch Readiness admits a bounded Step 5 / top-level entrypoint planning slice.
+Post-Release Truth: FB-005 is Released / Closed in v1.6.6-prebeta; release debt is clear; and FB-042 remains selected next planning-only / `Registry-only` on `feature/fb-042-step5-entrypoint-planning` until Branch Readiness admits a bounded Step 5 / top-level entrypoint planning slice.
 Selected Next Workstream: FB-042 Top-level experience entrypoint and broader workspace follow-through.
-Next-Branch Creation Gate: After `v1.6.6-prebeta` publication, validation, and updated-main revalidation; `feature/fb-042-top-level-entrypoint-workspace-follow-through` remains not created, and FB-042 Branch Readiness must stay planning-first around root-owned entrypoints and broader workspace ownership before any implementation slice is admitted.
+Next-Branch Creation Gate: Superseded by the active blocker-clearing Branch Readiness route. `feature/fb-042-step5-entrypoint-planning` is now the current FB-042 Branch Readiness branch, but FB-042 remains planning-first / `Registry-only` and must not admit any implementation slice until Branch Readiness completes.
 Minimal Scope: Complete only the admitted WS-1 dev-only desktop test harness relocation from `desktop/orin_desktop_test.py` to `dev/desktop/orin_desktop_test.py`, with direct reference sync and no broader workspace movement.
 Summary: Continue workspace organization only through explicitly approved path-sensitive slices, beginning with the now-completed dev-only desktop test harness move.
 Why it matters: Keeps folder and ownership cleanup deliberate instead of letting it blur into unrelated feature work.
@@ -112,7 +112,9 @@ Record State: Registry-only
 Priority: Low
 Deferred Since: v2.0 and v2.2 closeouts after the Step 4 workspace slice, when Step 5 top-level experience entrypoint work and broader workspace follow-through remained explicitly deferred.
 Deferred Because: Step 5 touches root-owned entrypoints and broader workspace reorganization, including `main.py`, launcher/VBS routing, and adjacent controlled surfaces, so it cannot piggyback on narrow dev-only path moves.
-Selection / Unblock: Selected next during FB-005 PR Readiness as planning-only. Branch Readiness may begin only after FB-005 merges, `v1.6.6-prebeta` is published and validated, updated `main` is revalidated, and the next branch remains bounded to planning-first Step 5 / root-entrypoint ownership definition before any implementation slice is admitted.
+Selection / Unblock: Selected next during FB-005 PR Readiness as planning-only. `feature/fb-042-step5-entrypoint-planning` is now the active Branch Readiness branch because escaped FB-005 post-merge canon drift had to be repaired before `Release Readiness` could continue. FB-042 remains planning-first / `Registry-only` on this branch; no Workstream or implementation slice is admitted until Branch Readiness defines exact Step 5 ownership and admission limits.
+Branch: feature/fb-042-step5-entrypoint-planning
+Branch Readiness: Active. The first blocker-clearing seam repairs escaped FB-005 post-merge canon drift while preserving `Repo State: No Active Branch`; FB-042 remains planning-only and unadmitted beyond Branch Readiness.
 Next Workstream: Selected
 Minimal Scope: Define the planning-first Step 5 / top-level experience entrypoint and broader workspace follow-through lane, including exact ownership, non-goals, branch objective, and admission limits around `main.py`, launcher/VBS routes, root-owned entry surfaces, and adjacent workspace moves before any branch implementation begins.
 Summary: Preserve the deferred Step 5 and broader workspace follow-through lane as its own bounded planning identity instead of letting it ride implicitly behind the completed WS-1 dev-only slice.

--- a/Docs/prebeta_roadmap.md
+++ b/Docs/prebeta_roadmap.md
@@ -68,10 +68,10 @@ Current merged truth indicates:
 - merged unreleased non-doc implementation debt exists: yes
 - the latest public released implementation milestone is FB-030 ORIN voice/audio direction refinement in `v1.6.5-prebeta`; FB-015 Boot and desktop phase-boundary model plus FB-029 ORIN legal-safe rebrand, future ARIA persona option, and repo licensing hardening remain released in `v1.6.4-prebeta`
 - current phase after `v1.6.5-prebeta` release closure: `Release Readiness`
-- phase status after `v1.6.5-prebeta` release closure: FB-030 is Released / Closed in `v1.6.5-prebeta`; merged-unreleased release debt is now active for `v1.6.6-prebeta`; FB-005 is the merged-unreleased release-debt owner; repo state is `No Active Branch`; the pending release scope remains bounded to WS-1 `desktop/orin_desktop_test.py` -> `dev/desktop/orin_desktop_test.py`; the residual visual-path mismatch remains confirmed as dev-only and non-user-facing; and FB-042 is selected next planning-only with branch not created.
+- phase status after `v1.6.5-prebeta` release closure: FB-030 is Released / Closed in `v1.6.5-prebeta`; merged-unreleased release debt is now active for `v1.6.6-prebeta`; FB-005 is the merged-unreleased release-debt owner; repo state is `No Active Branch`; the pending release scope remains bounded to WS-1 `desktop/orin_desktop_test.py` -> `dev/desktop/orin_desktop_test.py`; the residual visual-path mismatch remains confirmed as dev-only and non-user-facing; and FB-042 remains selected next planning-only on `feature/fb-042-step5-entrypoint-planning`, where Branch Readiness is active and no Workstream slice is admitted.
 - current active workstream: none
 - current branch after `v1.6.5-prebeta` release closure: none
-- next concern: merge PR #83, then execute file-frozen Release Readiness on updated `main` for `v1.6.6-prebeta`
+- next concern: merge the blocker-clearing FB-005 post-merge canon repair PR from `feature/fb-042-step5-entrypoint-planning`, then execute file-frozen Release Readiness on updated `main` for `v1.6.6-prebeta`
 
 That means the released FB-027 interaction baseline, the released FB-036 authoring-and-callable-group milestone, the released FB-041 deterministic callable-group execution milestone, the released FB-037 built-in catalog milestone, the released FB-038 tray quick-task UX milestone, the released FB-039 external trigger intake architecture milestone, the released FB-040 monitoring/thermal architecture milestone, the released FB-031 UI/UX architecture milestone, the released FB-032 source-of-truth migration milestone, the released FB-004 future boot-orchestrator architecture milestone, the released FB-015 plus FB-029 planning milestones, and the released FB-030 voice/audio planning milestone are now part of the current public shared pre-Beta baseline.
 
@@ -94,15 +94,15 @@ Historical Branch Readiness State: Complete on `feature/fb-005-workspace-path-pl
 Historical Workstream State: WS-1 `desktop/orin_desktop_test.py` -> `dev/desktop/orin_desktop_test.py` is complete.
 Historical Hardening State: Complete on `feature/fb-005-workspace-path-planning`.
 Historical Live Validation State: Complete on `feature/fb-005-workspace-path-planning`.
-PR Readiness State: Complete on `feature/fb-005-workspace-path-planning`; PR #83 is open, non-draft, mergeable, and clean against `main`.
+PR Readiness State: Complete on `feature/fb-005-workspace-path-planning`; PR #83 merged into `main` at `873c9b6801802a05bbcef074595e632c0ec9f1d2`, and merged-unreleased release-debt truth now owns current merge-target state.
 Admitted Workstream Chain: Complete for current approval; no WS-2 is admitted.
 Release Target: v1.6.6-prebeta
 Release Floor: patch prerelease
 Version Rationale: FB-005 delivers one bounded dev-only workspace/path implementation slice and direct path-truth sync with no change to shipped runtime entrypoints, launcher paths, audio paths, logs, visual assets, installer behavior, or user-facing desktop behavior, so patch prerelease remains the correct floor.
 Release Scope: WS-1 dev-only desktop test harness relocation from `desktop/orin_desktop_test.py` to `dev/desktop/orin_desktop_test.py`, local path-math preservation, direct workspace-layout truth sync, hardening corrections, Live Validation waivers, PR package history, and merged-unreleased release-debt truth for the first admitted FB-005 slice only.
 Release Artifacts: Tag v1.6.6-prebeta; release title Pre-Beta v1.6.6; rich Markdown release notes summarize the bounded FB-005 WS-1 workspace slice, validation evidence, non-user-facing release posture, and selected-next planning lane without repeating the release title inside the notes body, and GitHub-generated `## What's Changed` plus `**Full Changelog**:` must be included.
-Post-Release Truth: FB-005 is Released / Closed in v1.6.6-prebeta; release debt is clear; and FB-042 remains selected next planning-only with branch not created until Branch Readiness admits a bounded Step 5 / top-level entrypoint planning slice.
-Next-Branch Creation Gate: After `v1.6.6-prebeta` publication, validation, and updated-main revalidation; `feature/fb-042-top-level-entrypoint-workspace-follow-through` must remain not created until Branch Readiness admits a bounded planning-first Step 5 / top-level entrypoint slice.
+Post-Release Truth: FB-005 is Released / Closed in v1.6.6-prebeta; release debt is clear; and FB-042 remains selected next planning-only / `Registry-only` on `feature/fb-042-step5-entrypoint-planning` until Branch Readiness admits a bounded Step 5 / top-level entrypoint planning slice.
+Next-Branch Creation Gate: Superseded by the active blocker-clearing Branch Readiness route. `feature/fb-042-step5-entrypoint-planning` is now the current FB-042 Branch Readiness branch, but FB-042 remains planning-first / `Registry-only` and must not admit any implementation slice until Branch Readiness completes.
 
 ## Current Active Workstream
 
@@ -113,7 +113,7 @@ Next-Branch Creation Gate: After `v1.6.6-prebeta` publication, validation, and u
 - priority: `Low`
 - canonical workstream doc: `Docs/workstreams/FB-005_workspace_and_folder_organization.md`
 - branch: `feature/fb-005-workspace-path-planning`
-- phase status: FB-005 is the merged-unreleased release-debt owner for `v1.6.6-prebeta`; repo state is `No Active Branch`; the pending release scope remains bounded to WS-1 `desktop/orin_desktop_test.py` -> `dev/desktop/orin_desktop_test.py`; H-1 and LV-1 are complete historical proof; the residual visual-path mismatch remains dev-only and non-user-facing; and FB-042 is selected next planning-only with branch not created.
+- phase status: FB-005 is the merged-unreleased release-debt owner for `v1.6.6-prebeta`; repo state is `No Active Branch`; the pending release scope remains bounded to WS-1 `desktop/orin_desktop_test.py` -> `dev/desktop/orin_desktop_test.py`; H-1 and LV-1 are complete historical proof; the residual visual-path mismatch remains dev-only and non-user-facing; and FB-042 remains selected next planning-only on `feature/fb-042-step5-entrypoint-planning`, where Branch Readiness is active and no Workstream slice is admitted.
 - admitted slice: dev-only desktop test harness relocation with runtime entrypoints, launcher paths, audio paths, logs, visual assets, and user-facing desktop paths explicitly outside the slice.
 - next legal seam: `Release Readiness`
 Release Target: v1.6.6-prebeta
@@ -121,8 +121,8 @@ Release Floor: patch prerelease
 Version Rationale: FB-005 delivers one bounded dev-only workspace/path implementation slice and direct path-truth sync with no change to shipped runtime entrypoints, launcher paths, audio paths, logs, visual assets, installer behavior, or user-facing desktop behavior, so patch prerelease remains the correct floor.
 Release Scope: WS-1 dev-only desktop test harness relocation from `desktop/orin_desktop_test.py` to `dev/desktop/orin_desktop_test.py`, local path-math preservation, direct workspace-layout truth sync, hardening corrections, Live Validation waivers, PR package history, and merged-unreleased release-debt truth for the first admitted FB-005 slice only.
 Release Artifacts: Tag v1.6.6-prebeta; release title Pre-Beta v1.6.6; rich Markdown release notes summarize the bounded FB-005 WS-1 workspace slice, validation evidence, non-user-facing release posture, and selected-next planning lane without repeating the release title inside the notes body, and GitHub-generated `## What's Changed` plus `**Full Changelog**:` must be included.
-Post-Release Truth: FB-005 is Released / Closed in v1.6.6-prebeta; release debt is clear; and FB-042 remains selected next planning-only with branch not created until Branch Readiness admits a bounded Step 5 / top-level entrypoint planning slice.
-Next-Branch Creation Gate: After `v1.6.6-prebeta` publication, validation, and updated-main revalidation; `feature/fb-042-top-level-entrypoint-workspace-follow-through` must remain not created until Branch Readiness admits a bounded planning-first Step 5 / top-level entrypoint slice.
+Post-Release Truth: FB-005 is Released / Closed in v1.6.6-prebeta; release debt is clear; and FB-042 remains selected next planning-only / `Registry-only` on `feature/fb-042-step5-entrypoint-planning` until Branch Readiness admits a bounded Step 5 / top-level entrypoint planning slice.
+Next-Branch Creation Gate: Superseded by the active blocker-clearing Branch Readiness route. `feature/fb-042-step5-entrypoint-planning` is now the current FB-042 Branch Readiness branch, but FB-042 remains planning-first / `Registry-only` and must not admit any implementation slice until Branch Readiness completes.
 
 ### FB-030 ORIN voice/audio direction refinement
 
@@ -154,16 +154,17 @@ The 2026-04-23 priority reading is updated during FB-005 Branch Readiness:
 - FB-005 remains `Low` as historical workspace priority, but it is now the merged-unreleased release-debt owner for `v1.6.6-prebeta` and no longer remains the selected-next candidate.
 - FB-042 is now the selected-next planning-only candidate for future Step 5 / top-level experience entrypoint and broader workspace follow-through after `v1.6.6-prebeta` clears release debt.
 
-Current-branch clarity: merge-target canon now resolves to `No Active Branch`; latest public prerelease remains `v1.6.5-prebeta`; FB-005 is `Merged unreleased` and owns release debt for `v1.6.6-prebeta`; the completed delta remains bounded to WS-1 `desktop/orin_desktop_test.py` -> `dev/desktop/orin_desktop_test.py`; the residual visual-path mismatch remains dev-only and non-user-facing; and FB-042 is selected next planning-only with branch not created.
+Current-branch clarity: merge-target canon now resolves to `No Active Branch`; latest public prerelease remains `v1.6.5-prebeta`; FB-005 is `Merged unreleased` and owns release debt for `v1.6.6-prebeta`; the completed delta remains bounded to WS-1 `desktop/orin_desktop_test.py` -> `dev/desktop/orin_desktop_test.py`; the residual visual-path mismatch remains dev-only and non-user-facing; and FB-042 remains selected next planning-only on `feature/fb-042-step5-entrypoint-planning`, where Branch Readiness is active and no Workstream slice is admitted.
 
 ## Selected Next Workstream
 
 ID: `FB-042`
 Title: `Top-level experience entrypoint and broader workspace follow-through`
 Record State: `Registry-only`
-Branch: Not created
+Branch: `feature/fb-042-step5-entrypoint-planning`
+Branch Readiness State: Active on `feature/fb-042-step5-entrypoint-planning`; the first blocker-clearing seam repairs escaped FB-005 post-merge canon drift, and FB-042 remains planning-only / `Registry-only` with no Workstream admission yet.
 Minimal Scope: Define the planning-first Step 5 / top-level experience entrypoint and broader workspace follow-through lane, including exact ownership, non-goals, branch objective, and admission limits around `main.py`, launcher/VBS routes, root-owned entry surfaces, and adjacent workspace moves before any branch implementation begins.
-Branch Creation Gate: After `v1.6.6-prebeta` publication, validation, and updated-main revalidation; `feature/fb-042-top-level-entrypoint-workspace-follow-through` must remain not created until Branch Readiness admits a bounded planning-first Step 5 / top-level entrypoint slice.
+Branch Readiness Gate: Active after `v1.6.6-prebeta` updated-main revalidation and blocker routing. `feature/fb-042-step5-entrypoint-planning` is the current Branch Readiness branch, and FB-042 must stay planning-first / `Registry-only` until a bounded Step 5 / top-level entrypoint slice is explicitly admitted.
 
 ## Latest Released Workstream Context
 

--- a/Docs/workstreams/FB-005_workspace_and_folder_organization.md
+++ b/Docs/workstreams/FB-005_workspace_and_folder_organization.md
@@ -46,9 +46,9 @@
 - The pending release scope ends after WS-1 because no WS-2 or later FB-005 slice is admitted yet; later slices remain explicit approval gates.
 - No reverse runtime dependency on `dev/desktop/` or the moved harness was found.
 - LV-1 confirms the residual visual-path mismatch is dev-only and non-user-facing: the harness still names historical visual file `jarvis_core_desktop.html` while the current desktop visual asset on disk is `orin_core_desktop.html`.
-- Selected-next planning truth is locked to FB-042 Top-level experience entrypoint and broader workspace follow-through, and its branch remains not created.
+- Selected-next planning truth is locked to FB-042 Top-level experience entrypoint and broader workspace follow-through, and Branch Readiness is now active on `feature/fb-042-step5-entrypoint-planning` while FB-042 remains planning-only / `Registry-only` with no Workstream slice admitted.
 - Merge-target current-state truth is branchless release-debt ownership, not branch-owned execution.
-- PR #83 is open, non-draft, mergeable, and clean against `main`.
+- PR #83 merged into `main` at `873c9b6801802a05bbcef074595e632c0ec9f1d2`, and current merge-target truth is now merged-unreleased release-debt ownership rather than open-PR state.
 
 ## Branch Class
 
@@ -330,14 +330,14 @@ Release Floor: patch prerelease
 Version Rationale: FB-005 delivers a bounded dev-only workspace/path implementation slice and direct path-truth sync with no change to shipped runtime entrypoints, launcher paths, audio paths, logs, visual assets, installer behavior, or user-facing desktop behavior
 Release Scope: WS-1 dev-only desktop test harness relocation from `desktop/orin_desktop_test.py` to `dev/desktop/orin_desktop_test.py`, local path-math preservation, direct workspace-layout truth sync, hardening corrections, Live Validation waivers, PR package history, and merged-unreleased release-debt truth for the first admitted FB-005 slice only
 Release Artifacts: Tag v1.6.6-prebeta; release title Pre-Beta v1.6.6; rich Markdown release notes summarize the bounded FB-005 WS-1 workspace slice, validation evidence, non-user-facing release posture, and selected-next planning lane without repeating the release title inside the notes body, and GitHub-generated `## What's Changed` plus `**Full Changelog**:` must be included
-Post-Release Truth: FB-005 is Released / Closed in v1.6.6-prebeta; release debt is clear; and FB-042 remains selected next planning-only with branch not created until Branch Readiness admits a bounded Step 5 / top-level entrypoint planning slice
-Next-Branch Creation Gate: After `v1.6.6-prebeta` publication, validation, and updated-main revalidation; `feature/fb-042-top-level-entrypoint-workspace-follow-through` remains not created, and FB-042 Branch Readiness must stay planning-first around root-owned entrypoints and broader workspace ownership before any implementation slice is admitted
+Post-Release Truth: FB-005 is Released / Closed in v1.6.6-prebeta; release debt is clear; and FB-042 remains selected next planning-only / `Registry-only` on `feature/fb-042-step5-entrypoint-planning` until Branch Readiness admits a bounded Step 5 / top-level entrypoint planning slice
+Next-Branch Creation Gate: Superseded by the active blocker-clearing Branch Readiness route. `feature/fb-042-step5-entrypoint-planning` is now the current FB-042 Branch Readiness branch, but FB-042 remains planning-first / `Registry-only` and must not admit any implementation slice until Branch Readiness completes
 
 ## Post-Merge State
 
 - Historical post-merge state before release execution: repo state becomes `No Active Branch` because FB-005 will own merged-unreleased release debt on `main` for `v1.6.6-prebeta`.
 - Historical pending-package state: the pending release scope contains the completed FB-005 WS-1 dev-only workspace/path slice only.
-- Historical successor state: FB-042 remains selected next planning-only, and its implementation branch must stay not created until `v1.6.6-prebeta` is published, validated, updated `main` is revalidated, and Branch Readiness admits a bounded planning-first Step 5 / top-level entrypoint slice.
+- Historical successor state at PR package time: FB-042 remained selected next planning-only, and its implementation branch had not been created yet.
 
 ## Release Window Audit
 
@@ -382,9 +382,9 @@ PR Readiness validates the completed bounded FB-005 WS-1 implementation slice fo
 - Head Branch: `feature/fb-005-workspace-path-planning`
 - PR Summary: Promote the bounded FB-005 WS-1 workspace/path implementation slice by moving the dev-only desktop test harness from `desktop/orin_desktop_test.py` to `dev/desktop/orin_desktop_test.py`, preserving runtime non-reachability, recording hardening and Live Validation evidence, aligning merge-target canon for `v1.6.6-prebeta`, and selecting FB-042 as the next planning-only Step 5 / top-level entrypoint lane.
 - PR URL: https://github.com/GiribaldiTTV/Nexus-Desktop-AI/pull/83
-- PR State: OPEN, base `main`, head `feature/fb-005-workspace-path-planning`, mergeable `MERGEABLE`, merge state `CLEAN`.
+- PR State At PR Package Time: OPEN, base `main`, head `feature/fb-005-workspace-path-planning`, mergeable `MERGEABLE`, merge state `CLEAN`.
 - Review Thread State: PASS. Authenticated PR validation found zero review threads, zero review comments, and zero submitted reviews.
-- Merge Readiness: PASS. GitHub reports PR #83 as non-draft and mergeable with clean merge state.
+- Merge Readiness At PR Package Time: PASS. GitHub reported PR #83 as non-draft and mergeable with clean merge state.
 
 ### PR Readiness Completion Decision
 
@@ -401,6 +401,6 @@ PR Readiness validates the completed bounded FB-005 WS-1 implementation slice fo
 - `git diff --check`: PASS with line-ending normalization warnings only and no whitespace errors.
 - User-facing shortcut gate: WAIVED with exact markers in `## User Test Summary`.
 - User Test Summary results gate: WAIVED with exact markers in `## User Test Summary`.
-- Next-workstream selection gate: PASS. FB-042 is selected-next planning-only and its implementation branch remains not created.
-- Live PR state: PASS. PR #83 is open, non-draft, mergeable, and clean against `main`.
+- Next-workstream selection gate: PASS. At PR package time, FB-042 was selected-next planning-only and its implementation branch had not been created yet.
+- Historical Live PR State: PASS. At PR package time, PR #83 was open, non-draft, mergeable, and clean against `main`.
 - Review-thread state: PASS. Zero review threads, review comments, and submitted reviews were present at validation time.

--- a/Docs/workstreams/FB-015_boot_and_desktop_phase_boundary_model.md
+++ b/Docs/workstreams/FB-015_boot_and_desktop_phase_boundary_model.md
@@ -36,7 +36,7 @@
 - Release Title: Pre-Beta v1.6.4
 - Release debt is clear after live release validation and post-release canon closure.
 - FB-029 is released and closed in the same `v1.6.4-prebeta` package.
-- FB-030 is now released and closed in `v1.6.5-prebeta`; merged-unreleased release debt is now active for `v1.6.6-prebeta`; FB-005 is the merged-unreleased release-debt owner; repo state is `No Active Branch`; the pending release scope remains bounded to WS-1 `desktop/orin_desktop_test.py` -> `dev/desktop/orin_desktop_test.py`; and FB-042 remains selected next planning-only with branch not created.
+- FB-030 is now released and closed in `v1.6.5-prebeta`; merged-unreleased release debt is now active for `v1.6.6-prebeta`; FB-005 is the merged-unreleased release-debt owner; repo state is `No Active Branch`; the pending release scope remains bounded to WS-1 `desktop/orin_desktop_test.py` -> `dev/desktop/orin_desktop_test.py`; and FB-042 remains selected next planning-only on `feature/fb-042-step5-entrypoint-planning`, where Branch Readiness is active and no Workstream slice is admitted.
 - FB-015 Branch Readiness is complete and this record is now closed historical lane truth.
 - Branch Readiness is complete.
 - WS-1 current boot/desktop boundary inventory and ownership map is complete.
@@ -618,7 +618,7 @@ Release Floor: patch prerelease
 Version Rationale: FB-015 remains a docs/canon-only boot and desktop phase-boundary architecture plus admission milestone with no new executable, runtime, operator-facing, user-facing, or materially expanded product capability
 Release Scope: FB-015 boot and desktop phase-boundary inventory, ownership map, lifecycle and state framing, implementation admission contract, hardening corrections, Live Validation waivers, PR Readiness package history, post-merge canon repair, and historical release-debt framing, plus the FB-029 identity source-of-truth inventory, persona-option boundary framing, licensing boundary framing, implementation admission contract, hardening corrections, Live Validation waivers, and PR Readiness package history
 Release Artifacts: Tag v1.6.4-prebeta; release title Pre-Beta v1.6.4; rich Markdown release notes summarize the FB-015 boundary model and the FB-029 identity/licensing planning frame without repeating the release title inside the notes body, and GitHub-generated `## What's Changed` plus `**Full Changelog**:` must be included
-Post-Release Truth: FB-015 and FB-029 are Released / Closed in v1.6.4-prebeta, FB-030 is Released / Closed in v1.6.5-prebeta, merged-unreleased release debt is now active for v1.6.6-prebeta, FB-005 is the merged-unreleased release-debt owner with repo state `No Active Branch`, the pending release scope remains bounded to WS-1 `desktop/orin_desktop_test.py` -> `dev/desktop/orin_desktop_test.py`, and FB-042 remains selected next planning-only with branch not created
+Post-Release Truth: FB-015 and FB-029 are Released / Closed in v1.6.4-prebeta, FB-030 is Released / Closed in v1.6.5-prebeta, merged-unreleased release debt is now active for v1.6.6-prebeta, FB-005 is the merged-unreleased release-debt owner with repo state `No Active Branch`, the pending release scope remains bounded to WS-1 `desktop/orin_desktop_test.py` -> `dev/desktop/orin_desktop_test.py`, and FB-042 remains selected next planning-only on `feature/fb-042-step5-entrypoint-planning`, where Branch Readiness is active and no Workstream slice is admitted
 
 ## Post-Merge State
 

--- a/Docs/workstreams/FB-029_orin_identity_licensing_hardening.md
+++ b/Docs/workstreams/FB-029_orin_identity_licensing_hardening.md
@@ -36,7 +36,7 @@
 - Release Title: Pre-Beta v1.6.4
 - Release debt is clear after live release validation and post-release canon closure.
 - FB-015 is released and closed in the same `v1.6.4-prebeta` package.
-- FB-030 is now released and closed in `v1.6.5-prebeta`; merged-unreleased release debt is now active for `v1.6.6-prebeta`; FB-005 is the merged-unreleased release-debt owner; repo state is `No Active Branch`; the pending release scope remains bounded to WS-1 `desktop/orin_desktop_test.py` -> `dev/desktop/orin_desktop_test.py`; and FB-042 remains selected next planning-only with branch not created.
+- FB-030 is now released and closed in `v1.6.5-prebeta`; merged-unreleased release debt is now active for `v1.6.6-prebeta`; FB-005 is the merged-unreleased release-debt owner; repo state is `No Active Branch`; the pending release scope remains bounded to WS-1 `desktop/orin_desktop_test.py` -> `dev/desktop/orin_desktop_test.py`; and FB-042 remains selected next planning-only on `feature/fb-042-step5-entrypoint-planning`, where Branch Readiness is active and no Workstream slice is admitted.
 - FB-029 is now closed historical lane truth and no longer owns active implementation truth.
 - This milestone remains docs/canon-only planning and governance work.
 - WS-1 current identity, persona-option, and licensing source-of-truth inventory is complete and durably recorded.
@@ -394,7 +394,7 @@ Release Floor: patch prerelease
 Version Rationale: FB-029 remains a docs/canon-only identity, persona-option, and licensing-planning milestone with no new executable, runtime, operator-facing, user-facing, or materially expanded product capability
 Release Scope: FB-015 boot and desktop phase-boundary inventory, ownership map, lifecycle and state framing, implementation admission contract, hardening corrections, Live Validation waivers, PR package history, historical release-debt framing, plus the FB-029 identity source-of-truth inventory, persona-option boundary framing, licensing boundary framing, implementation admission contract, hardening corrections, Live Validation waivers, PR package history, and historical merged-package-state repair
 Release Artifacts: Tag v1.6.4-prebeta; release title Pre-Beta v1.6.4; rich Markdown release notes summarize the FB-015 boundary model and the FB-029 identity/licensing planning frame without repeating the release title inside the notes body, and GitHub-generated `## What's Changed` plus `**Full Changelog**:` must be included
-Post-Release Truth: FB-015 and FB-029 are Released / Closed in v1.6.4-prebeta, FB-030 is Released / Closed in v1.6.5-prebeta, merged-unreleased release debt is now active for v1.6.6-prebeta, FB-005 is the merged-unreleased release-debt owner with repo state `No Active Branch`, the pending release scope remains bounded to WS-1 `desktop/orin_desktop_test.py` -> `dev/desktop/orin_desktop_test.py`, and FB-042 remains selected next planning-only with branch not created
+Post-Release Truth: FB-015 and FB-029 are Released / Closed in v1.6.4-prebeta, FB-030 is Released / Closed in v1.6.5-prebeta, merged-unreleased release debt is now active for v1.6.6-prebeta, FB-005 is the merged-unreleased release-debt owner with repo state `No Active Branch`, the pending release scope remains bounded to WS-1 `desktop/orin_desktop_test.py` -> `dev/desktop/orin_desktop_test.py`, and FB-042 remains selected next planning-only on `feature/fb-042-step5-entrypoint-planning`, where Branch Readiness is active and no Workstream slice is admitted
 
 ## Post-Merge State
 

--- a/Docs/workstreams/FB-030_orin_voice_audio_direction_refinement.md
+++ b/Docs/workstreams/FB-030_orin_voice_audio_direction_refinement.md
@@ -36,7 +36,7 @@
 - Latest Public Prerelease: v1.6.5-prebeta
 - Release Title: Pre-Beta v1.6.5
 - Release debt is clear after live release validation and post-release canon closure.
-- FB-005 is now the merged-unreleased release-debt owner for `v1.6.6-prebeta`; repo state is `No Active Branch`; the pending release scope remains bounded to WS-1 `desktop/orin_desktop_test.py` -> `dev/desktop/orin_desktop_test.py`; and FB-042 remains selected next planning-only with branch not created.
+- FB-005 is now the merged-unreleased release-debt owner for `v1.6.6-prebeta`; repo state is `No Active Branch`; the pending release scope remains bounded to WS-1 `desktop/orin_desktop_test.py` -> `dev/desktop/orin_desktop_test.py`; and FB-042 remains selected next planning-only on `feature/fb-042-step5-entrypoint-planning`, where Branch Readiness is active and no Workstream slice is admitted.
 - FB-030 is now closed historical lane truth and no longer owns active implementation or release-debt truth.
 - Release Execution published `v1.6.5-prebeta` on commit `7c2933d6427feb08a1139ba7f5ba2393eb61f1e1`.
 - The voice/audio design goal and affected-surface map are now explicitly recorded before any runtime voice, shutdown voice, recovery voice, diagnostics, UI, asset, or public-claim change is admitted.
@@ -95,7 +95,7 @@ None.
 - Version Rationale: FB-030 remains a docs/canon-only voice/audio planning and admission milestone with no new executable, runtime, operator-facing, user-facing, or materially expanded product capability
 - Released Scope: Voice/audio trigger-surface inventory, playback-authority inventory, transcript/telemetry/history ownership map, lifecycle and persona-state framing, implementation admission contract, hardening corrections, Live Validation waivers, selected-next workspace/path gate, and PR package history
 - Released Artifacts: Tag v1.6.5-prebeta; release title Pre-Beta v1.6.5; rich Markdown release notes summarize the FB-030 voice/audio direction planning frame without repeating the release title inside the notes body, and GitHub-generated `## What's Changed` plus `**Full Changelog**:` must be included
-- Post-Release Truth: FB-030 is Released / Closed in v1.6.5-prebeta; merged-unreleased release debt is now active for v1.6.6-prebeta; FB-005 is the merged-unreleased release-debt owner with repo state `No Active Branch`; the pending release scope remains bounded to WS-1 `desktop/orin_desktop_test.py` -> `dev/desktop/orin_desktop_test.py`; and FB-042 remains selected next planning-only with branch not created
+- Post-Release Truth: FB-030 is Released / Closed in v1.6.5-prebeta; merged-unreleased release debt is now active for v1.6.6-prebeta; FB-005 is the merged-unreleased release-debt owner with repo state `No Active Branch`; the pending release scope remains bounded to WS-1 `desktop/orin_desktop_test.py` -> `dev/desktop/orin_desktop_test.py`; and FB-042 remains selected next planning-only on `feature/fb-042-step5-entrypoint-planning`, where Branch Readiness is active and no Workstream slice is admitted
 - Selected Next Workstream: FB-005 Workspace and folder organization
 - Branch Readiness Gate: Satisfied. Release publication, validation, updated-main revalidation, explicit path-sensitive workspace approval, and bounded-slice admission are complete for WS-1 `desktop/orin_desktop_test.py` -> `dev/desktop/orin_desktop_test.py`; later workspace/path slices remain separate approval gates
 
@@ -660,7 +660,7 @@ Release Floor: patch prerelease
 Version Rationale: FB-030 remains a docs/canon-only voice/audio planning and admission milestone with no new executable, runtime, operator-facing, user-facing, or materially expanded product capability
 Release Scope: Voice/audio trigger-surface inventory, playback-authority inventory, transcript/telemetry/history ownership map, lifecycle and persona-state framing, implementation admission contract, hardening corrections, Live Validation waivers, selected-next workspace/path gate, and PR package history
 Release Artifacts: Tag v1.6.5-prebeta; release title Pre-Beta v1.6.5; rich Markdown release notes summarize the FB-030 voice/audio direction planning frame without repeating the release title inside the notes body, and GitHub-generated `## What's Changed` plus `**Full Changelog**:` must be included
-Post-Release Truth: FB-030 is Released / Closed in v1.6.5-prebeta; merged-unreleased release debt is now active for v1.6.6-prebeta; FB-005 is the merged-unreleased release-debt owner with repo state `No Active Branch`; the pending release scope remains bounded to WS-1 `desktop/orin_desktop_test.py` -> `dev/desktop/orin_desktop_test.py`; and FB-042 remains selected next planning-only with branch not created
+Post-Release Truth: FB-030 is Released / Closed in v1.6.5-prebeta; merged-unreleased release debt is now active for v1.6.6-prebeta; FB-005 is the merged-unreleased release-debt owner with repo state `No Active Branch`; the pending release scope remains bounded to WS-1 `desktop/orin_desktop_test.py` -> `dev/desktop/orin_desktop_test.py`; and FB-042 remains selected next planning-only on `feature/fb-042-step5-entrypoint-planning`, where Branch Readiness is active and no Workstream slice is admitted
 
 ## Post-Merge State
 

--- a/Docs/workstreams/index.md
+++ b/Docs/workstreams/index.md
@@ -89,7 +89,7 @@ These records are not active implementation branch owners after merge.
 
 - `Docs/workstreams/FB-005_workspace_and_folder_organization.md`
 
-Current merge-target truth is `No Active Branch`. FB-005 is the merged-unreleased release-debt owner for `v1.6.6-prebeta`; the pending release scope remains bounded to WS-1 `desktop/orin_desktop_test.py` -> `dev/desktop/orin_desktop_test.py`; the residual visual-path mismatch remains dev-only and non-user-facing; and FB-042 is selected next planning-only with branch not created.
+Current merge-target truth is `No Active Branch`. FB-005 is the merged-unreleased release-debt owner for `v1.6.6-prebeta`; the pending release scope remains bounded to WS-1 `desktop/orin_desktop_test.py` -> `dev/desktop/orin_desktop_test.py`; the residual visual-path mismatch remains dev-only and non-user-facing; and FB-042 remains selected next planning-only on `feature/fb-042-step5-entrypoint-planning`, where Branch Readiness is active and no Workstream slice is admitted.
 
 ### Closed
 


### PR DESCRIPTION
## Summary

Current merge-target canon updated the FB-005 release-debt package, but several current-state surfaces still carried pre-merge PR-open / merge-PR wording from PR Readiness. That escaped drift blocked `Release Readiness` on `main`.

## What Changed

### Changes

- repair escaped FB-005 post-merge canon drift after PR #83 merged
- preserve merged-unreleased release-debt truth for `v1.6.6-prebeta` with `Repo State: No Active Branch`
- record `feature/fb-042-step5-entrypoint-planning` as the active FB-042 Branch Readiness branch while keeping FB-042 planning-first and `Registry-only`
- sync the carry-forward workstream mirrors and branch-authority index to the same current-state truth

### Root Cause
Current merge-target canon updated the FB-005 release-debt package, but several current-state surfaces still carried pre-merge PR-open / merge-PR wording from PR Readiness. That escaped drift blocked `Release Readiness` on `main`.

### Changes

- repair escaped FB-005 post-merge canon drift after PR #83 merged
- preserve merged-unreleased release-debt truth for `v1.6.6-prebeta` with `Repo State: No Active Branch`
- record `feature/fb-042-step5-entrypoint-planning` as the active FB-042 Branch Readiness branch while keeping FB-042 planning-first and `Registry-only`
- sync the carry-forward workstream mirrors and branch-authority index to the same current-state truth

### Root Cause
Current merge-target canon updated the FB-005 release-debt package, but several current-state surfaces still carried pre-merge PR-open / merge-PR wording from PR Readiness. That escaped drift blocked `Release Readiness` on `main`.
