### PR TITLE
FB-043 Release-Debt Marker Repair For FB-042

### DIFF
--- a/Docs/Main.md
+++ b/Docs/Main.md
@@ -58,7 +58,7 @@ Use this ownership split unless a validated source conflict requires a temporary
 - User Test Summary = validation-contract layer owned by the relevant workstream
 - phase governance = repo-wide execution, proof, timeout, seam, stop-loss, validation-helper, and desktop UI audit contract
 - validation helper registry = repo-wide helper naming, ownership, reuse, workstream-scoped exception, and consolidation contract
-- branch authority records = repo-owned phase owners for approved non-backlog `release packaging` branches and historical `docs/governance` records
+- branch authority records = repo-owned phase owners for approved non-backlog `release packaging` branches and preserved historical `docs/governance` or `emergency canon repair` records; new fixes and repairs still use a new `feature/` branch by default
 - `Docs/Main.md` = routing authority aligned to merged truth
 
 ## Analysis-First Prompt Baseline
@@ -248,6 +248,9 @@ These are reference layers, not active workstream or roadmap owners.
 - if repo truth resolves to blocked `No Active Branch`, report the blocking repair path
 - if repo truth resolves to steady-state `No Active Branch`, do not invent a next implementation branch by inertia
 - governance-only branches are not used for new Nexus work; governance or canon repair rides on the active branch that owns the affected truth, or on the next active branch's `Branch Readiness` if a PR Readiness miss escaped the prior branch
+- All fixes and repairs use a new `feature/` branch by default.
+- Do not create a `docs/governance` or `emergency canon repair` branch unless explicit `Docs/Governance Branch Waiver: APPROVED` is recorded from the USER.
+- Repair-only `feature/` branch existence does not imply Branch Readiness admission or active branch truth.
 - Pre-PR Durability Rule: before `PR Readiness`, when a bounded phase pass or durability seam changes source, docs, canon, validator, helper registry, workstream authority, or branch-truth files and validation is green, Codex must commit and push those changes on the active branch instead of stopping at a copy-ready, staged-only, or uncommitted state
 - the Pre-PR Durability Rule applies through `Branch Readiness`, `Workstream`, `Hardening`, and `Live Validation`; `PR Readiness` remains the later merge-target gate and must still prove clean durable branch truth
 - prompt-level requests to stop before commit/push are not durability exceptions; only a documented `Durability Waiver`, failed validation, legally file-frozen `Release Readiness`, or a named Codex self-imposed blocker may stop commit/push, and self-imposed blockers must automatically commit and push once lifted

--- a/Docs/branch_records/index.md
+++ b/Docs/branch_records/index.md
@@ -7,7 +7,7 @@ This index routes repo-owned authority records for approved branches that do not
 Use this layer for:
 
 - `release packaging` branches
-- historical `docs/governance` or emergency repair records
+- preserved historical `docs/governance` or `emergency canon repair` records
 
 when those branches need a durable repo-owned phase authority record.
 
@@ -21,6 +21,9 @@ Do not use this layer to replace:
 - branch authority records are for explicitly approved non-backlog branches only
 - active-branch-first remains the default during `pre-Beta`
 - new governance-only branches are not used for Nexus work
+- All fixes and repairs use a new `feature/` branch by default.
+- Do not create a `docs/governance` or `emergency canon repair` branch unless explicit `Docs/Governance Branch Waiver: APPROVED` is recorded from the USER.
+- Repair-only `feature/` branch existence does not imply Branch Readiness admission or active branch truth.
 - between-branch canon repair is blocked
 - missed PR Readiness canon work must be carried by the next active branch's `Branch Readiness` before implementation begins
 - the `Active Branch Authority Records` list is only for branches that are still the current execution base

--- a/Docs/codex_modes.md
+++ b/Docs/codex_modes.md
@@ -148,6 +148,9 @@ In Workflow mode, Codex should:
 - Docs-only Workstreams require explicit USER approval.
 - Planning-loop bypass requires `Planning-Loop Bypass User Approval: APPROVED` and `Planning-Loop Bypass Reason:`.
 - Release-bearing implementation work with no runtime/user-facing, backend/runtime, or developer-tooling delta is blocked unless the USER explicitly approves that release window.
+- All fixes and repairs use a new `feature/` branch by default.
+- Do not create a `docs/governance` or `emergency canon repair` branch unless explicit `Docs/Governance Branch Waiver: APPROVED` is recorded from the USER.
+- Repair-only `feature/` branch existence does not imply Branch Readiness admission or active branch truth.
 
 ### What Codex Must Not Do
 
@@ -160,6 +163,7 @@ In Workflow mode, Codex must not:
 - stop after a green seam merely because the prompt task named only the entry seam, the output asks for `Next Safe Move`, durability completed, or one seam was recorded
 - treat branch existence, branch rename, backlog promotion, repair-only traceability, or release-bearing posture as Workstream progress by themselves
 - treat planning or canon-only output on an implementation branch as valid Workstream progress without explicit USER-approved bypass markers
+- open a `docs/governance` or `emergency canon repair` branch for a fix or repair without explicit USER waiver
 
 ### Expected Outputs
 

--- a/Docs/codex_user_guide.md
+++ b/Docs/codex_user_guide.md
@@ -365,6 +365,9 @@ Required add-ons:
 - `Docs-only Workstreams require explicit USER approval.`
 - `Planning-loop bypass requires Planning-Loop Bypass User Approval: APPROVED and Planning-Loop Bypass Reason:.`
 - `Release-bearing implementation work with no runtime/user-facing, backend/runtime, or developer-tooling delta is blocked unless the USER explicitly approves that release window.`
+- All fixes and repairs use a new `feature/` branch by default.
+- Do not create a `docs/governance` or `emergency canon repair` branch unless explicit `Docs/Governance Branch Waiver: APPROVED` is recorded from the USER.
+- Repair-only `feature/` branch existence does not imply Branch Readiness admission or active branch truth.
 
 Use this when:
 

--- a/Docs/development_rules.md
+++ b/Docs/development_rules.md
@@ -66,7 +66,7 @@ Use this layered ownership model:
 - User Test Summary = validation-contract layer owned by workstreams
 - phase governance = repo-wide execution, exact phase enum, blockers, branch classes, proof, timeout, seam, stop-loss, validation-helper, Governance Drift Audit, phase resolver, and desktop UI audit contract
 - validation helper registry = repo-wide helper naming, helper ownership, reuse-first inventory, workstream-scoped exception markers, and consolidation contract
-- branch authority records = repo-owned phase owners for approved non-backlog `release packaging` branches and historical `docs/governance` records
+- branch authority records = repo-owned phase owners for approved non-backlog `release packaging` branches and preserved historical `docs/governance` or `emergency canon repair` records; new fixes and repairs still use a new `feature/` branch by default
 - `Docs/Main.md` = routing authority aligned to merged truth
 
 Use `Docs/phase_governance.md` for:
@@ -210,6 +210,9 @@ When a governance or canon update is directly required to keep the active branch
 That allowance does not permit unrelated governance churn, product scope expansion, validation weakening, stop-condition weakening, or phase-authority bypass.
 Do not use a standalone `docs/governance` branch to carry routine canon or governance work that belongs on an already-active implementation or release branch.
 Do not open a governance-only branch for between-branch canon repair.
+All fixes and repairs use a new `feature/` branch by default.
+Do not create a `docs/governance` or `emergency canon repair` branch unless explicit `Docs/Governance Branch Waiver: APPROVED` is recorded from the USER.
+Repair-only `feature/` branch existence does not imply Branch Readiness admission or active branch truth.
 If PR Readiness missed required canon or docs work and the owning branch has already merged, the next active branch must treat the miss as a `Branch Readiness` blocker and repair it before implementation begins.
 
 Pre-PR Durability Rule:
@@ -333,6 +336,9 @@ That means:
 - governance-only branches are not used for new Nexus work:
   - governance and canon repair ride on the active branch when tied to that branch's truth
   - between-branch canon repair is blocked
+  - all fixes and repairs use a new `feature/` branch by default
+  - `docs/governance` and `emergency canon repair` branches are waiver-only historical paths that require `Docs/Governance Branch Waiver: APPROVED` from the USER
+  - repair-only `feature/` branch existence does not imply Branch Readiness admission or active branch truth
   - direct writes to `main` are blocked as `Main Write Attempt`
   - Release Readiness must not absorb docs sync or canon cleanup that PR Readiness should have completed
   - Release Readiness must not mutate files to repair a discovered gap; use `PR Readiness` before merge or the next active branch's `Branch Readiness` after merge

--- a/Docs/feature_backlog.md
+++ b/Docs/feature_backlog.md
@@ -56,6 +56,7 @@ Current Active Workstream Before Merge: FB-042 Desktop entrypoint runtime refine
 Active Branch: None.
 Active Branch Before Merge: feature/fb-042-desktop-entrypoint-runtime-refinement.
 Selected Next Workstream: FB-043 Top-level desktop entrypoint ownership and main.py handoff refinement.
+Repair-Only Branch Handling: `feature/fb-043-release-debt-marker-repair` is a repair-only `feature/` branch and does not imply Branch Readiness admission or active branch truth for FB-043.
 Historical Branch Readiness State: Complete on `feature/fb-005-workspace-path-planning`.
 Current Branch Readiness State: Complete on `feature/fb-042-desktop-entrypoint-runtime-refinement`.
 Historical Workstream State: WS-1 `desktop/orin_desktop_test.py` -> `dev/desktop/orin_desktop_test.py` is complete.
@@ -146,6 +147,7 @@ Record State: Registry-only
 Priority: High
 Selection / Unblock: Select after FB-042 because the next highest-value runtime-bearing follow-through is the still-ambiguous top-level desktop entrypoint handoff across `main.py` and the shipped launcher chain. Branch Readiness must keep planning/framing bounded and end by admitting one runtime/user-facing implementation seam rather than another docs-only lane.
 Branch: Not created
+Repair-Only Branch Handling: `feature/fb-043-release-debt-marker-repair` is a repair-only `feature/` branch and does not imply Branch Readiness admission or active branch truth.
 Canonical Workstream Doc: Not created yet
 Branch Readiness: Not started. It must record affected-surface ownership across `main.py`, `launch_orin_desktop.vbs`, `desktop/orin_desktop_launcher.pyw`, `desktop/orin_desktop_main.py`, and `dev/orin_desktop_entrypoint_validation.py`, then admit one bounded runtime-bearing slice.
 Next Workstream: Selected

--- a/Docs/nexus_startup_contract.md
+++ b/Docs/nexus_startup_contract.md
@@ -124,11 +124,14 @@ Generated prompts must require default startup validation:
 Additional validation is phase- and workstream-specific and must be read from the active workstream doc and `Docs/phase_governance.md`.
 This file does not own those execution validation rules.
 
-For docs/governance-only passes, validation must include:
+For docs/governance-only passes, which are historical/waiver-only rather than the default repair path, validation must include:
 
 - governance alignment check against owning canon
 - duplication check so the new doc routes rather than re-owning detailed policy
 - conflict check against phase governance, protected-main law, and durability rules
+- All fixes and repairs use a new `feature/` branch by default.
+- Do not create a `docs/governance` or `emergency canon repair` branch unless explicit `Docs/Governance Branch Waiver: APPROVED` is recorded from the USER.
+- Repair-only `feature/` branch existence does not imply Branch Readiness admission or active branch truth.
 
 ## Loader Stop Conditions
 
@@ -175,7 +178,7 @@ Mode: <Analysis / Workflow>
 Phase: <canonical phase or analysis-only>
 Workstream: <FB-XXX or No Active Branch>
 Branch: <branch name>
-Branch Class: <implementation / docs/governance historical context / release packaging / as canon allows>
+Branch Class: <implementation / repair on new feature branch / release packaging / docs/governance historical context only with explicit waiver / as canon allows>
 
 First, read as a loader map only:
 - Docs/nexus_startup_contract.md

--- a/Docs/orin_task_template.md
+++ b/Docs/orin_task_template.md
@@ -54,7 +54,7 @@ Phase:
 [Branch Readiness / Workstream / Hardening / Live Validation / PR Readiness / Release Readiness]
 
 Branch Class:
-[implementation / docs/governance / emergency canon repair / release packaging]
+[implementation / repair on new feature branch / release packaging / docs/governance historical context only with explicit Docs/Governance Branch Waiver: APPROVED / emergency canon repair historical context only with explicit Docs/Governance Branch Waiver: APPROVED]
 
 Implementation Delta Class:
 [runtime/user-facing / backend/runtime / developer-tooling / docs-only / comma-separated non-docs-only values]
@@ -591,3 +591,6 @@ During Release Execution, use GitHub-generated release notes through the GitHub 
 - Do not modify backlog status or add backlog items unless the task explicitly authorizes backlog updates.
 - Do not force tightly coupled governance or canon updates onto a separate docs/governance branch when the active branch owns the affected truth and the update can stay inside its current phase, branch class, validation rules, and stop conditions.
 - Do not open a governance-only branch or between-branch repair window for missed PR Readiness work; carry the repair in the next active branch's `Branch Readiness` before implementation begins.
+- All fixes and repairs use a new `feature/` branch by default.
+- Do not create a `docs/governance` or `emergency canon repair` branch unless explicit `Docs/Governance Branch Waiver: APPROVED` is recorded from the USER.
+- Repair-only `feature/` branch existence does not imply Branch Readiness admission or active branch truth.

--- a/Docs/phase_governance.md
+++ b/Docs/phase_governance.md
@@ -38,7 +38,7 @@ For phase-sensitive execution, prompts must include:
 
 Add these fields when relevant:
 
-- `Branch Class: <implementation / docs/governance / emergency canon repair / release packaging>`
+- `Branch Class: <implementation / repair on new feature branch / docs/governance historical context only with explicit waiver / emergency canon repair historical context only with explicit waiver / release packaging>`
 - `Active Seam: <seam name>`
 - `Seam Sequence: <ordered seam list>` when the current phase permits a bounded multi-seam pipeline
 - `Validation Contract: <summary or authority reference>`
@@ -150,6 +150,9 @@ This path is for explicitly approved non-backlog branch classes such as:
 - `release packaging`
 
 `docs/governance` branch records may exist as historical records, but new governance-only branches are not used in the normal Nexus flow.
+All fixes and repairs use a new `feature/` branch by default.
+Do not create a `docs/governance` or `emergency canon repair` branch unless explicit `Docs/Governance Branch Waiver: APPROVED` is recorded from the USER.
+Repair-only `feature/` branch existence does not imply Branch Readiness admission or active branch truth.
 Tightly coupled governance and canon repair must ride on the active branch that owns the affected truth.
 It must not be used to avoid carrying supporting canon sync on an already-active implementation branch.
 

--- a/Docs/prebeta_roadmap.md
+++ b/Docs/prebeta_roadmap.md
@@ -77,7 +77,6 @@ That means the released FB-027 interaction baseline, the released FB-036 authori
 
 ## Current Branch Readiness Posture
 
-Merged-Unreleased Release-Debt Owner: None.
 Merged-Unreleased Release-Debt Owner: FB-042 Desktop entrypoint runtime refinement.
 Repo State: No Active Branch.
 
@@ -93,6 +92,7 @@ Active Branch: `None`
 Active Branch Before Merge: `feature/fb-042-desktop-entrypoint-runtime-refinement`
 Active Branch Before Release: `feature/fb-005-workspace-path-planning`
 Selected Next Workstream: FB-043 Top-level desktop entrypoint ownership and main.py handoff refinement.
+Repair-Only Branch Handling: `feature/fb-043-release-debt-marker-repair` is a repair-only `feature/` branch and does not imply Branch Readiness admission or active branch truth for FB-043.
 Historical Branch Readiness State: Complete on `feature/fb-005-workspace-path-planning`.
 Current Branch Readiness State: Complete on `feature/fb-042-desktop-entrypoint-runtime-refinement`.
 Historical Workstream State: WS-1 `desktop/orin_desktop_test.py` -> `dev/desktop/orin_desktop_test.py` is complete.
@@ -182,6 +182,7 @@ Current-branch clarity: latest public prerelease is `v1.6.6-prebeta`; FB-005 is 
 - status: `selected`
 - record state: `Registry-only`
 - Branch: Not created
+- Repair-Only Branch Handling: `feature/fb-043-release-debt-marker-repair` is a repair-only `feature/` branch and does not imply Branch Readiness admission or active branch truth.
 - selection basis: selected during FB-042 PR Readiness because the next highest-value runtime-bearing follow-through is the still-ambiguous top-level desktop entrypoint handoff across `main.py` and the shipped launcher chain, and the planning-loop guardrail requires the next lane to stay implementation-bearing.
 - branch creation gate: after FB-042 merges, `v1.6.7-prebeta` is published and validated, updated `main` is revalidated, and FB-043 Branch Readiness admits one bounded runtime-bearing top-level entrypoint slice.
 - minimal scope: complete Branch Readiness for a bounded top-level desktop entrypoint ownership and handoff refinement slice across `main.py`, `launch_orin_desktop.vbs`, `desktop/orin_desktop_launcher.pyw`, `desktop/orin_desktop_main.py`, and `dev/orin_desktop_entrypoint_validation.py`, then admit one implementation seam that reduces top-level handoff ambiguity without widening into `Audio/`, `logs/`, `jarvis_visual/`, installer work, or broader workspace reshaping.

--- a/dev/orin_branch_governance_validation.py
+++ b/dev/orin_branch_governance_validation.py
@@ -679,6 +679,24 @@ NON_RELEASE_WAIVER_BRANCH_CLASSES = (
 
 EMERGENCY_CANON_REPAIR_BRANCH_CLASS = "emergency canon repair"
 REPAIR_ONLY_BRANCH_HANDLING_LABEL = "Repair-Only Branch Handling"
+FEATURE_REPAIR_BRANCH_RE = re.compile(r"(?:origin/)?feature/[A-Za-z0-9._-]+")
+
+FEATURE_BRANCH_REPAIR_CONTRACT_DOCS = (
+    Path("Docs/phase_governance.md"),
+    Path("Docs/development_rules.md"),
+    Path("Docs/Main.md"),
+    Path("Docs/codex_modes.md"),
+    Path("Docs/codex_user_guide.md"),
+    Path("Docs/orin_task_template.md"),
+    Path("Docs/nexus_startup_contract.md"),
+    Path("Docs/branch_records/index.md"),
+)
+
+FEATURE_BRANCH_REPAIR_CONTRACT_PHRASES = (
+    "All fixes and repairs use a new `feature/` branch by default.",
+    "Do not create a `docs/governance` or `emergency canon repair` branch unless explicit `Docs/Governance Branch Waiver: APPROVED` is recorded from the USER.",
+    "Repair-only `feature/` branch existence does not imply Branch Readiness admission or active branch truth.",
+)
 
 BRANCH_RECORD_INDEX = Path("Docs/branch_records/index.md")
 
@@ -792,6 +810,10 @@ def _is_open_backlog_candidate(entry: dict[str, str]) -> bool:
 def _extract_colon_value(block: str, label: str) -> str:
     match = re.search(rf"^{re.escape(label)}:\s*(.+)$", block, flags=re.M)
     return match.group(1).strip() if match else ""
+
+
+def _extract_colon_values(block: str, label: str) -> list[str]:
+    return [match.strip() for match in re.findall(rf"^{re.escape(label)}:\s*(.+)$", block, flags=re.M)]
 
 
 def _clean_release_value(value: str) -> str:
@@ -1442,7 +1464,9 @@ def _selected_next_ignored_branch_names(
     return set()
 
 
-def _selected_next_repair_only_branch_handling(blocks: list[str]) -> bool:
+def _selected_next_repair_only_branch_info(blocks: list[str]) -> tuple[bool, set[str]]:
+    handling_active = False
+    handled_branches: set[str] = set()
     for block in blocks:
         marker = _extract_marker_value(block, REPAIR_ONLY_BRANCH_HANDLING_LABEL)
         marker_lower = marker.casefold()
@@ -1452,8 +1476,34 @@ def _selected_next_repair_only_branch_handling(blocks: list[str]) -> bool:
             and "does not imply branch readiness admission" in marker_lower
             and "active branch truth" in marker_lower
         ):
-            return True
-    return False
+            handling_active = True
+            for branch_name in FEATURE_REPAIR_BRANCH_RE.findall(marker):
+                handled_branches.add(branch_name)
+                if branch_name.startswith("origin/"):
+                    handled_branches.add(branch_name.removeprefix("origin/"))
+                else:
+                    handled_branches.add(f"origin/{branch_name}")
+    return handling_active, handled_branches
+
+
+def _require_no_conflicting_marker_values(require, source_name: str, text: str, label: str) -> None:
+    cleaned_values = [
+        _clean_release_value(value)
+        for value in _extract_colon_values(text, label)
+        if _clean_release_value(value)
+    ]
+    unique_values: list[str] = []
+    seen: set[str] = set()
+    for value in cleaned_values:
+        key = value.casefold()
+        if key in seen:
+            continue
+        seen.add(key)
+        unique_values.append(value)
+    require(
+        len(unique_values) <= 1,
+        f"{source_name}: conflicting '{label}' markers found: {', '.join(unique_values)}",
+    )
 
 
 def _branch_names_for_workstream(
@@ -1609,7 +1659,7 @@ def _run_next_workstream_gate(
     selected_block = selected["block"]
     selected_scope = _extract_colon_value(selected_block, "Minimal Scope")
     roadmap_section = _next_workstream_roadmap_section(roadmap_text)
-    repair_only_handling = _selected_next_repair_only_branch_handling(
+    repair_only_handling, explicitly_handled_repair_branches = _selected_next_repair_only_branch_info(
         [selected_block, roadmap_section]
     )
 
@@ -1675,12 +1725,14 @@ def _run_next_workstream_gate(
         branch_name
         for branch_name in matching_branches
         if branch_record_class_map.get(branch_name) != EMERGENCY_CANON_REPAIR_BRANCH_CLASS
+        and branch_name not in explicitly_handled_repair_branches
     ]
     if repair_only_handling and not non_repair_matching_branches:
         matching_branches = []
     else:
         if not non_repair_matching_branches and any(
             branch_record_class_map.get(branch_name) == EMERGENCY_CANON_REPAIR_BRANCH_CLASS
+            or branch_name in explicitly_handled_repair_branches
             for branch_name in matching_branches
         ):
             require(
@@ -1931,6 +1983,14 @@ def main() -> int:
             "docs/governance" in text,
             f"{relative_path}: docs/governance historical branch-class guidance is missing",
         )
+
+    for relative_path in FEATURE_BRANCH_REPAIR_CONTRACT_DOCS:
+        text = _read_text(relative_path)
+        for required_phrase in FEATURE_BRANCH_REPAIR_CONTRACT_PHRASES:
+            require(
+                required_phrase in text,
+                f"{relative_path}: feature-branch repair contract is missing '{required_phrase}'",
+            )
 
     for relative_path in GOVERNANCE_ONLY_BLOCK_DOCS:
         text = _read_text(relative_path).casefold()
@@ -2469,19 +2529,21 @@ def main() -> int:
                 ignored_selected_next_branch_names,
             )
             if matching_branches:
-                repair_only_handling = _selected_next_repair_only_branch_handling(
+                repair_only_handling, explicitly_handled_repair_branches = _selected_next_repair_only_branch_info(
                     [selected["block"], roadmap_section]
                 )
                 non_repair_matching_branches = [
                     branch_name
                     for branch_name in matching_branches
                     if branch_record_class_map.get(branch_name) != EMERGENCY_CANON_REPAIR_BRANCH_CLASS
+                    and branch_name not in explicitly_handled_repair_branches
                 ]
                 if repair_only_handling and not non_repair_matching_branches:
                     matching_branches = []
                 else:
                     if not non_repair_matching_branches and any(
                         branch_record_class_map.get(branch_name) == EMERGENCY_CANON_REPAIR_BRANCH_CLASS
+                        or branch_name in explicitly_handled_repair_branches
                         for branch_name in matching_branches
                     ):
                         require(
@@ -2987,6 +3049,24 @@ def main() -> int:
 
         if normalized_workstream_status == "merged unreleased":
             roadmap_section = _roadmap_section_for_id(roadmap_text, workstream_id)
+            _require_no_conflicting_marker_values(
+                require,
+                "Docs/feature_backlog.md",
+                backlog_text,
+                "Merged-Unreleased Release-Debt Owner",
+            )
+            _require_no_conflicting_marker_values(
+                require,
+                "Docs/prebeta_roadmap.md",
+                roadmap_text,
+                "Merged-Unreleased Release-Debt Owner",
+            )
+            _require_no_conflicting_marker_values(
+                require,
+                canonical_path,
+                workstream_text,
+                "Merged-Unreleased Release-Debt Owner",
+            )
             for required_marker in REQUIRED_MERGED_UNRELEASED_MARKERS:
                 require(
                     required_marker in workstream_text,

--- a/dev/orin_codex_recovery_utility.ps1
+++ b/dev/orin_codex_recovery_utility.ps1
@@ -4,46 +4,38 @@ param(
     [string]$OutputDirectory = [Environment]::GetFolderPath("Desktop"),
     [switch]$SkipPackageState,
     [switch]$ForceCloseCodex,
-    [switch]$ResetClipboard
+    [switch]$ResetClipboard,
+    [switch]$QuarantineOversizedSessions,
+    [ValidateRange(1, 4096)]
+    [int]$OversizedSessionThresholdMB = 100,
+    [switch]$ResetAppShellState,
+    [switch]$RepairWindowsShell,
+    [switch]$CaptureShellDiagnostics
 )
 
 $ErrorActionPreference = "Stop"
+
+$script:UserProfile = [Environment]::GetFolderPath("UserProfile")
+$script:DesktopPath = [Environment]::GetFolderPath("Desktop")
+$script:LocalAppData = [Environment]::GetFolderPath("LocalApplicationData")
+$script:CodexRoot = Join-Path $script:UserProfile ".codex"
+$script:PackageRoot = Join-Path $script:LocalAppData "Packages\OpenAI.Codex_2p2nqsd0c76g0"
+$script:RoamingCodexRoot = Join-Path $script:PackageRoot "LocalCache\Roaming\Codex"
+$script:CodexProcessNames = @("Codex", "codex")
+$script:ShellProcessNames = @("explorer", "StartMenuExperienceHost", "ShellExperienceHost", "SearchHost", "TextInputHost")
 
 function Write-Step {
     param([string]$Message)
     Write-Host "[codex-recovery] $Message"
 }
 
-function Assert-CodexClosed {
-    $running = Get-Process | Where-Object { $_.ProcessName -like "*Codex*" -or $_.ProcessName -like "codex" }
-    if ($running) {
-        $details = ($running | Sort-Object ProcessName, Id | ForEach-Object { "$($_.ProcessName)#$($_.Id)" }) -join ", "
-        throw "Codex must be fully closed before this utility runs. Still running: $details"
-    }
-}
-
-function Stop-CodexIfRequested {
-    param([bool]$Force)
-
-    if (-not $Force) {
-        Assert-CodexClosed
-        return
-    }
-
-    $running = Get-Process | Where-Object { $_.ProcessName -like "*Codex*" -or $_.ProcessName -like "codex" }
-    if (-not $running) {
-        return
-    }
-
-    $details = ($running | Sort-Object ProcessName, Id | ForEach-Object { "$($_.ProcessName)#$($_.Id)" }) -join ", "
-    Write-Step "Closing Codex processes: $details"
-    $running | Stop-Process -Force
-    Start-Sleep -Seconds 2
-    Assert-CodexClosed
-}
-
 function Ensure-Directory {
     param([string]$Path)
+
+    if ([string]::IsNullOrWhiteSpace($Path)) {
+        throw "Ensure-Directory requires a non-empty path."
+    }
+
     New-Item -ItemType Directory -Path $Path -Force | Out-Null
 }
 
@@ -85,6 +77,153 @@ function Remove-FileIfPresent {
     return $true
 }
 
+function Get-CodexProcesses {
+    $allProcesses = @()
+    foreach ($name in $script:CodexProcessNames) {
+        $allProcesses += Get-Process -Name $name -ErrorAction SilentlyContinue
+    }
+
+    $seen = @{}
+    $unique = foreach ($process in $allProcesses) {
+        if (-not $seen.ContainsKey($process.Id)) {
+            $seen[$process.Id] = $true
+            $process
+        }
+    }
+
+    return @($unique)
+}
+
+function Test-InertCodexResidue {
+    param([System.Diagnostics.Process]$Process)
+
+    $path = $null
+    try {
+        $path = $Process.Path
+    } catch {
+        $path = $null
+    }
+
+    return (
+        $Process.ProcessName -eq "Codex" -and
+        $Process.MainWindowHandle -eq 0 -and
+        [string]::IsNullOrWhiteSpace($path) -and
+        $Process.WorkingSet64 -le 128KB
+    )
+}
+
+function Get-BlockingCodexProcesses {
+    return @(
+        Get-CodexProcesses | Where-Object { -not (Test-InertCodexResidue -Process $_) }
+    )
+}
+
+function Format-ProcessSummary {
+    param([System.Diagnostics.Process]$Process)
+
+    return "{0}#{1}" -f $Process.ProcessName, $Process.Id
+}
+
+function Assert-CodexClosed {
+    $blocking = Get-BlockingCodexProcesses
+    if ($blocking.Count -gt 0) {
+        $details = ($blocking | Sort-Object ProcessName, Id | ForEach-Object { Format-ProcessSummary -Process $_ }) -join ", "
+        throw "Codex must be fully closed before this utility runs. Still running: $details. If Windows reports Access is denied, right-click the repair batch and choose Run as administrator, or restart Windows and run repair before reopening Codex."
+    }
+
+    $residue = @(Get-CodexProcesses | Where-Object { Test-InertCodexResidue -Process $_ })
+    if ($residue.Count -gt 0) {
+        $details = ($residue | Sort-Object Id | ForEach-Object { Format-ProcessSummary -Process $_ }) -join ", "
+        Write-Step "Ignoring inert Codex shell residue: $details"
+    }
+}
+
+function Invoke-GracefulCodexClose {
+    param(
+        [System.Diagnostics.Process[]]$Processes,
+        [System.Collections.Generic.List[string]]$Actions
+    )
+
+    foreach ($process in $Processes) {
+        if ($process.MainWindowHandle -eq 0) {
+            continue
+        }
+
+        try {
+            if ($process.CloseMainWindow()) {
+                $Actions.Add("requested graceful close for $(Format-ProcessSummary -Process $process)") | Out-Null
+            }
+        } catch {
+            $Actions.Add("graceful close skipped for $(Format-ProcessSummary -Process $process): $($_.Exception.Message)") | Out-Null
+        }
+    }
+}
+
+function Stop-CodexIfRequested {
+    param(
+        [bool]$Force,
+        [System.Collections.Generic.List[string]]$Actions
+    )
+
+    if (-not $Force) {
+        Assert-CodexClosed
+        return
+    }
+
+    $blocking = Get-BlockingCodexProcesses
+    if ($blocking.Count -eq 0) {
+        Assert-CodexClosed
+        return
+    }
+
+    $details = ($blocking | Sort-Object ProcessName, Id | ForEach-Object { Format-ProcessSummary -Process $_ }) -join ", "
+    Write-Step "Closing Codex processes: $details"
+
+    Invoke-GracefulCodexClose -Processes $blocking -Actions $Actions
+    Start-Sleep -Seconds 2
+
+    foreach ($process in (Get-BlockingCodexProcesses)) {
+        try {
+            Stop-Process -Id $process.Id -Force -ErrorAction Stop
+            $Actions.Add("force-stopped $(Format-ProcessSummary -Process $process)") | Out-Null
+        } catch {
+            $Actions.Add("Stop-Process failed for $(Format-ProcessSummary -Process $process): $($_.Exception.Message)") | Out-Null
+        }
+    }
+
+    Start-Sleep -Seconds 2
+
+    foreach ($process in (Get-BlockingCodexProcesses)) {
+        $null = & taskkill.exe /PID $process.Id /T /F 2>&1
+        if ($LASTEXITCODE -eq 0) {
+            $Actions.Add("taskkill stopped $(Format-ProcessSummary -Process $process)") | Out-Null
+        } else {
+            $Actions.Add("taskkill failed for $(Format-ProcessSummary -Process $process)") | Out-Null
+        }
+    }
+
+    Start-Sleep -Seconds 2
+    Assert-CodexClosed
+}
+
+function Get-DisplayPath {
+    param([string]$Path)
+
+    if ([string]::IsNullOrWhiteSpace($Path)) {
+        return $Path
+    }
+
+    if ($Path.StartsWith($script:DesktopPath, [System.StringComparison]::OrdinalIgnoreCase)) {
+        return $Path.Replace($script:DesktopPath, "$env:USERPROFILE\Desktop")
+    }
+
+    if ($Path.StartsWith($script:UserProfile, [System.StringComparison]::OrdinalIgnoreCase)) {
+        return $Path.Replace($script:UserProfile, "$env:USERPROFILE")
+    }
+
+    return $Path
+}
+
 function New-RecoveryReadme {
     param(
         [string]$Path,
@@ -120,32 +259,110 @@ Important:
 "@ | Set-Content -LiteralPath $Path -Encoding UTF8
 }
 
-function New-RepairReport {
-    param(
-        [string]$Path,
-        [string[]]$Actions
-    )
+function Get-ProcessSnapshotLines {
+    param([string[]]$Names)
 
-    $actionBlock = if ($Actions.Count -gt 0) {
-        ($Actions | ForEach-Object { "- $_" }) -join [Environment]::NewLine
-    } else {
-        "- No repair actions were needed."
+    $lines = New-Object System.Collections.Generic.List[string]
+    foreach ($name in $Names) {
+        $processes = Get-Process -Name $name -ErrorAction SilentlyContinue | Sort-Object Id
+        if (-not $processes) {
+            $lines.Add("${name}: not running") | Out-Null
+            continue
+        }
+
+        foreach ($process in $processes) {
+            $path = $null
+            try {
+                $path = $process.Path
+            } catch {
+                $path = $null
+            }
+
+            $wsMb = [math]::Round($process.WorkingSet64 / 1MB, 2)
+            $startText = "unknown"
+            try {
+                $startText = $process.StartTime.ToString("yyyy-MM-dd HH:mm:ss")
+            } catch {
+                $startText = "unavailable"
+            }
+
+            $line = "{0} pid={1} ws_mb={2} main_window={3} started={4}" -f $process.ProcessName, $process.Id, $wsMb, $process.MainWindowHandle, $startText
+            if (-not [string]::IsNullOrWhiteSpace($path)) {
+                $line = "$line path=$path"
+            }
+            $lines.Add($line) | Out-Null
+        }
     }
 
-    @"
-Codex Repair Report
-Created: $(Get-Date -Format 'yyyy-MM-dd HH:mm:ss zzz')
+    return $lines.ToArray()
+}
 
-Actions performed:
-$actionBlock
+function Get-RelevantApplicationEvents {
+    param([datetime]$StartTime)
 
-Repair scope:
-- Removed transient sqlite WAL/SHM files so Codex can rebuild them cleanly.
-- Cleared temp/cache folders that are safe to regenerate.
-- Cleared Electron renderer, code, GPU, and WebGPU caches that can contribute to UI stalls.
-- Optionally reset Windows clipboard state when requested.
-- Did not delete your primary .codex sessions, memories, auth, config, plugins, or skills.
-"@ | Set-Content -LiteralPath $Path -Encoding UTF8
+    $providers = @("Application Hang", "Windows Error Reporting", "Application Error")
+    $events = New-Object System.Collections.Generic.List[object]
+
+    foreach ($provider in $providers) {
+        try {
+            $providerEvents = Get-WinEvent -FilterHashtable @{
+                LogName = "Application"
+                StartTime = $StartTime
+                ProviderName = $provider
+            } -ErrorAction Stop
+
+            foreach ($event in $providerEvents) {
+                if ($event.Message -match "Codex\.exe|explorer\.exe|StartMenuExperienceHost|ShellExperienceHost|SearchHost|TextInputHost|svchost\.exe") {
+                    $events.Add($event) | Out-Null
+                }
+            }
+        } catch {
+            continue
+        }
+    }
+
+    return @($events | Sort-Object TimeCreated -Descending | Select-Object -First 30)
+}
+
+function Format-EventSummary {
+    param($Event)
+
+    $lines = @($Event.Message -split "`r?`n" | Where-Object { -not [string]::IsNullOrWhiteSpace($_) })
+    $snippet = ($lines | Select-Object -First 5) -join " | "
+    return "[{0}] {1} #{2} {3}" -f $Event.TimeCreated.ToString("yyyy-MM-dd HH:mm:ss"), $Event.ProviderName, $Event.Id, $snippet
+}
+
+function Export-ShellDiagnosticsSnapshot {
+    param(
+        [string]$Path,
+        [string]$Stage
+    )
+
+    $divider = "=" * 78
+    $content = New-Object System.Collections.Generic.List[string]
+    $content.Add($divider) | Out-Null
+    $content.Add("Stage: $Stage") | Out-Null
+    $content.Add("Captured: $(Get-Date -Format 'yyyy-MM-dd HH:mm:ss zzz')") | Out-Null
+    $content.Add("") | Out-Null
+    $content.Add("Relevant processes:") | Out-Null
+
+    foreach ($line in (Get-ProcessSnapshotLines -Names ($script:ShellProcessNames + $script:CodexProcessNames))) {
+        $content.Add("- $line") | Out-Null
+    }
+
+    $content.Add("") | Out-Null
+    $content.Add("Recent relevant Application log events:") | Out-Null
+    $events = Get-RelevantApplicationEvents -StartTime (Get-Date).AddDays(-2)
+    if ($events.Count -eq 0) {
+        $content.Add("- none found in the last 48 hours") | Out-Null
+    } else {
+        foreach ($event in $events) {
+            $content.Add("- $(Format-EventSummary -Event $event)") | Out-Null
+        }
+    }
+
+    $content.Add("") | Out-Null
+    Add-Content -LiteralPath $Path -Value $content -Encoding UTF8
 }
 
 function Invoke-ClipboardReset {
@@ -197,18 +414,18 @@ function New-BackupBundle {
 
     $sources = @(
         @{
-            Source = "C:\Users\anden\.codex"
+            Source = $script:CodexRoot
             Destination = Join-Path $payloadRoot ".codex"
         },
         @{
-            Source = "C:\Users\anden\AppData\Local\OpenAI\Codex"
+            Source = Join-Path $script:LocalAppData "OpenAI\Codex"
             Destination = Join-Path $payloadRoot "Local_OpenAI\Codex"
         }
     )
 
     if ($IncludePackageState) {
         $sources += @{
-            Source = "C:\Users\anden\AppData\Local\Packages\OpenAI.Codex_2p2nqsd0c76g0"
+            Source = $script:PackageRoot
             Destination = Join-Path $payloadRoot "Packages\OpenAI.Codex_2p2nqsd0c76g0"
         }
     }
@@ -234,22 +451,216 @@ function New-BackupBundle {
     }
 }
 
+function Invoke-OversizedSessionQuarantine {
+    param(
+        [string]$DesktopPath,
+        [int]$ThresholdMB,
+        [System.Collections.Generic.List[string]]$Actions
+    )
+
+    $thresholdBytes = $ThresholdMB * 1MB
+    $candidates = New-Object System.Collections.Generic.List[System.IO.FileInfo]
+    foreach ($root in @((Join-Path $script:CodexRoot "sessions"), (Join-Path $script:CodexRoot "archived_sessions"))) {
+        if (-not (Test-Path -LiteralPath $root)) {
+            continue
+        }
+
+        foreach ($file in (Get-ChildItem -LiteralPath $root -Recurse -File -Filter "*.jsonl" -ErrorAction SilentlyContinue | Where-Object { $_.Length -gt $thresholdBytes })) {
+            $candidates.Add($file) | Out-Null
+        }
+    }
+
+    if ($candidates.Count -eq 0) {
+        $Actions.Add("found no Codex session files over ${ThresholdMB} MB to quarantine") | Out-Null
+        return $null
+    }
+
+    $stamp = Get-Date -Format "yyyyMMdd_HHmmss"
+    $quarantineRoot = Join-Path $DesktopPath "Codex_Oversized_Session_Quarantine_$stamp"
+    Ensure-Directory -Path $quarantineRoot
+
+    foreach ($file in $candidates) {
+        $relative = $file.FullName.Substring($script:CodexRoot.Length).TrimStart("\")
+        $destination = Join-Path $quarantineRoot $relative
+        Ensure-Directory -Path (Split-Path -Parent $destination)
+        Move-Item -LiteralPath $file.FullName -Destination $destination -Force
+        $sizeMb = [math]::Round($file.Length / 1MB, 2)
+        $Actions.Add("cold-quarantined oversized session $($file.FullName) (${sizeMb} MB) to $destination") | Out-Null
+    }
+
+    return $quarantineRoot
+}
+
+function Invoke-AppShellReset {
+    param([System.Collections.Generic.List[string]]$Actions)
+
+    if (-not (Test-Path -LiteralPath $script:RoamingCodexRoot)) {
+        $Actions.Add("Codex app-shell cache root was not present: $script:RoamingCodexRoot") | Out-Null
+        return
+    }
+
+    $resetDirectories = @(
+        (Join-Path $script:RoamingCodexRoot "Cache"),
+        (Join-Path $script:RoamingCodexRoot "Code Cache"),
+        (Join-Path $script:RoamingCodexRoot "GPUCache"),
+        (Join-Path $script:RoamingCodexRoot "DawnGraphiteCache"),
+        (Join-Path $script:RoamingCodexRoot "DawnWebGPUCache"),
+        (Join-Path $script:RoamingCodexRoot "Shared Dictionary\cache"),
+        (Join-Path $script:RoamingCodexRoot "blob_storage"),
+        (Join-Path $script:RoamingCodexRoot "Local Storage"),
+        (Join-Path $script:RoamingCodexRoot "Session Storage"),
+        (Join-Path $script:RoamingCodexRoot "sentry"),
+        (Join-Path $script:RoamingCodexRoot "Crashpad")
+    )
+
+    foreach ($directory in $resetDirectories) {
+        if (Remove-ChildrenIfPresent -Path $directory) {
+            $Actions.Add("cleared Codex app-shell directory $directory") | Out-Null
+        }
+    }
+
+    $resetFiles = @(
+        (Join-Path $script:RoamingCodexRoot "DIPS"),
+        (Join-Path $script:RoamingCodexRoot "DIPS-wal"),
+        (Join-Path $script:RoamingCodexRoot "SharedStorage"),
+        (Join-Path $script:RoamingCodexRoot "SharedStorage-wal"),
+        (Join-Path $script:RoamingCodexRoot "Local State"),
+        (Join-Path $script:RoamingCodexRoot "Preferences"),
+        (Join-Path $script:RoamingCodexRoot "lockfile")
+    )
+
+    foreach ($file in $resetFiles) {
+        if (Remove-FileIfPresent -Path $file) {
+            $Actions.Add("removed Codex app-shell file $file") | Out-Null
+        }
+    }
+}
+
+function Invoke-WindowsShellRecovery {
+    param([System.Collections.Generic.List[string]]$Actions)
+
+    foreach ($processName in @("StartMenuExperienceHost", "ShellExperienceHost", "SearchHost", "TextInputHost")) {
+        foreach ($process in (Get-Process -Name $processName -ErrorAction SilentlyContinue)) {
+            try {
+                Stop-Process -Id $process.Id -Force -ErrorAction Stop
+                $Actions.Add("restarted Windows shell helper $processName process $($process.Id)") | Out-Null
+            } catch {
+                $Actions.Add("Windows shell helper restart skipped for $processName process $($process.Id): $($_.Exception.Message)") | Out-Null
+            }
+        }
+    }
+
+    $explorerWasRunning = $false
+    foreach ($process in (Get-Process -Name explorer -ErrorAction SilentlyContinue)) {
+        $explorerWasRunning = $true
+        try {
+            if ($process.MainWindowHandle -ne 0) {
+                $null = $process.CloseMainWindow()
+            }
+        } catch {
+        }
+    }
+
+    if ($explorerWasRunning) {
+        Start-Sleep -Seconds 2
+        foreach ($process in (Get-Process -Name explorer -ErrorAction SilentlyContinue)) {
+            try {
+                Stop-Process -Id $process.Id -Force -ErrorAction Stop
+                $Actions.Add("stopped explorer.exe process $($process.Id) for shell rebuild") | Out-Null
+            } catch {
+                $Actions.Add("explorer.exe stop skipped for $($process.Id): $($_.Exception.Message)") | Out-Null
+            }
+        }
+    } else {
+        $Actions.Add("explorer.exe was not running before shell recovery; starting a fresh shell instance") | Out-Null
+    }
+
+    Start-Sleep -Seconds 2
+    Start-Process explorer.exe
+    $Actions.Add("started explorer.exe to rebuild the Windows taskbar and Start menu shell") | Out-Null
+}
+
+function New-RepairReport {
+    param(
+        [string]$Path,
+        [string[]]$Actions,
+        [string]$DiagnosticsPath,
+        [string]$QuarantinePath
+    )
+
+    $actionBlock = if ($Actions.Count -gt 0) {
+        ($Actions | ForEach-Object { "- $_" }) -join [Environment]::NewLine
+    } else {
+        "- No repair actions were needed."
+    }
+
+    $extras = New-Object System.Collections.Generic.List[string]
+    if (-not [string]::IsNullOrWhiteSpace($DiagnosticsPath)) {
+        $extras.Add("- Shell diagnostics: $(Get-DisplayPath -Path $DiagnosticsPath)") | Out-Null
+    }
+    if (-not [string]::IsNullOrWhiteSpace($QuarantinePath)) {
+        $extras.Add("- Oversized-session quarantine: $(Get-DisplayPath -Path $QuarantinePath)") | Out-Null
+    }
+
+    $extraBlock = if ($extras.Count -gt 0) {
+        ($extras | ForEach-Object { $_ }) -join [Environment]::NewLine
+    } else {
+        "- No additional artifacts were created."
+    }
+
+    @"
+Codex Repair Report
+Created: $(Get-Date -Format 'yyyy-MM-dd HH:mm:ss zzz')
+
+Actions performed:
+$actionBlock
+
+Artifacts:
+$extraBlock
+
+Repair scope:
+- Removed transient sqlite WAL/SHM files so Codex can rebuild them cleanly.
+- Cleared temp/cache folders that are safe to regenerate.
+- Cleared Electron renderer, code, GPU, and WebGPU caches that can contribute to UI stalls.
+- Can cold-quarantine oversized session files outside .codex after a backup.
+- Can reset Codex app-shell state that may keep bad sidebar, pin, or window state alive.
+- Can restart the Windows taskbar and Start-menu shell if shell recovery is requested.
+- Can capture shell/Codex hang evidence into a lightweight diagnostics log for the next freeze.
+- Optionally resets Windows clipboard state when requested.
+- Did not delete your primary .codex memories, auth, config, plugins, or skills.
+"@ | Set-Content -LiteralPath $Path -Encoding UTF8
+}
+
 function Invoke-SafeRepair {
     param(
         [string]$DesktopPath,
-        [bool]$ResetClipboardState
+        [bool]$ResetClipboardState,
+        [bool]$QuarantineSessions,
+        [int]$ThresholdMB,
+        [bool]$ResetCodexAppShellState,
+        [bool]$RecoverWindowsShell,
+        [bool]$CaptureDiagnostics
     )
 
     $stamp = Get-Date -Format "yyyyMMdd_HHmmss"
     $repairRoot = Join-Path $DesktopPath "Codex_Repair_Report_$stamp"
     Ensure-Directory -Path $repairRoot
+
     $actions = New-Object System.Collections.Generic.List[string]
+    $diagnosticsPath = $null
+    $quarantineRoot = $null
+
+    if ($CaptureDiagnostics) {
+        $diagnosticsPath = Join-Path $repairRoot "SHELL_DIAGNOSTICS.txt"
+        Export-ShellDiagnosticsSnapshot -Path $diagnosticsPath -Stage "Before repair"
+        $actions.Add("captured pre-repair shell diagnostics to $diagnosticsPath") | Out-Null
+    }
 
     $transientFiles = @(
-        "C:\Users\anden\.codex\logs_2.sqlite-shm",
-        "C:\Users\anden\.codex\logs_2.sqlite-wal",
-        "C:\Users\anden\.codex\state_5.sqlite-shm",
-        "C:\Users\anden\.codex\state_5.sqlite-wal"
+        (Join-Path $script:CodexRoot "logs_2.sqlite-shm"),
+        (Join-Path $script:CodexRoot "logs_2.sqlite-wal"),
+        (Join-Path $script:CodexRoot "state_5.sqlite-shm"),
+        (Join-Path $script:CodexRoot "state_5.sqlite-wal")
     )
 
     foreach ($file in $transientFiles) {
@@ -259,16 +670,16 @@ function Invoke-SafeRepair {
     }
 
     $transientDirs = @(
-        "C:\Users\anden\.codex\.tmp",
-        "C:\Users\anden\.codex\tmp",
-        "C:\Users\anden\AppData\Local\Packages\OpenAI.Codex_2p2nqsd0c76g0\TempState",
-        "C:\Users\anden\AppData\Local\Packages\OpenAI.Codex_2p2nqsd0c76g0\AC\Temp",
-        "C:\Users\anden\AppData\Local\Packages\OpenAI.Codex_2p2nqsd0c76g0\LocalCache\Roaming\Codex\Cache",
-        "C:\Users\anden\AppData\Local\Packages\OpenAI.Codex_2p2nqsd0c76g0\LocalCache\Roaming\Codex\Code Cache",
-        "C:\Users\anden\AppData\Local\Packages\OpenAI.Codex_2p2nqsd0c76g0\LocalCache\Roaming\Codex\GPUCache",
-        "C:\Users\anden\AppData\Local\Packages\OpenAI.Codex_2p2nqsd0c76g0\LocalCache\Roaming\Codex\DawnGraphiteCache",
-        "C:\Users\anden\AppData\Local\Packages\OpenAI.Codex_2p2nqsd0c76g0\LocalCache\Roaming\Codex\DawnWebGPUCache",
-        "C:\Users\anden\AppData\Local\Packages\OpenAI.Codex_2p2nqsd0c76g0\LocalCache\Roaming\Codex\Shared Dictionary\cache"
+        (Join-Path $script:CodexRoot ".tmp"),
+        (Join-Path $script:CodexRoot "tmp"),
+        (Join-Path $script:PackageRoot "TempState"),
+        (Join-Path $script:PackageRoot "AC\Temp"),
+        (Join-Path $script:RoamingCodexRoot "Cache"),
+        (Join-Path $script:RoamingCodexRoot "Code Cache"),
+        (Join-Path $script:RoamingCodexRoot "GPUCache"),
+        (Join-Path $script:RoamingCodexRoot "DawnGraphiteCache"),
+        (Join-Path $script:RoamingCodexRoot "DawnWebGPUCache"),
+        (Join-Path $script:RoamingCodexRoot "Shared Dictionary\cache")
     )
 
     foreach ($dir in $transientDirs) {
@@ -277,32 +688,46 @@ function Invoke-SafeRepair {
         }
     }
 
-    $localCacheRoot = "C:\Users\anden\AppData\Local\Packages\OpenAI.Codex_2p2nqsd0c76g0\LocalCache"
-    if (Test-Path -LiteralPath $localCacheRoot) {
-        $cacheTargets = @(
-            (Join-Path $localCacheRoot "Temp"),
-            (Join-Path $localCacheRoot "Local\Temp")
-        )
-        foreach ($cacheDir in $cacheTargets) {
-            if (Remove-ChildrenIfPresent -Path $cacheDir) {
-                $actions.Add("cleared cache directory $cacheDir") | Out-Null
-            }
+    $localCacheRoot = Join-Path $script:PackageRoot "LocalCache"
+    foreach ($cacheDir in @((Join-Path $localCacheRoot "Temp"), (Join-Path $localCacheRoot "Local\Temp"))) {
+        if (Remove-ChildrenIfPresent -Path $cacheDir) {
+            $actions.Add("cleared cache directory $cacheDir") | Out-Null
         }
+    }
+
+    if ($ResetCodexAppShellState) {
+        Invoke-AppShellReset -Actions $actions
+    }
+
+    if ($QuarantineSessions) {
+        $quarantineRoot = Invoke-OversizedSessionQuarantine -DesktopPath $DesktopPath -ThresholdMB $ThresholdMB -Actions $actions
     }
 
     if ($ResetClipboardState) {
         Invoke-ClipboardReset -Actions $actions
     }
 
-    New-RepairReport -Path (Join-Path $repairRoot "REPAIR_REPORT.txt") -Actions $actions.ToArray()
+    if ($RecoverWindowsShell) {
+        Invoke-WindowsShellRecovery -Actions $actions
+    }
+
+    if ($CaptureDiagnostics) {
+        Export-ShellDiagnosticsSnapshot -Path $diagnosticsPath -Stage "After repair"
+        $actions.Add("captured post-repair shell diagnostics to $diagnosticsPath") | Out-Null
+    }
+
+    New-RepairReport -Path (Join-Path $repairRoot "REPAIR_REPORT.txt") -Actions $actions.ToArray() -DiagnosticsPath $diagnosticsPath -QuarantinePath $quarantineRoot
 
     return @{
         RepairRoot = $repairRoot
         Actions = $actions.ToArray()
+        DiagnosticsPath = $diagnosticsPath
+        QuarantinePath = $quarantineRoot
     }
 }
 
-Stop-CodexIfRequested -Force:$ForceCloseCodex
+$startupActions = New-Object System.Collections.Generic.List[string]
+Stop-CodexIfRequested -Force:$ForceCloseCodex -Actions $startupActions
 Ensure-Directory -Path $OutputDirectory
 
 $includePackageState = -not $SkipPackageState
@@ -316,14 +741,37 @@ switch ($Mode) {
     }
     "Repair" {
         Write-Step "Running safe Codex repair."
-        $repairResult = Invoke-SafeRepair -DesktopPath $OutputDirectory -ResetClipboardState:$ResetClipboard
+        $repairResult = Invoke-SafeRepair `
+            -DesktopPath $OutputDirectory `
+            -ResetClipboardState:$ResetClipboard `
+            -QuarantineSessions:$QuarantineOversizedSessions `
+            -ThresholdMB $OversizedSessionThresholdMB `
+            -ResetCodexAppShellState:$ResetAppShellState `
+            -RecoverWindowsShell:$RepairWindowsShell `
+            -CaptureDiagnostics:$CaptureShellDiagnostics
     }
     "BackupAndRepair" {
         Write-Step "Creating recovery bundle before repair."
         $backupResult = New-BackupBundle -DesktopPath $OutputDirectory -IncludePackageState:$includePackageState
         Write-Step "Running safe Codex repair."
-        $repairResult = Invoke-SafeRepair -DesktopPath $OutputDirectory -ResetClipboardState:$ResetClipboard
+        $repairResult = Invoke-SafeRepair `
+            -DesktopPath $OutputDirectory `
+            -ResetClipboardState:$ResetClipboard `
+            -QuarantineSessions:$QuarantineOversizedSessions `
+            -ThresholdMB $OversizedSessionThresholdMB `
+            -ResetCodexAppShellState:$ResetAppShellState `
+            -RecoverWindowsShell:$RepairWindowsShell `
+            -CaptureDiagnostics:$CaptureShellDiagnostics
     }
+}
+
+if ($startupActions.Count -gt 0 -and $repairResult) {
+    $repairResult.Actions = @($startupActions.ToArray() + $repairResult.Actions)
+    New-RepairReport `
+        -Path (Join-Path $repairResult.RepairRoot "REPAIR_REPORT.txt") `
+        -Actions $repairResult.Actions `
+        -DiagnosticsPath $repairResult.DiagnosticsPath `
+        -QuarantinePath $repairResult.QuarantinePath
 }
 
 $result = [ordered]@{
@@ -338,6 +786,12 @@ if ($backupResult) {
 if ($repairResult) {
     $result["repair_report_dir"] = $repairResult.RepairRoot
     $result["repair_actions"] = $repairResult.Actions
+    if ($repairResult.DiagnosticsPath) {
+        $result["shell_diagnostics"] = $repairResult.DiagnosticsPath
+    }
+    if ($repairResult.QuarantinePath) {
+        $result["oversized_session_quarantine"] = $repairResult.QuarantinePath
+    }
 }
 
 $result | ConvertTo-Json -Depth 4


### PR DESCRIPTION
## Summary

Updates FB-043 Release-Debt Marker Repair For FB-042.

## What Changed

### Changes

- remove the stale duplicate release-debt owner marker from Docs/prebeta_roadmap.md
- preserve FB-042 as the only merged-unreleased release-debt owner for
1.6.7-prebeta
- harden validator coverage so conflicting duplicate release-debt-owner markers fail
- record that repairs default to new
eature/ branches and that repair-only feature-branch existence does not imply Branch Readiness admission or active branch truth

### Changes

- remove the stale duplicate release-debt owner marker from Docs/prebeta_roadmap.md
- preserve FB-042 as the only merged-unreleased release-debt owner for
1.6.7-prebeta
- harden validator coverage so conflicting duplicate release-debt-owner markers fail
- record that repairs default to new
eature/ branches and that repair-only feature-branch existence does not imply Branch Readiness admission or active branch truth
