### PR TITLE
FB-047 Active-Session Relaunch Decline Preservation

### DIFF
--- a/Docs/Main.md
+++ b/Docs/Main.md
@@ -140,6 +140,7 @@ Rules:
 Use these for promoted work that needs a stable feature-state, branch-local validation/evidence record, active seam trail, durable artifact/reuse history, and closure history:
 
 - `Docs/workstreams/index.md`
+- `Docs/workstreams/FB-047_active_session_relaunch_decline_preservation.md`
 - `Docs/workstreams/FB-046_active_session_relaunch_reacquisition.md`
 - `Docs/workstreams/FB-045_active_session_relaunch_outcome_refinement.md`
 - `Docs/workstreams/FB-044_boot_desktop_handoff_outcome_refinement.md`

--- a/Docs/branch_records/feature_fb_047_active_session_relaunch_decline_preservation.md
+++ b/Docs/branch_records/feature_fb_047_active_session_relaunch_decline_preservation.md
@@ -13,6 +13,7 @@ This branch record owns FB-047 `Branch Readiness` while the backlog item remains
 This pass closes FB-046 post-release canon on the next legal `feature/` branch surface, advances latest public prerelease truth to `v1.6.10-prebeta`, clears merged-unreleased release debt, and admits the first bounded runtime/user-facing relaunch-decline preservation slice without promoting FB-047 before `Workstream`.
 
 Historical traceability note: `feature/fb-046-post-merge-canon-sync` was a bounded repair-only post-merge canon-sync branch only and did not imply FB-046 or FB-047 Branch Readiness admission or active branch truth.
+Historical traceability note: Branch Readiness is complete historical proof only. Active execution truth now lives in `Docs/workstreams/FB-047_active_session_relaunch_decline_preservation.md`.
 
 ## Current Phase
 
@@ -20,17 +21,17 @@ Historical traceability note: `feature/fb-046-post-merge-canon-sync` was a bound
 
 ## Phase Status
 
-- Repo State: `Active Branch`
-- Active Branch: `feature/fb-047-active-session-relaunch-decline-preservation`
-- Active Branch Authority Record: `Docs/branch_records/feature_fb_047_active_session_relaunch_decline_preservation.md`
+- Repo State: `Historical Traceability`
+- Historical Branch: `feature/fb-047-active-session-relaunch-decline-preservation`
+- Historical posture: `Branch Readiness completed before promotion; active execution truth moved to Docs/workstreams/FB-047_active_session_relaunch_decline_preservation.md.`
 - Latest Public Prerelease: `v1.6.10-prebeta`
 - Latest Public Release Commit: `36cf07495dc8e239b20b11afb5194355b77ffd8b`
 - Latest Public Prerelease Publication: `https://github.com/GiribaldiTTV/Nexus-Desktop-AI/releases/tag/v1.6.10-prebeta`
 - Latest Public Prerelease Title: `Pre-Beta v1.6.10`
 - FB-046 is now `Released / Closed` historical proof in `v1.6.10-prebeta`.
 - Merged-unreleased release debt is clear after publication, validation, and post-release canon closure.
-- FB-047 Branch Readiness is active on this branch, and the first bounded relaunch-decline preservation slice is admitted.
-- Active seam: `None.`
+- FB-047 Branch Readiness is complete historical proof, and active execution truth now lives in the promoted canonical workstream doc on this same branch.
+- Active seam: `None.` This record is now preserved historical Branch Readiness truth.
 
 ## Branch Class
 

--- a/Docs/branch_records/feature_fb_047_active_session_relaunch_decline_preservation.md
+++ b/Docs/branch_records/feature_fb_047_active_session_relaunch_decline_preservation.md
@@ -1,0 +1,203 @@
+# Branch Authority Record: feature/fb-047-active-session-relaunch-decline-preservation
+
+## Branch Identity
+
+- Branch: `feature/fb-047-active-session-relaunch-decline-preservation`
+- Workstream: `FB-047`
+- Branch Class: `implementation`
+
+## Purpose / Why It Exists
+
+This branch record owns FB-047 `Branch Readiness` while the backlog item remains `Registry-only` and before a promoted canonical workstream record exists.
+
+This pass closes FB-046 post-release canon on the next legal `feature/` branch surface, advances latest public prerelease truth to `v1.6.10-prebeta`, clears merged-unreleased release debt, and admits the first bounded runtime/user-facing relaunch-decline preservation slice without promoting FB-047 before `Workstream`.
+
+Historical traceability note: `feature/fb-046-post-merge-canon-sync` was a bounded repair-only post-merge canon-sync branch only and did not imply FB-046 or FB-047 Branch Readiness admission or active branch truth.
+
+## Current Phase
+
+- Phase: `Branch Readiness`
+
+## Phase Status
+
+- Repo State: `Active Branch`
+- Active Branch: `feature/fb-047-active-session-relaunch-decline-preservation`
+- Active Branch Authority Record: `Docs/branch_records/feature_fb_047_active_session_relaunch_decline_preservation.md`
+- Latest Public Prerelease: `v1.6.10-prebeta`
+- Latest Public Release Commit: `36cf07495dc8e239b20b11afb5194355b77ffd8b`
+- Latest Public Prerelease Publication: `https://github.com/GiribaldiTTV/Nexus-Desktop-AI/releases/tag/v1.6.10-prebeta`
+- Latest Public Prerelease Title: `Pre-Beta v1.6.10`
+- FB-046 is now `Released / Closed` historical proof in `v1.6.10-prebeta`.
+- Merged-unreleased release debt is clear after publication, validation, and post-release canon closure.
+- FB-047 Branch Readiness is active on this branch, and the first bounded relaunch-decline preservation slice is admitted.
+- Active seam: `None.`
+
+## Branch Class
+
+- `implementation`
+
+## Blockers
+
+None. Post-release closure prerequisites are satisfied, and the first bounded relaunch-decline preservation slice is admitted.
+
+## Entry Basis
+
+- `v1.6.10-prebeta` is published and validated at `https://github.com/GiribaldiTTV/Nexus-Desktop-AI/releases/tag/v1.6.10-prebeta` on target commit `36cf07495dc8e239b20b11afb5194355b77ffd8b`.
+- FB-046 is live released, and release debt is clear after publication, validation, and post-release canon closure.
+- Updated-main revalidation is green after FB-046 Release Readiness and live release validation.
+- The current code already contains the relaunch prompt, the decline button path, and the incoming-launch early exit when the active session is kept, but the repo does not yet prove that declining replacement preserves the settled active session, keeps single-instance ownership with that session, and terminates the incoming launch truthfully without false replacement-session markers.
+- A new `feature/` branch is the legal active surface because `main` is protected and no active implementation branch remains.
+
+## Exit Criteria
+
+- latest public prerelease truth advances to `v1.6.10-prebeta` in active canon
+- FB-046 closes as released historical truth, and merged-unreleased release debt clears
+- FB-047 owns a bounded runtime/user-facing slice on a normal `feature/` branch while remaining `Registry-only` during Branch Readiness
+- the admitted slice records exact affected paths, validation coverage, rollback conditions, and same-branch backlog-completion posture
+- Branch Readiness resolves without widening into `main.py`, `Audio/`, `logs/`, `jarvis_visual/`, installer work, or broader boot-orchestrator implementation
+
+## Rollback Target
+
+- `Branch Readiness`
+
+## Next Legal Phase
+
+- `Workstream`
+
+## Branch Objective
+
+- close FB-046 post-release canon on the next legal active branch surface
+- admit the smallest runtime-bearing FB-047 slice that proves declined relaunch preserves the settled active session and truthfully terminates the incoming launch
+- preserve selected-only Branch Readiness truth until promotion is warranted by actual Workstream execution
+
+## Target End-State
+
+- current-state canon shows FB-046 as `Released / Closed` historical proof in `v1.6.10-prebeta`
+- FB-047 remains selected-only on this branch until `Workstream` begins
+- `Workstream` can start on real relaunch-decline preservation proof instead of a vague future-planning label
+- same-branch backlog completion remains the default unless only future-dependent blockers remain
+
+## Backlog Completion Strategy
+
+Branch Completion Goal: `Complete FB-047 on this same branch unless only future-dependent blockers remain after the remaining implementable relaunch-decline preservation work is exhausted.`
+Known Future-Dependent Blockers: `None proven during Branch Readiness.`
+Branch Closure Rule: `Do not leave Workstream after WS-1 while more implementable FB-047 work remains; exit Workstream only when Backlog Completion State becomes Implemented Complete or Implemented Complete Except Future Dependency.`
+
+## Affected Surface Ownership
+
+- `desktop/single_instance.py`: relaunch prompt outcome handling, harness-only decline path, and single-instance ownership truth at the conflict prompt boundary
+- `desktop/orin_desktop_launcher.pyw`: truthful incoming-launch decline classification, active-session preservation breadcrumbs, and incoming-launch termination behavior
+- `desktop/orin_desktop_main.py`: current-session relaunch-receipt absence and settled-session preservation breadcrumbs if minimal runtime proof needs an explicit renderer-side marker
+- `dev/orin_desktop_entrypoint_validation.py`: reusable production-path proof owner for declined relaunch, preserved active-session ownership, and incoming-launch truthful exit
+- `dev/orin_boot_transition_verification.py`: reusable explicit dev-boot proof owner if decline-path lifecycle truth must stay aligned across proof families
+
+## Expected Seam Families And Risk Classes
+
+- relaunch-decline prompt outcome family; risk class: incoming launch may still collapse into a generic already-running skip without proving why that exit is correct
+- active-session preservation family; risk class: the settled active session may remain preserved in reality but unproven in durable repo evidence
+- single-instance ownership family; risk class: the repo may not prove that the active session kept sole ownership while the incoming launch exited
+- validation alignment family; risk class: accepted and declined relaunch paths may diverge on lifecycle truth or falsely share replacement-session success markers
+
+## Planning-Loop Guardrail
+
+Implementation Delta Class: `runtime/user-facing`
+Docs-Only Workstream: `No`
+Planning-Loop Bypass User Approval: `None`
+Planning-Loop Bypass Reason: `None`
+
+- FB-047 is an implementation branch and this Branch Readiness pass admits a real runtime-bearing slice instead of a planning-only continuation.
+
+## Slice Continuation Policy
+
+Slice Continuation Default: `Same-branch backlog completion`
+Backlog-Split User Approval: `None`
+Backlog-Split Reason: `None`
+
+- WS-1 is the first admitted FB-047 slice, not a branch cap.
+- Additional FB-047 slices should continue on this branch whenever they stay inside the same backlog item, branch class, scope family, and validation surface.
+- A bounded stop condition or explicit USER-approved split is required before stopping the branch after only WS-1.
+
+## Admitted Implementation Slice
+
+- Slice ID: `WS-1 declined relaunch incoming-launch truthful exit proof`
+- Goal: prove and refine end-to-end declined relaunch so declining replacement preserves the active settled session, keeps single-instance ownership with that session, and cleanly terminates the incoming launch without dual ownership or false replacement-session markers.
+- Runtime/User-Facing Delta: relaunch decline stops being a generic already-running skip and becomes an explicit preserved-session / truthful incoming-launch termination story.
+- Exact Affected Paths:
+  - `desktop/single_instance.py`
+  - `desktop/orin_desktop_launcher.pyw`
+  - `desktop/orin_desktop_main.py`
+  - `dev/orin_desktop_entrypoint_validation.py`
+  - `dev/orin_boot_transition_verification.py`
+- In-Scope Paths:
+  - `desktop/single_instance.py`
+  - `desktop/orin_desktop_launcher.pyw`
+  - `desktop/orin_desktop_main.py`
+  - `dev/orin_desktop_entrypoint_validation.py`
+  - `dev/orin_boot_transition_verification.py`
+  - direct canon updates required to keep released-state truth and active FB-047 Branch Readiness truth aligned
+- Out-Of-Scope Paths:
+  - `main.py`
+  - `Audio/`
+  - `logs/`
+  - `jarvis_visual/`
+  - installer, packaging, or shortcut-registration redesign
+  - broader boot-orchestrator implementation
+  - unrelated tray, task, or runtime UX expansion
+- Allowed Changes:
+  - bounded relaunch-decline prompt / guard / incoming-launch classification handling needed to prove preserved-session truth
+  - bounded launcher / renderer breadcrumbs needed to show that the active session remained the owner while the incoming launch exited
+  - bounded validator changes needed to assert declined relaunch truth without cleanup masking
+  - direct canon updates required to keep released-state and Branch Readiness truth correct
+- Prohibited Changes:
+  - no `main.py` ownership rewrite
+  - no `Audio/` rewiring
+  - no `logs/` ownership changes
+  - no `jarvis_visual/` relocation or reorganization
+  - no installer or shortcut-registration redesign
+  - no broader boot-orchestrator buildout
+
+## Validation Contract
+
+- run `python dev\orin_desktop_entrypoint_validation.py`
+- run `python dev\orin_boot_transition_verification.py`
+- run `python -m py_compile desktop\single_instance.py desktop\orin_desktop_launcher.pyw desktop\orin_desktop_main.py dev\orin_desktop_entrypoint_validation.py dev\orin_boot_transition_verification.py`
+- run `python dev\orin_branch_governance_validation.py`
+- run `git diff --check`
+- preserve proof that default launch, accepted relaunch, repeated launch, and explicit dev-boot paths remain green while declined relaunch becomes a first-class preserved-session proof surface
+- confirm the incoming launch terminates without false replacement-session success markers and that the active settled session remains the sole owner throughout the decline lane
+
+## Rollback Conditions
+
+- rollback if the already-green desktop shortcut / VBS / launcher / renderer startup path regresses before or at authoritative settled
+- rollback if accepted relaunch proof regresses while proving decline-path preservation
+- rollback if active-session preservation or single-instance ownership truth becomes less explicit or depends on cleanup masking instead of real evidence
+- rollback if explicit dev-boot proof regresses or drifts away from the authoritative settled contract
+- rollback if the slice widens into `main.py`, `Audio/`, `logs/`, `jarvis_visual/`, installer behavior, or broader orchestrator work
+
+## User Test Summary Strategy
+
+- Branch Readiness itself does not change runtime behavior, so no manual User Test Summary artifact is required for this pass.
+- The admitted WS-1 slice is runtime/user-facing and touches the shipped relaunch path, so later Live Validation must classify real shortcut applicability and exact `## User Test Summary` status before green.
+- Existing real shortcut proof remains a baseline, but it will not replace later FB-047 live proof if the admitted slice materially changes relaunch-decline behavior.
+
+## Later-Phase Expectations
+
+- Workstream must begin with the admitted WS-1 declined relaunch incoming-launch truthful exit proof slice and keep same-branch backlog completion as the default for any remaining FB-047 slices.
+- Hardening must pressure-test rapid decline timing, repeated decline attempts, accepted-versus-declined relaunch cross-path truth, and hidden coupling around single-instance cleanup versus preserved-session proof.
+- Live Validation must classify real shortcut applicability, validate production-path and explicit dev-boot proof on the updated lane, and record exact User Test Summary status.
+- PR Readiness must package FB-047 as a real runtime/user-facing relaunch-decline preservation lane, not as a docs-only successor label.
+
+## Initial Workstream Seam Sequence
+
+Seam 1: `WS-1 declined relaunch incoming-launch truthful exit proof`
+
+- Goal: refine and prove the declined relaunch path end to end so the active session remains the owner and the incoming launch exits truthfully.
+- Scope: bounded prompt / ownership / incoming-launch termination proof across the admitted paths only.
+- Non-Includes: no `main.py` ownership rewrite, no audio changes, no log-root changes, no visual-asset moves, no installer redesign, and no broader boot-orchestrator implementation.
+
+## Active Seam
+
+Active seam: `None.`
+
+- Branch Readiness defines the admitted WS-1 slice but does not execute it.
+- `Workstream` is now the next legal phase.

--- a/Docs/branch_records/index.md
+++ b/Docs/branch_records/index.md
@@ -47,10 +47,11 @@ Do not use this layer to replace:
 
 ## Active Branch Authority Records
 
-- `Docs/branch_records/feature_fb_047_active_session_relaunch_decline_preservation.md`
+- `None.`
 
 ## Historical Branch Authority Records
 
+- `Docs/branch_records/feature_fb_047_active_session_relaunch_decline_preservation.md`
 - `Docs/branch_records/feature_fb_046_active_session_relaunch_reacquisition.md`
 - `Docs/branch_records/feature_fb_045_active_session_relaunch_stability.md`
 - `Docs/branch_records/feature_fb_044_boot_desktop_handoff_outcome_refinement.md`

--- a/Docs/branch_records/index.md
+++ b/Docs/branch_records/index.md
@@ -47,7 +47,7 @@ Do not use this layer to replace:
 
 ## Active Branch Authority Records
 
-- `None.`
+- `Docs/branch_records/feature_fb_047_active_session_relaunch_decline_preservation.md`
 
 ## Historical Branch Authority Records
 

--- a/Docs/feature_backlog.md
+++ b/Docs/feature_backlog.md
@@ -76,8 +76,8 @@ Historical Live Validation State: Complete on `feature/fb-046-active-session-rel
 PR Readiness State: Historical proof complete on `feature/fb-046-active-session-relaunch-reacquisition`; PR #92 merged into `main` at `36cf07495dc8e239b20b11afb5194355b77ffd8b`.
 Release Execution State: `v1.6.10-prebeta` is live at https://github.com/GiribaldiTTV/Nexus-Desktop-AI/releases/tag/v1.6.10-prebeta on commit `36cf07495dc8e239b20b11afb5194355b77ffd8b`.
 Current Branch Objective: complete the full currently implementable FB-047 runtime/user-facing relaunch-decline preservation pass by proving repeated declined incoming launches preserve active ownership and exit truthfully.
-Next Legal Phase: Hardening.
-Active Workstream Chain: Release debt is clear; FB-047 is the active promoted workstream on `feature/fb-047-active-session-relaunch-decline-preservation`; WS-1 is complete and validated; `Backlog Completion State` is `Implemented Complete`; and `Hardening` is the next legal phase.
+Next Legal Phase: Live Validation.
+Active Workstream Chain: Release debt is clear; FB-047 is the active promoted workstream on `feature/fb-047-active-session-relaunch-decline-preservation`; WS-1 is complete and validated; H-1 is complete and green; `Backlog Completion State` is `Implemented Complete`; and `Live Validation` is the next legal phase.
 
 ## Backlog Governance Sync
 
@@ -97,7 +97,7 @@ Open-candidate priority review:
 - FB-046 is now Released / Closed in `v1.6.10-prebeta`.
 - FB-047 is now the active promoted workstream on `feature/fb-047-active-session-relaunch-decline-preservation`.
 
-Current-branch clarity: latest public prerelease is `v1.6.10-prebeta`; FB-044 and FB-045 are released and closed in `v1.6.9-prebeta`; FB-046 is released and closed in `v1.6.10-prebeta`; release debt is clear; and FB-047 is now the active promoted workstream on `feature/fb-047-active-session-relaunch-decline-preservation`, with WS-1 complete, `Backlog Completion State` at `Implemented Complete`, and `Hardening` next.
+Current-branch clarity: latest public prerelease is `v1.6.10-prebeta`; FB-044 and FB-045 are released and closed in `v1.6.9-prebeta`; FB-046 is released and closed in `v1.6.10-prebeta`; release debt is clear; and FB-047 is now the active promoted workstream on `feature/fb-047-active-session-relaunch-decline-preservation`, with WS-1 complete, H-1 complete / green, `Backlog Completion State` at `Implemented Complete`, and `Live Validation` next.
 
 ## Registry Items
 
@@ -269,7 +269,7 @@ Branch: feature/fb-047-active-session-relaunch-decline-preservation
 Canonical Workstream Doc: Docs/workstreams/FB-047_active_session_relaunch_decline_preservation.md
 Historical Branch Readiness Record: Docs/branch_records/feature_fb_047_active_session_relaunch_decline_preservation.md
 Branch Readiness: Historical complete. The branch objective, target end-state, admitted WS-1 slice, validation contract, rollback conditions, and same-branch backlog-completion posture remain preserved in the historical branch-readiness record.
-Workstream: WS-1 `declined relaunch incoming-launch truthful exit proof` is complete and validated; harness-driven decline proof now records explicit preserved-session success markers instead of a generic already-running skip; repeated incoming declined launches preserve the active settled session and never emit replacement-session markers; `Backlog Completion State` is `Implemented Complete`; and `Hardening` is next.
+Workstream: WS-1 `declined relaunch incoming-launch truthful exit proof` is complete and validated; harness-driven decline proof now records explicit preserved-session success markers instead of a generic already-running skip; repeated incoming declined launches preserve the active settled session and never emit replacement-session markers; H-1 decline-lifecycle hardening is complete / green; `Backlog Completion State` is `Implemented Complete`; and `Live Validation` is next.
 Minimal Scope: Prove and refine the relaunch-decline lane across `desktop/single_instance.py`, `desktop/orin_desktop_launcher.pyw`, `desktop/orin_desktop_main.py`, and the minimum required reusable validator surfaces so declining replacement preserves the active settled session and cleanly terminates the incoming launch without dual ownership or false successor markers.
 Summary: Make relaunch decline as provable and truthful as accepted relaunch.
 Why it matters: The runtime should be just as explicit when the user keeps the current settled session as when the user accepts replacement.

--- a/Docs/feature_backlog.md
+++ b/Docs/feature_backlog.md
@@ -40,48 +40,55 @@ Historical note:
 
 [Docs/workstreams/FB-047_active_session_relaunch_decline_preservation.md](Docs/workstreams/FB-047_active_session_relaunch_decline_preservation.md)
 
-FB-044 Boot-to-desktop handoff outcome refinement, FB-045 Active-session relaunch outcome refinement, and FB-046 Active-session relaunch reacquisition and settled re-entry proof are now Released / Closed historical proof through `v1.6.10-prebeta`. Latest public prerelease truth is `v1.6.10-prebeta`; release debt is clear after publication, validation, and post-release canon closure; and FB-047 is now the active promoted workstream on `feature/fb-047-active-session-relaunch-decline-preservation`.
+FB-044 Boot-to-desktop handoff outcome refinement, FB-045 Active-session relaunch outcome refinement, and FB-046 Active-session relaunch reacquisition and settled re-entry proof are now Released / Closed historical proof through `v1.6.10-prebeta`. Latest public prerelease truth is `v1.6.10-prebeta`; after merge, FB-047 becomes the merged-unreleased release-debt owner for `v1.6.11-prebeta`; and FB-048 is now the selected-next `Registry-only` successor lane with branch not created.
 Released baseline truth is aligned: FB-040 is released and closed in `v1.6.0-prebeta`, FB-031 is released and closed in `v1.6.1-prebeta`, FB-032 is released and closed in `v1.6.2-prebeta`, FB-004 is released and closed in `v1.6.3-prebeta`, FB-015 plus FB-029 are released and closed in `v1.6.4-prebeta`, FB-030 is released and closed in `v1.6.5-prebeta`, FB-005 is released and closed in `v1.6.6-prebeta`, FB-042 is released and closed in `v1.6.7-prebeta`, FB-043 is released and closed in `v1.6.8-prebeta`, FB-044 plus FB-045 are released and closed in `v1.6.9-prebeta`, and FB-046 is now released and closed in `v1.6.10-prebeta`.
 FB-039 is released and closed in `v1.5.0-prebeta`.
 FB-038 remains released and closed in `v1.4.1-prebeta`.
 
 ## Current Branch Execution Posture
 
-Merged-Unreleased Release-Debt Owner: None.
-Repo State: Active Branch.
+Merged-Unreleased Release-Debt Owner: FB-047 Active-session relaunch decline session-preservation proof.
+Repo State: No Active Branch.
 Merged-Main Repo State: No Active Branch.
 Latest Public Prerelease: v1.6.10-prebeta.
 Latest Public Release Commit: 36cf07495dc8e239b20b11afb5194355b77ffd8b.
 Latest Public Prerelease Publication: https://github.com/GiribaldiTTV/Nexus-Desktop-AI/releases/tag/v1.6.10-prebeta.
 Latest Public Prerelease Title: Pre-Beta v1.6.10.
-Release Debt: Clear after v1.6.10-prebeta publication, validation, and post-release canon closure.
-Current Active Workstream: FB-047 Active-session relaunch decline session-preservation proof.
-Current Active Workstream Before Release: None.
-Current Active Branch: feature/fb-047-active-session-relaunch-decline-preservation.
+Release Debt: Active after merge until v1.6.11-prebeta is published, validated, and post-release canon closure completes.
+Current Active Workstream: None.
+Current Active Workstream Before Release: FB-047 Active-session relaunch decline session-preservation proof.
+Current Active Branch: None.
 Current Active Branch Authority Record: None.
-Current Active Canonical Workstream Doc: Docs/workstreams/FB-047_active_session_relaunch_decline_preservation.md.
-Historical Active Workstream Before Release: FB-046 Active-session relaunch reacquisition and settled re-entry proof.
-Earlier Historical Active Workstream Before Release: FB-045 Active-session relaunch outcome refinement.
-Historical Active Branch Before Release: feature/fb-046-active-session-relaunch-reacquisition.
-Earlier Historical Active Branch Before Release: feature/fb-045-active-session-relaunch-stability.
-Selected Next Workstream: None selected while FB-047 remains the active promoted workstream.
-Selected Next Record State: None.
-Selected Next Implementation Branch: None.
+Current Active Canonical Workstream Doc: None.
+Historical Active Workstream Before Release: FB-047 Active-session relaunch decline session-preservation proof.
+Earlier Historical Active Workstream Before Release: FB-046 Active-session relaunch reacquisition and settled re-entry proof.
+Historical Active Branch Before Release: feature/fb-047-active-session-relaunch-decline-preservation.
+Earlier Historical Active Branch Before Release: feature/fb-046-active-session-relaunch-reacquisition.
+Selected Next Workstream: FB-048 Active-session relaunch signal-failure and wait-timeout truth.
+Selected Next Record State: Registry-only.
+Selected Next Implementation Branch: Not created.
 Historical Repair-Only Branch Handling: `feature/fb-046-post-merge-canon-sync` was a bounded repair-only post-merge canon-sync `feature/` branch and did not imply Branch Readiness admission or active branch truth for FB-046.
-Historical Branch Readiness State: Complete on `feature/fb-046-active-session-relaunch-reacquisition`.
-Current Branch Readiness State: Historical proof complete on `feature/fb-047-active-session-relaunch-decline-preservation`; active execution truth now lives in the promoted canonical workstream doc.
-Historical Workstream State: FB-046 is Released / Closed in `v1.6.10-prebeta`; FB-044 and FB-045 remain Released / Closed historical proof in `v1.6.9-prebeta`.
-Historical Hardening State: Complete on `feature/fb-046-active-session-relaunch-reacquisition`.
-Historical Live Validation State: Complete on `feature/fb-046-active-session-relaunch-reacquisition`.
-PR Readiness State: Historical proof complete on `feature/fb-046-active-session-relaunch-reacquisition`; PR #92 merged into `main` at `36cf07495dc8e239b20b11afb5194355b77ffd8b`.
+Historical Branch Readiness State: Complete on `feature/fb-047-active-session-relaunch-decline-preservation`.
+Current Branch Readiness State: Not started for FB-048. Branch creation remains blocked until `v1.6.11-prebeta` is published and validated, updated `main` is revalidated, and FB-048 Branch Readiness admits the first bounded relaunch signal-failure and wait-timeout truth slice.
+Historical Workstream State: FB-047 is merge-target complete and will become the merged-unreleased release-debt owner for `v1.6.11-prebeta` after merge; FB-046 is Released / Closed in `v1.6.10-prebeta`; FB-044 and FB-045 remain Released / Closed historical proof in `v1.6.9-prebeta`.
+Historical Hardening State: Complete on `feature/fb-047-active-session-relaunch-decline-preservation`.
+Historical Live Validation State: Complete on `feature/fb-047-active-session-relaunch-decline-preservation`.
+PR Readiness State: Complete on `feature/fb-047-active-session-relaunch-decline-preservation`; PR-1 merge-target canon completeness, PR-2 selected-next successor lock, and PR-3 live PR creation plus validation are complete; PR number and live state are recorded in the canonical workstream doc.
 Release Execution State: `v1.6.10-prebeta` is live at https://github.com/GiribaldiTTV/Nexus-Desktop-AI/releases/tag/v1.6.10-prebeta on commit `36cf07495dc8e239b20b11afb5194355b77ffd8b`.
-Current Branch Objective: complete the full currently implementable FB-047 runtime/user-facing relaunch-decline preservation pass by proving repeated declined incoming launches preserve active ownership and exit truthfully.
-Next Legal Phase: PR Readiness.
-Active Workstream Chain: Release debt is clear; FB-047 is the active promoted workstream on `feature/fb-047-active-session-relaunch-decline-preservation`; WS-1 is complete and validated; H-1 is complete and green; LV-1 is complete and green; `Backlog Completion State` is `Implemented Complete`; and `PR Readiness` is the next legal phase.
+Release Target: v1.6.11-prebeta.
+Release Floor: patch prerelease.
+Version Rationale: FB-047 delivers a bounded runtime/user-facing relaunch-decline preservation refinement on the existing desktop startup family without opening a new product lane or materially expanded feature family, so the next release remains a patch prerelease.
+Release Scope: completed FB-047 WS-1 declined relaunch incoming-launch truthful exit proof, H-1 decline lifecycle hardening, LV-1 real desktop shortcut evidence, reusable validation evidence, merged-unreleased release-debt truth, and selected-next FB-048 successor lock for the bounded runtime/user-facing lane only.
+Release Artifacts: Tag v1.6.11-prebeta; release title Pre-Beta v1.6.11; rich Markdown release notes summarize the bounded FB-047 relaunch-decline preservation runtime/user-facing package, real shortcut evidence, and the FB-048 successor lane without repeating the release title inside the notes body, and GitHub-generated `## What's Changed` plus `**Full Changelog**:` must be included.
+Post-Release Truth: FB-047 is Released / Closed in `v1.6.11-prebeta` after publication and validation; release debt then clears; and FB-048 remains selected next, `Registry-only`, and branch-not-created until updated `main` is revalidated and Branch Readiness admits the first bounded relaunch signal-failure and wait-timeout truth slice.
+Next-Branch Creation Gate: After `v1.6.11-prebeta` is published and validated, updated `main` is revalidated, and FB-048 Branch Readiness admits the first bounded runtime/user-facing relaunch signal-failure and wait-timeout truth slice; branch creation remains blocked until then.
+Current Branch Objective: carry the merged-unreleased FB-047 relaunch-decline preservation package through `Release Readiness` on updated `main` after merge while preserving FB-048 as selected next and branch-not-created.
+Next Legal Phase: Release Readiness.
+Active Workstream Chain: FB-047 is merge-target complete and prepared to own merged-unreleased release debt for `v1.6.11-prebeta`; WS-1, H-1, and LV-1 are complete and green; PR-1 merge-target canon completeness, PR-2 selected-next successor lock, and PR-3 live PR creation plus validation are complete; FB-048 is selected next, `Registry-only`, and branch-not-created; and `Release Readiness` is the next legal phase after merge.
 
 ## Backlog Governance Sync
 
-Last Reviewed: 2026-04-26 during FB-047 Workstream.
+Last Reviewed: 2026-04-26 during FB-047 PR Readiness.
 
 Open-candidate priority review:
 
@@ -95,9 +102,10 @@ Open-candidate priority review:
 - FB-044 is now Released / Closed in `v1.6.9-prebeta`.
 - FB-045 is now Released / Closed in `v1.6.9-prebeta`.
 - FB-046 is now Released / Closed in `v1.6.10-prebeta`.
-- FB-047 is now the active promoted workstream on `feature/fb-047-active-session-relaunch-decline-preservation`.
+- FB-047 is merge-target complete and prepared to become the merged-unreleased release-debt owner for `v1.6.11-prebeta` after merge.
+- FB-048 is selected next, `Registry-only`, and branch-not-created.
 
-Current-branch clarity: latest public prerelease is `v1.6.10-prebeta`; FB-044 and FB-045 are released and closed in `v1.6.9-prebeta`; FB-046 is released and closed in `v1.6.10-prebeta`; release debt is clear; and FB-047 is now the active promoted workstream on `feature/fb-047-active-session-relaunch-decline-preservation`, with WS-1 complete, H-1 complete / green, LV-1 complete / green, `Backlog Completion State` at `Implemented Complete`, and `PR Readiness` next.
+Current-branch clarity: latest public prerelease is `v1.6.10-prebeta`; FB-044 and FB-045 are released and closed in `v1.6.9-prebeta`; FB-046 is released and closed in `v1.6.10-prebeta`; after merge, repo state is `No Active Branch`; FB-047 owns merged-unreleased release debt for `v1.6.11-prebeta`; and FB-048 remains selected next, `Registry-only`, and branch-not-created until post-release revalidation and Branch Readiness admission occur.
 
 ## Registry Items
 
@@ -252,27 +260,51 @@ Release Floor: patch prerelease
 Version Rationale: FB-046 delivers a bounded runtime/user-facing relaunch-reacquisition refinement on the existing desktop startup family without opening a new product lane or materially expanded feature family.
 Release Scope: completed FB-046 WS-1 accepted relaunch replacement-session settled re-entry proof, H-1 relaunch lifecycle hardening, LV-1 real desktop shortcut evidence, reusable validation evidence, PR package history, merged-unreleased release-debt truth, and selected-next FB-047 successor lock for the bounded runtime/user-facing lane only.
 Release Artifacts: Tag v1.6.10-prebeta; release title Pre-Beta v1.6.10; rich Markdown release notes summarize the bounded FB-046 relaunch-reacquisition runtime/user-facing package, real shortcut evidence, and the FB-047 successor lane without repeating the release title inside the notes body, and GitHub-generated `## What's Changed` plus `**Full Changelog**:` must be included.
-Post-Release Truth: FB-046 is Released / Closed in `v1.6.10-prebeta`; release debt is clear; and FB-047 now holds the selected-only active Branch Readiness lane on `feature/fb-047-active-session-relaunch-decline-preservation` until `Workstream` promotion begins.
+Post-Release Truth: FB-046 is Released / Closed in `v1.6.10-prebeta`; release debt is clear; and after merge FB-047 becomes the merged-unreleased release-debt owner for `v1.6.11-prebeta`, while FB-048 is selected next, `Registry-only`, and branch-not-created.
 Minimal Scope: Complete the bounded relaunch-reacquisition runtime/user-facing pass across `desktop/single_instance.py`, `desktop/orin_desktop_launcher.pyw`, `desktop/orin_desktop_main.py`, `dev/orin_boot_transition_verification.py`, and the minimum required reusable validator surfaces so a confirmed relaunch request closes the active session, reacquires the runtime guard, and returns the replacement session to authoritative settled state without widening into `main.py`, `Audio/`, `logs/`, `jarvis_visual/`, installer work, or broader boot-orchestrator scope.
 Summary: Turn accepted relaunch into a full replacement-session completion proof surface instead of a partial signal-and-exit story.
 Why it matters: The repo now proves who owns the runtime after relaunch, when the old session is truly gone, and when the replacement session has actually made it back to authoritative settled state.
 
 ### [ID: FB-047] Active-session relaunch decline session-preservation proof
 
-Status: In Progress
+Status: Merged unreleased (v1.6.11-prebeta)
 Record State: Promoted
 Priority: High
-Selection / Unblock: Selected during FB-046 PR Readiness because accepted relaunch is now fully proven, but the complementary decline path still lacked first-class proof that declining replacement preserves the settled active session, keeps single-instance ownership with that session, and terminates the incoming launch truthfully without dual ownership or false replacement-session markers. `v1.6.10-prebeta` is now published and validated, updated `main` is revalidated, Branch Readiness has completed, and Workstream promotion is now active on `feature/fb-047-active-session-relaunch-decline-preservation`.
-Next Workstream: Active current workstream. No successor is selected yet.
+Release Stage: merged unreleased
+Target Version: v1.6.11-prebeta
+Selection / Unblock: Promoted on `feature/fb-047-active-session-relaunch-decline-preservation`. WS-1 declined relaunch incoming-launch truthful exit proof is complete and validated, H-1 decline lifecycle hardening is complete and green, LV-1 live validation is complete and green with real shortcut evidence, startup and explicit dev-boot proof remain green, and PR Readiness packages this lane as the merged-unreleased release-debt owner for `v1.6.11-prebeta`.
+Next Workstream: Selected successor is FB-048 after this merged-unreleased release window clears.
 Branch Creation Gate: Historical complete. `v1.6.10-prebeta` was published and validated, updated `main` was revalidated, and FB-047 Branch Readiness admitted the bounded runtime/user-facing relaunch-decline preservation slice before promotion.
 Branch: feature/fb-047-active-session-relaunch-decline-preservation
 Canonical Workstream Doc: Docs/workstreams/FB-047_active_session_relaunch_decline_preservation.md
 Historical Branch Readiness Record: Docs/branch_records/feature_fb_047_active_session_relaunch_decline_preservation.md
 Branch Readiness: Historical complete. The branch objective, target end-state, admitted WS-1 slice, validation contract, rollback conditions, and same-branch backlog-completion posture remain preserved in the historical branch-readiness record.
-Workstream: WS-1 `declined relaunch incoming-launch truthful exit proof` is complete and validated; harness-driven decline proof now records explicit preserved-session success markers instead of a generic already-running skip; repeated incoming declined launches preserve the active settled session and never emit replacement-session markers; H-1 decline-lifecycle hardening is complete / green; LV-1 real desktop shortcut evidence and reusable decline-lifecycle proof are complete / green; `Backlog Completion State` is `Implemented Complete`; and `PR Readiness` is next.
+Workstream: WS-1 `declined relaunch incoming-launch truthful exit proof` is complete and validated; harness-driven decline proof now records explicit preserved-session success markers instead of a generic already-running skip; repeated incoming declined launches preserve the active settled session and never emit replacement-session markers; H-1 decline-lifecycle hardening is complete / green; LV-1 real desktop shortcut evidence and reusable decline-lifecycle proof are complete / green; `Backlog Completion State` is `Implemented Complete`; PR-1 merge-target canon completeness and PR-2 selected-next successor lock are complete on this branch; and after merge this lane becomes the merged-unreleased release-debt owner for `v1.6.11-prebeta`.
+Backlog Completion State: Implemented Complete
+PR Readiness: Complete. PR-1 merge-target canon completeness, PR-2 selected-next workstream selection, and PR-3 live PR creation plus validation are complete; the live PR number, URL, and merge state are recorded in the canonical workstream doc.
+Release Target: v1.6.11-prebeta
+Release Floor: patch prerelease
+Version Rationale: FB-047 delivers a bounded runtime/user-facing relaunch-decline preservation refinement on the existing desktop startup family without opening a new product lane or materially expanded feature family.
+Release Scope: completed FB-047 WS-1 declined relaunch incoming-launch truthful exit proof, H-1 decline lifecycle hardening, LV-1 real desktop shortcut evidence, reusable validation evidence, PR package history, merged-unreleased release-debt truth, and selected-next FB-048 successor lock for the bounded runtime/user-facing lane only.
+Release Artifacts: Tag v1.6.11-prebeta; release title Pre-Beta v1.6.11; rich Markdown release notes summarize the bounded FB-047 relaunch-decline preservation runtime/user-facing package, real shortcut evidence, and the FB-048 successor lane without repeating the release title inside the notes body, and GitHub-generated `## What's Changed` plus `**Full Changelog**:` must be included.
+Post-Release Truth: FB-047 is Released / Closed in `v1.6.11-prebeta` after publication and validation; release debt then clears; and FB-048 remains selected next, `Registry-only`, and branch-not-created until updated `main` is revalidated and Branch Readiness admits the first bounded relaunch signal-failure and wait-timeout truth slice.
 Minimal Scope: Prove and refine the relaunch-decline lane across `desktop/single_instance.py`, `desktop/orin_desktop_launcher.pyw`, `desktop/orin_desktop_main.py`, and the minimum required reusable validator surfaces so declining replacement preserves the active settled session and cleanly terminates the incoming launch without dual ownership or false successor markers.
 Summary: Make relaunch decline as provable and truthful as accepted relaunch.
 Why it matters: The runtime should be just as explicit when the user keeps the current settled session as when the user accepts replacement.
+
+### [ID: FB-048] Active-session relaunch signal-failure and wait-timeout truth
+
+Status: Selected next
+Record State: Registry-only
+Priority: High
+Selection / Unblock: Selected during FB-047 PR Readiness because accepted relaunch success and declined relaunch preservation are now first-class proven surfaces, but the accepted incoming-launch failure lane still lacks equivalent proof when relaunch signaling fails or the current session does not release before the reacquire wait deadline.
+Next Workstream: Selected
+Branch Creation Gate: After `v1.6.11-prebeta` is published and validated, updated `main` is revalidated, and FB-048 Branch Readiness admits the first bounded relaunch signal-failure and wait-timeout truth slice.
+Branch: Not created
+Branch Readiness: Not started. Must begin on a new `feature/` branch only after the gate above clears.
+Minimal Scope: Prove and refine the accepted relaunch failure lane across `desktop/single_instance.py`, `desktop/orin_desktop_launcher.pyw`, `desktop/orin_desktop_main.py`, and the minimum required reusable validator surfaces so relaunch-signal failure or reacquire wait-timeout preserves truthful ownership, emits explicit failure-path markers, and avoids false replacement-session or guard-transfer claims.
+Summary: Make accepted-but-unfinished relaunch failures as truthful as accepted and declined success paths.
+Why it matters: Users should get an explicit, proven outcome when relaunch was requested but the current session could not be signaled or did not release in time.
 
 ### [ID: FB-015] Boot and desktop phase-boundary model
 

--- a/Docs/feature_backlog.md
+++ b/Docs/feature_backlog.md
@@ -73,7 +73,7 @@ Current Branch Readiness State: Not started for FB-048. Branch creation remains 
 Historical Workstream State: FB-047 is merge-target complete and will become the merged-unreleased release-debt owner for `v1.6.11-prebeta` after merge; FB-046 is Released / Closed in `v1.6.10-prebeta`; FB-044 and FB-045 remain Released / Closed historical proof in `v1.6.9-prebeta`.
 Historical Hardening State: Complete on `feature/fb-047-active-session-relaunch-decline-preservation`.
 Historical Live Validation State: Complete on `feature/fb-047-active-session-relaunch-decline-preservation`.
-PR Readiness State: Complete on `feature/fb-047-active-session-relaunch-decline-preservation`; PR-1 merge-target canon completeness, PR-2 selected-next successor lock, and PR-3 live PR creation plus validation are complete; PR number and live state are recorded in the canonical workstream doc.
+PR Readiness State: Complete on `feature/fb-047-active-session-relaunch-decline-preservation`; PR-1 merge-target canon completeness, PR-2 selected-next successor lock, and PR-3 live PR creation plus validation are complete; PR #93 is open, non-draft, and mergeable.
 Release Execution State: `v1.6.10-prebeta` is live at https://github.com/GiribaldiTTV/Nexus-Desktop-AI/releases/tag/v1.6.10-prebeta on commit `36cf07495dc8e239b20b11afb5194355b77ffd8b`.
 Release Target: v1.6.11-prebeta.
 Release Floor: patch prerelease.
@@ -281,7 +281,7 @@ Historical Branch Readiness Record: Docs/branch_records/feature_fb_047_active_se
 Branch Readiness: Historical complete. The branch objective, target end-state, admitted WS-1 slice, validation contract, rollback conditions, and same-branch backlog-completion posture remain preserved in the historical branch-readiness record.
 Workstream: WS-1 `declined relaunch incoming-launch truthful exit proof` is complete and validated; harness-driven decline proof now records explicit preserved-session success markers instead of a generic already-running skip; repeated incoming declined launches preserve the active settled session and never emit replacement-session markers; H-1 decline-lifecycle hardening is complete / green; LV-1 real desktop shortcut evidence and reusable decline-lifecycle proof are complete / green; `Backlog Completion State` is `Implemented Complete`; PR-1 merge-target canon completeness and PR-2 selected-next successor lock are complete on this branch; and after merge this lane becomes the merged-unreleased release-debt owner for `v1.6.11-prebeta`.
 Backlog Completion State: Implemented Complete
-PR Readiness: Complete. PR-1 merge-target canon completeness, PR-2 selected-next workstream selection, and PR-3 live PR creation plus validation are complete; the live PR number, URL, and merge state are recorded in the canonical workstream doc.
+PR Readiness: Complete. PR-1 merge-target canon completeness, PR-2 selected-next workstream selection, and PR-3 live PR creation plus validation are complete; PR #93 is open, non-draft, and mergeable.
 Release Target: v1.6.11-prebeta
 Release Floor: patch prerelease
 Version Rationale: FB-047 delivers a bounded runtime/user-facing relaunch-decline preservation refinement on the existing desktop startup family without opening a new product lane or materially expanded feature family.

--- a/Docs/feature_backlog.md
+++ b/Docs/feature_backlog.md
@@ -37,27 +37,27 @@ Historical note:
 
 ## Active Promoted Workstream
 
-- `Docs/workstreams/FB-046_active_session_relaunch_reacquisition.md`
+`None.`
 
-FB-044 Boot-to-desktop handoff outcome refinement and FB-045 Active-session relaunch outcome refinement are now Released / Closed historical proof in `v1.6.9-prebeta`. Latest public prerelease truth is `v1.6.9-prebeta`; after merge, FB-046 becomes the merged-unreleased release-debt owner for `v1.6.10-prebeta`; and FB-047 is now the selected-next `Registry-only` successor lane with branch not created.
-Released baseline truth is aligned: FB-040 is released and closed in `v1.6.0-prebeta`, FB-031 is released and closed in `v1.6.1-prebeta`, FB-032 is released and closed in `v1.6.2-prebeta`, FB-004 is released and closed in `v1.6.3-prebeta`, FB-015 plus FB-029 are released and closed in `v1.6.4-prebeta`, FB-030 is released and closed in `v1.6.5-prebeta`, FB-005 is released and closed in `v1.6.6-prebeta`, FB-042 is released and closed in `v1.6.7-prebeta`, FB-043 is released and closed in `v1.6.8-prebeta`, and FB-044 plus FB-045 are now released and closed in `v1.6.9-prebeta`.
+FB-044 Boot-to-desktop handoff outcome refinement, FB-045 Active-session relaunch outcome refinement, and FB-046 Active-session relaunch reacquisition and settled re-entry proof are now Released / Closed historical proof through `v1.6.10-prebeta`. Latest public prerelease truth is `v1.6.10-prebeta`; release debt is clear after publication, validation, and post-release canon closure; and FB-047 now holds the selected-only active Branch Readiness lane on `feature/fb-047-active-session-relaunch-decline-preservation`.
+Released baseline truth is aligned: FB-040 is released and closed in `v1.6.0-prebeta`, FB-031 is released and closed in `v1.6.1-prebeta`, FB-032 is released and closed in `v1.6.2-prebeta`, FB-004 is released and closed in `v1.6.3-prebeta`, FB-015 plus FB-029 are released and closed in `v1.6.4-prebeta`, FB-030 is released and closed in `v1.6.5-prebeta`, FB-005 is released and closed in `v1.6.6-prebeta`, FB-042 is released and closed in `v1.6.7-prebeta`, FB-043 is released and closed in `v1.6.8-prebeta`, FB-044 plus FB-045 are released and closed in `v1.6.9-prebeta`, and FB-046 is now released and closed in `v1.6.10-prebeta`.
 FB-039 is released and closed in `v1.5.0-prebeta`.
 FB-038 remains released and closed in `v1.4.1-prebeta`.
 
 ## Current Branch Execution Posture
 
-Merged-Unreleased Release-Debt Owner: FB-046 Active-session relaunch reacquisition and settled re-entry proof.
-Repo State: No Active Branch.
+Merged-Unreleased Release-Debt Owner: None.
+Repo State: Active Branch.
 Merged-Main Repo State: No Active Branch.
-Latest Public Prerelease: v1.6.9-prebeta.
-Latest Public Release Commit: 348fd55b944435e3cae80b97acd0bb857fd65d56.
-Latest Public Prerelease Publication: https://github.com/GiribaldiTTV/Nexus-Desktop-AI/releases/tag/v1.6.9-prebeta.
-Latest Public Prerelease Title: Pre-Beta v1.6.9.
-Release Debt: Active after merge until v1.6.10-prebeta is published, validated, and post-release canon closure completes.
+Latest Public Prerelease: v1.6.10-prebeta.
+Latest Public Release Commit: 36cf07495dc8e239b20b11afb5194355b77ffd8b.
+Latest Public Prerelease Publication: https://github.com/GiribaldiTTV/Nexus-Desktop-AI/releases/tag/v1.6.10-prebeta.
+Latest Public Prerelease Title: Pre-Beta v1.6.10.
+Release Debt: Clear after v1.6.10-prebeta publication, validation, and post-release canon closure.
 Current Active Workstream: None.
-Current Active Workstream Before Release: FB-046 Active-session relaunch reacquisition and settled re-entry proof.
-Current Active Branch: None.
-Current Active Branch Authority Record: None.
+Current Active Workstream Before Release: None.
+Current Active Branch: feature/fb-047-active-session-relaunch-decline-preservation.
+Current Active Branch Authority Record: Docs/branch_records/feature_fb_047_active_session_relaunch_decline_preservation.md.
 Current Active Canonical Workstream Doc: None.
 Historical Active Workstream Before Release: FB-046 Active-session relaunch reacquisition and settled re-entry proof.
 Earlier Historical Active Workstream Before Release: FB-045 Active-session relaunch outcome refinement.
@@ -65,29 +65,22 @@ Historical Active Branch Before Release: feature/fb-046-active-session-relaunch-
 Earlier Historical Active Branch Before Release: feature/fb-045-active-session-relaunch-stability.
 Selected Next Workstream: FB-047 Active-session relaunch decline session-preservation proof.
 Selected Next Record State: Registry-only.
-Selected Next Implementation Branch: Not created.
+Selected Next Implementation Branch: feature/fb-047-active-session-relaunch-decline-preservation.
 Historical Repair-Only Branch Handling: `feature/fb-046-post-merge-canon-sync` was a bounded repair-only post-merge canon-sync `feature/` branch and did not imply Branch Readiness admission or active branch truth for FB-046.
 Historical Branch Readiness State: Complete on `feature/fb-046-active-session-relaunch-reacquisition`.
-Current Branch Readiness State: Not started for FB-047. Branch creation remains blocked until `v1.6.10-prebeta` is published and validated, updated `main` is revalidated, and FB-047 Branch Readiness admits the first bounded relaunch-decline preservation slice.
-Historical Workstream State: FB-046 is merge-target complete and will become the merged-unreleased release-debt owner for `v1.6.10-prebeta` after merge; FB-044 and FB-045 remain Released / Closed historical proof in `v1.6.9-prebeta`.
+Current Branch Readiness State: Complete on `feature/fb-047-active-session-relaunch-decline-preservation`. Post-release canon closure is complete, and the first bounded relaunch-decline preservation slice is admitted.
+Historical Workstream State: FB-046 is Released / Closed in `v1.6.10-prebeta`; FB-044 and FB-045 remain Released / Closed historical proof in `v1.6.9-prebeta`.
 Historical Hardening State: Complete on `feature/fb-046-active-session-relaunch-reacquisition`.
 Historical Live Validation State: Complete on `feature/fb-046-active-session-relaunch-reacquisition`.
-PR Readiness State: Complete on `feature/fb-046-active-session-relaunch-reacquisition`; PR-1 merge-target canon completeness, PR-2 selected-next successor lock, and PR-3 live PR creation plus validation are complete; PR #92 is open and mergeable.
-Release Execution State: `v1.6.9-prebeta` is live at https://github.com/GiribaldiTTV/Nexus-Desktop-AI/releases/tag/v1.6.9-prebeta on commit `348fd55b944435e3cae80b97acd0bb857fd65d56`.
-Release Target: v1.6.10-prebeta.
-Release Floor: patch prerelease.
-Version Rationale: FB-046 delivers a bounded runtime/user-facing relaunch-reacquisition refinement on the existing desktop startup family without opening a new product lane or materially expanded feature family, so the next release remains a patch prerelease.
-Release Scope: completed FB-046 WS-1 accepted relaunch replacement-session settled re-entry proof, H-1 relaunch lifecycle hardening, LV-1 real desktop shortcut evidence, reusable validation evidence, merged-unreleased release-debt truth, and selected-next FB-047 successor lock for the bounded runtime/user-facing lane only.
-Release Artifacts: Tag v1.6.10-prebeta; release title Pre-Beta v1.6.10; rich Markdown release notes summarize the bounded FB-046 relaunch-reacquisition runtime/user-facing package, real shortcut evidence, and the FB-047 successor lane without repeating the release title inside the notes body, and GitHub-generated `## What's Changed` plus `**Full Changelog**:` must be included.
-Post-Release Truth: FB-046 is Released / Closed in `v1.6.10-prebeta` after publication and validation; release debt then clears; and FB-047 remains selected next, `Registry-only`, and branch-not-created until updated `main` is revalidated and Branch Readiness admits the first bounded relaunch-decline preservation slice.
-Next-Branch Creation Gate: After `v1.6.10-prebeta` is published and validated, updated `main` is revalidated, and FB-047 Branch Readiness admits the first bounded runtime/user-facing relaunch-decline preservation slice; branch creation remains blocked until then.
-Current Branch Objective: carry the merged-unreleased FB-046 relaunch-reacquisition package through `Release Readiness` on updated `main` after merge while preserving FB-047 as selected next and branch-not-created.
-Next Legal Phase: Release Readiness.
-Active Workstream Chain: FB-046 is merge-target complete and prepared to own merged-unreleased release debt for `v1.6.10-prebeta`; WS-1, H-1, and LV-1 are complete and green; PR-1 merge-target canon completeness, PR-2 selected-next successor lock, and PR-3 live PR creation plus validation are complete; FB-047 is selected next, `Registry-only`, and branch-not-created; and `Release Readiness` is the next legal phase after merge.
+PR Readiness State: Historical proof complete on `feature/fb-046-active-session-relaunch-reacquisition`; PR #92 merged into `main` at `36cf07495dc8e239b20b11afb5194355b77ffd8b`.
+Release Execution State: `v1.6.10-prebeta` is live at https://github.com/GiribaldiTTV/Nexus-Desktop-AI/releases/tag/v1.6.10-prebeta on commit `36cf07495dc8e239b20b11afb5194355b77ffd8b`.
+Current Branch Objective: close FB-046 post-release canon and admit the first bounded runtime/user-facing FB-047 relaunch-decline preservation slice while preserving selected-only truth until `Workstream` begins.
+Next Legal Phase: Workstream.
+Active Workstream Chain: Release debt is clear; FB-047 now holds the selected-only active Branch Readiness lane on `feature/fb-047-active-session-relaunch-decline-preservation`; the first bounded relaunch-decline preservation slice is admitted; and `Workstream` is the next legal phase.
 
 ## Backlog Governance Sync
 
-Last Reviewed: 2026-04-26 during FB-046 PR Readiness.
+Last Reviewed: 2026-04-26 during FB-047 Branch Readiness.
 
 Open-candidate priority review:
 
@@ -100,10 +93,10 @@ Open-candidate priority review:
 - FB-043 is now Released / Closed in `v1.6.8-prebeta`.
 - FB-044 is now Released / Closed in `v1.6.9-prebeta`.
 - FB-045 is now Released / Closed in `v1.6.9-prebeta`.
-- FB-046 is merge-target complete and prepared to become the merged-unreleased release-debt owner for `v1.6.10-prebeta` after merge.
-- FB-047 is selected next, `Registry-only`, and branch-not-created.
+- FB-046 is now Released / Closed in `v1.6.10-prebeta`.
+- FB-047 is selected next, `Registry-only`, and now holds the active Branch Readiness lane on `feature/fb-047-active-session-relaunch-decline-preservation`.
 
-Current-branch clarity: latest public prerelease is `v1.6.9-prebeta`; FB-044 and FB-045 are released and closed; after merge, repo state is `No Active Branch`; FB-046 owns merged-unreleased release debt for `v1.6.10-prebeta`; and FB-047 remains selected next, `Registry-only`, and branch-not-created until post-release revalidation and Branch Readiness admission occur.
+Current-branch clarity: latest public prerelease is `v1.6.10-prebeta`; FB-044 and FB-045 are released and closed in `v1.6.9-prebeta`; FB-046 is released and closed in `v1.6.10-prebeta`; release debt is clear; and FB-047 now holds the selected-only active Branch Readiness lane on `feature/fb-047-active-session-relaunch-decline-preservation`, with the first bounded relaunch-decline preservation slice admitted and `Workstream` next.
 
 ## Registry Items
 
@@ -235,41 +228,46 @@ Why it matters: Keeps startup truth honest, prevents post-settled runtime exits 
 
 ### [ID: FB-046] Active-session relaunch reacquisition and settled re-entry proof
 
-Status: Merged unreleased (v1.6.10-prebeta)
-Record State: Promoted
+Status: Released (v1.6.10-prebeta)
+Record State: Closed
 Priority: High
-Release Stage: merged unreleased
+Release Stage: Released
 Target Version: v1.6.10-prebeta
-Selection / Unblock: Promoted on `feature/fb-046-active-session-relaunch-reacquisition`. WS-1 accepted relaunch replacement-session settled re-entry proof is complete and validated, H-1 relaunch lifecycle hardening is complete and green, LV-1 live validation is complete and green with real shortcut evidence, startup and explicit dev-boot proof remain green, and PR Readiness packages this lane as the merged-unreleased release-debt owner for `v1.6.10-prebeta`.
-Next Workstream: Selected successor is FB-047 after this merged-unreleased release window clears.
+Release Title: Pre-Beta v1.6.10
+Selection / Unblock: Implemented complete. `feature/fb-046-active-session-relaunch-reacquisition` delivered the admitted relaunch-reacquisition slice chain, PR #92 merged into `main`, and `v1.6.10-prebeta` is now published and validated.
+Next Workstream: Released / closed historical proof. No remaining implementable FB-046 work remains on this backlog lane.
 Branch: feature/fb-046-active-session-relaunch-reacquisition
 Repair-Only Branch Handling: `feature/fb-046-post-merge-canon-sync` is a bounded repair-only post-merge canon-sync `feature/` branch and does not imply Branch Readiness admission or active branch truth for FB-046.
 Canonical Workstream Doc: Docs/workstreams/FB-046_active_session_relaunch_reacquisition.md
 Historical Branch Readiness Record: Docs/branch_records/feature_fb_046_active_session_relaunch_reacquisition.md
 Branch Readiness: Historical complete. The admitted slice, validation contract, rollback conditions, and same-branch backlog-completion posture remain preserved in the historical branch-readiness record.
-Workstream: WS-1 accepted relaunch replacement-session settled re-entry proof is complete and validated. Accepted relaunch now proves prior-session shutdown, single-instance guard release, replacement-session reacquisition, replacement-session authoritative settled re-entry, and truthful post-settled lifecycle completion without dual ownership. H-1 relaunch lifecycle hardening is complete and green across slow shutdown, recoverable-exit relaunch, and rapid consecutive relaunch-cycle proof. LV-1 is complete and green with real desktop shortcut evidence plus a focused User Test Summary waiver. `Backlog Completion State` is `Implemented Complete`. PR-1 merge-target canon completeness and PR-2 selected-next successor lock are complete on this branch, and after merge this lane becomes the merged-unreleased release-debt owner for `v1.6.10-prebeta`.
+Workstream: Released. WS-1 accepted relaunch replacement-session settled re-entry proof is complete and validated; accepted relaunch now proves prior-session shutdown, single-instance guard release, replacement-session reacquisition, replacement-session authoritative settled re-entry, and truthful post-settled lifecycle completion without dual ownership; H-1 relaunch lifecycle hardening is complete and green across slow shutdown, recoverable-exit relaunch, and rapid consecutive relaunch-cycle proof; LV-1 is complete and green with real desktop shortcut evidence plus a focused User Test Summary waiver; `Backlog Completion State` is `Implemented Complete`; and the released branch is now historical proof in `v1.6.10-prebeta`.
 Backlog Completion State: Implemented Complete
-PR Readiness: Complete. PR-1 merge-target canon completeness, PR-2 selected-next workstream selection, and PR-3 live PR creation plus validation are complete; PR #92 is open, non-draft, and mergeable.
+PR Readiness: Complete. PR-1 merge-target canon completeness, PR-2 selected-next workstream selection, and PR-3 live PR creation plus validation are complete; PR #92 merged into `main` at `36cf07495dc8e239b20b11afb5194355b77ffd8b`.
+Release Readiness: Complete. `main` validated green for `v1.6.10-prebeta` release packaging before release execution.
+Release Execution: `v1.6.10-prebeta` is live at https://github.com/GiribaldiTTV/Nexus-Desktop-AI/releases/tag/v1.6.10-prebeta on commit `36cf07495dc8e239b20b11afb5194355b77ffd8b`.
 Release Target: v1.6.10-prebeta
 Release Floor: patch prerelease
 Version Rationale: FB-046 delivers a bounded runtime/user-facing relaunch-reacquisition refinement on the existing desktop startup family without opening a new product lane or materially expanded feature family.
 Release Scope: completed FB-046 WS-1 accepted relaunch replacement-session settled re-entry proof, H-1 relaunch lifecycle hardening, LV-1 real desktop shortcut evidence, reusable validation evidence, PR package history, merged-unreleased release-debt truth, and selected-next FB-047 successor lock for the bounded runtime/user-facing lane only.
 Release Artifacts: Tag v1.6.10-prebeta; release title Pre-Beta v1.6.10; rich Markdown release notes summarize the bounded FB-046 relaunch-reacquisition runtime/user-facing package, real shortcut evidence, and the FB-047 successor lane without repeating the release title inside the notes body, and GitHub-generated `## What's Changed` plus `**Full Changelog**:` must be included.
-Post-Release Truth: FB-046 is Released / Closed in `v1.6.10-prebeta` after publication and validation; release debt then clears; and FB-047 remains selected next, `Registry-only`, and branch-not-created until updated `main` is revalidated and Branch Readiness admits the first bounded relaunch-decline preservation slice.
+Post-Release Truth: FB-046 is Released / Closed in `v1.6.10-prebeta`; release debt is clear; and FB-047 now holds the selected-only active Branch Readiness lane on `feature/fb-047-active-session-relaunch-decline-preservation` until `Workstream` promotion begins.
 Minimal Scope: Complete the bounded relaunch-reacquisition runtime/user-facing pass across `desktop/single_instance.py`, `desktop/orin_desktop_launcher.pyw`, `desktop/orin_desktop_main.py`, `dev/orin_boot_transition_verification.py`, and the minimum required reusable validator surfaces so a confirmed relaunch request closes the active session, reacquires the runtime guard, and returns the replacement session to authoritative settled state without widening into `main.py`, `Audio/`, `logs/`, `jarvis_visual/`, installer work, or broader boot-orchestrator scope.
 Summary: Turn accepted relaunch into a full replacement-session completion proof surface instead of a partial signal-and-exit story.
 Why it matters: The repo now proves who owns the runtime after relaunch, when the old session is truly gone, and when the replacement session has actually made it back to authoritative settled state.
 
 ### [ID: FB-047] Active-session relaunch decline session-preservation proof
 
-Status: Selected next
+Status: Branch Readiness complete
 Record State: Registry-only
 Priority: High
-Selection / Unblock: Selected during FB-046 PR Readiness because accepted relaunch is now fully proven, but the complementary decline path still lacks first-class proof that declining replacement preserves the settled active session, keeps single-instance ownership with that session, and terminates the incoming launch truthfully without dual ownership or false replacement-session markers.
+Selection / Unblock: Selected during FB-046 PR Readiness because accepted relaunch is now fully proven, but the complementary decline path still lacks first-class proof that declining replacement preserves the settled active session, keeps single-instance ownership with that session, and terminates the incoming launch truthfully without dual ownership or false replacement-session markers. `v1.6.10-prebeta` is now published and validated, updated `main` is revalidated, and Branch Readiness has admitted the first bounded relaunch-decline preservation slice on `feature/fb-047-active-session-relaunch-decline-preservation`.
 Next Workstream: Selected
-Branch Creation Gate: After `v1.6.10-prebeta` is published and validated, updated `main` is revalidated, and FB-047 Branch Readiness admits the first bounded relaunch-decline preservation slice.
-Branch: Not created
-Branch Readiness: Not started. Must begin on a new `feature/` branch only after the gate above clears.
+Branch Creation Gate: Cleared. `v1.6.10-prebeta` is published and validated, updated `main` is revalidated, and FB-047 Branch Readiness has admitted the first bounded relaunch-decline preservation slice.
+Branch: feature/fb-047-active-session-relaunch-decline-preservation
+Branch Authority Record: Docs/branch_records/feature_fb_047_active_session_relaunch_decline_preservation.md
+Branch Readiness: Complete. The branch objective, target end-state, admitted WS-1 slice, validation contract, rollback conditions, and same-branch backlog-completion posture are recorded in the active branch authority record.
+Workstream: Not started yet. WS-1 `declined relaunch incoming-launch truthful exit proof` is admitted on this branch, and `Workstream` is next.
 Minimal Scope: Prove and refine the relaunch-decline lane across `desktop/single_instance.py`, `desktop/orin_desktop_launcher.pyw`, `desktop/orin_desktop_main.py`, and the minimum required reusable validator surfaces so declining replacement preserves the active settled session and cleanly terminates the incoming launch without dual ownership or false successor markers.
 Summary: Make relaunch decline as provable and truthful as accepted relaunch.
 Why it matters: The runtime should be just as explicit when the user keeps the current settled session as when the user accepts replacement.

--- a/Docs/feature_backlog.md
+++ b/Docs/feature_backlog.md
@@ -76,8 +76,8 @@ Historical Live Validation State: Complete on `feature/fb-046-active-session-rel
 PR Readiness State: Historical proof complete on `feature/fb-046-active-session-relaunch-reacquisition`; PR #92 merged into `main` at `36cf07495dc8e239b20b11afb5194355b77ffd8b`.
 Release Execution State: `v1.6.10-prebeta` is live at https://github.com/GiribaldiTTV/Nexus-Desktop-AI/releases/tag/v1.6.10-prebeta on commit `36cf07495dc8e239b20b11afb5194355b77ffd8b`.
 Current Branch Objective: complete the full currently implementable FB-047 runtime/user-facing relaunch-decline preservation pass by proving repeated declined incoming launches preserve active ownership and exit truthfully.
-Next Legal Phase: Live Validation.
-Active Workstream Chain: Release debt is clear; FB-047 is the active promoted workstream on `feature/fb-047-active-session-relaunch-decline-preservation`; WS-1 is complete and validated; H-1 is complete and green; `Backlog Completion State` is `Implemented Complete`; and `Live Validation` is the next legal phase.
+Next Legal Phase: PR Readiness.
+Active Workstream Chain: Release debt is clear; FB-047 is the active promoted workstream on `feature/fb-047-active-session-relaunch-decline-preservation`; WS-1 is complete and validated; H-1 is complete and green; LV-1 is complete and green; `Backlog Completion State` is `Implemented Complete`; and `PR Readiness` is the next legal phase.
 
 ## Backlog Governance Sync
 
@@ -97,7 +97,7 @@ Open-candidate priority review:
 - FB-046 is now Released / Closed in `v1.6.10-prebeta`.
 - FB-047 is now the active promoted workstream on `feature/fb-047-active-session-relaunch-decline-preservation`.
 
-Current-branch clarity: latest public prerelease is `v1.6.10-prebeta`; FB-044 and FB-045 are released and closed in `v1.6.9-prebeta`; FB-046 is released and closed in `v1.6.10-prebeta`; release debt is clear; and FB-047 is now the active promoted workstream on `feature/fb-047-active-session-relaunch-decline-preservation`, with WS-1 complete, H-1 complete / green, `Backlog Completion State` at `Implemented Complete`, and `Live Validation` next.
+Current-branch clarity: latest public prerelease is `v1.6.10-prebeta`; FB-044 and FB-045 are released and closed in `v1.6.9-prebeta`; FB-046 is released and closed in `v1.6.10-prebeta`; release debt is clear; and FB-047 is now the active promoted workstream on `feature/fb-047-active-session-relaunch-decline-preservation`, with WS-1 complete, H-1 complete / green, LV-1 complete / green, `Backlog Completion State` at `Implemented Complete`, and `PR Readiness` next.
 
 ## Registry Items
 
@@ -269,7 +269,7 @@ Branch: feature/fb-047-active-session-relaunch-decline-preservation
 Canonical Workstream Doc: Docs/workstreams/FB-047_active_session_relaunch_decline_preservation.md
 Historical Branch Readiness Record: Docs/branch_records/feature_fb_047_active_session_relaunch_decline_preservation.md
 Branch Readiness: Historical complete. The branch objective, target end-state, admitted WS-1 slice, validation contract, rollback conditions, and same-branch backlog-completion posture remain preserved in the historical branch-readiness record.
-Workstream: WS-1 `declined relaunch incoming-launch truthful exit proof` is complete and validated; harness-driven decline proof now records explicit preserved-session success markers instead of a generic already-running skip; repeated incoming declined launches preserve the active settled session and never emit replacement-session markers; H-1 decline-lifecycle hardening is complete / green; `Backlog Completion State` is `Implemented Complete`; and `Live Validation` is next.
+Workstream: WS-1 `declined relaunch incoming-launch truthful exit proof` is complete and validated; harness-driven decline proof now records explicit preserved-session success markers instead of a generic already-running skip; repeated incoming declined launches preserve the active settled session and never emit replacement-session markers; H-1 decline-lifecycle hardening is complete / green; LV-1 real desktop shortcut evidence and reusable decline-lifecycle proof are complete / green; `Backlog Completion State` is `Implemented Complete`; and `PR Readiness` is next.
 Minimal Scope: Prove and refine the relaunch-decline lane across `desktop/single_instance.py`, `desktop/orin_desktop_launcher.pyw`, `desktop/orin_desktop_main.py`, and the minimum required reusable validator surfaces so declining replacement preserves the active settled session and cleanly terminates the incoming launch without dual ownership or false successor markers.
 Summary: Make relaunch decline as provable and truthful as accepted relaunch.
 Why it matters: The runtime should be just as explicit when the user keeps the current settled session as when the user accepts replacement.

--- a/Docs/feature_backlog.md
+++ b/Docs/feature_backlog.md
@@ -31,15 +31,16 @@ Historical note:
 
 ## Promoted Canonical Workstreams
 
+- `Docs/workstreams/FB-047_active_session_relaunch_decline_preservation.md`
 - `Docs/workstreams/FB-046_active_session_relaunch_reacquisition.md`
 - `Docs/workstreams/FB-045_active_session_relaunch_outcome_refinement.md`
 - `Docs/workstreams/FB-044_boot_desktop_handoff_outcome_refinement.md`
 
 ## Active Promoted Workstream
 
-`None.`
+[Docs/workstreams/FB-047_active_session_relaunch_decline_preservation.md](Docs/workstreams/FB-047_active_session_relaunch_decline_preservation.md)
 
-FB-044 Boot-to-desktop handoff outcome refinement, FB-045 Active-session relaunch outcome refinement, and FB-046 Active-session relaunch reacquisition and settled re-entry proof are now Released / Closed historical proof through `v1.6.10-prebeta`. Latest public prerelease truth is `v1.6.10-prebeta`; release debt is clear after publication, validation, and post-release canon closure; and FB-047 now holds the selected-only active Branch Readiness lane on `feature/fb-047-active-session-relaunch-decline-preservation`.
+FB-044 Boot-to-desktop handoff outcome refinement, FB-045 Active-session relaunch outcome refinement, and FB-046 Active-session relaunch reacquisition and settled re-entry proof are now Released / Closed historical proof through `v1.6.10-prebeta`. Latest public prerelease truth is `v1.6.10-prebeta`; release debt is clear after publication, validation, and post-release canon closure; and FB-047 is now the active promoted workstream on `feature/fb-047-active-session-relaunch-decline-preservation`.
 Released baseline truth is aligned: FB-040 is released and closed in `v1.6.0-prebeta`, FB-031 is released and closed in `v1.6.1-prebeta`, FB-032 is released and closed in `v1.6.2-prebeta`, FB-004 is released and closed in `v1.6.3-prebeta`, FB-015 plus FB-029 are released and closed in `v1.6.4-prebeta`, FB-030 is released and closed in `v1.6.5-prebeta`, FB-005 is released and closed in `v1.6.6-prebeta`, FB-042 is released and closed in `v1.6.7-prebeta`, FB-043 is released and closed in `v1.6.8-prebeta`, FB-044 plus FB-045 are released and closed in `v1.6.9-prebeta`, and FB-046 is now released and closed in `v1.6.10-prebeta`.
 FB-039 is released and closed in `v1.5.0-prebeta`.
 FB-038 remains released and closed in `v1.4.1-prebeta`.
@@ -54,33 +55,33 @@ Latest Public Release Commit: 36cf07495dc8e239b20b11afb5194355b77ffd8b.
 Latest Public Prerelease Publication: https://github.com/GiribaldiTTV/Nexus-Desktop-AI/releases/tag/v1.6.10-prebeta.
 Latest Public Prerelease Title: Pre-Beta v1.6.10.
 Release Debt: Clear after v1.6.10-prebeta publication, validation, and post-release canon closure.
-Current Active Workstream: None.
+Current Active Workstream: FB-047 Active-session relaunch decline session-preservation proof.
 Current Active Workstream Before Release: None.
 Current Active Branch: feature/fb-047-active-session-relaunch-decline-preservation.
-Current Active Branch Authority Record: Docs/branch_records/feature_fb_047_active_session_relaunch_decline_preservation.md.
-Current Active Canonical Workstream Doc: None.
+Current Active Branch Authority Record: None.
+Current Active Canonical Workstream Doc: Docs/workstreams/FB-047_active_session_relaunch_decline_preservation.md.
 Historical Active Workstream Before Release: FB-046 Active-session relaunch reacquisition and settled re-entry proof.
 Earlier Historical Active Workstream Before Release: FB-045 Active-session relaunch outcome refinement.
 Historical Active Branch Before Release: feature/fb-046-active-session-relaunch-reacquisition.
 Earlier Historical Active Branch Before Release: feature/fb-045-active-session-relaunch-stability.
-Selected Next Workstream: FB-047 Active-session relaunch decline session-preservation proof.
-Selected Next Record State: Registry-only.
-Selected Next Implementation Branch: feature/fb-047-active-session-relaunch-decline-preservation.
+Selected Next Workstream: None selected while FB-047 remains the active promoted workstream.
+Selected Next Record State: None.
+Selected Next Implementation Branch: None.
 Historical Repair-Only Branch Handling: `feature/fb-046-post-merge-canon-sync` was a bounded repair-only post-merge canon-sync `feature/` branch and did not imply Branch Readiness admission or active branch truth for FB-046.
 Historical Branch Readiness State: Complete on `feature/fb-046-active-session-relaunch-reacquisition`.
-Current Branch Readiness State: Complete on `feature/fb-047-active-session-relaunch-decline-preservation`. Post-release canon closure is complete, and the first bounded relaunch-decline preservation slice is admitted.
+Current Branch Readiness State: Historical proof complete on `feature/fb-047-active-session-relaunch-decline-preservation`; active execution truth now lives in the promoted canonical workstream doc.
 Historical Workstream State: FB-046 is Released / Closed in `v1.6.10-prebeta`; FB-044 and FB-045 remain Released / Closed historical proof in `v1.6.9-prebeta`.
 Historical Hardening State: Complete on `feature/fb-046-active-session-relaunch-reacquisition`.
 Historical Live Validation State: Complete on `feature/fb-046-active-session-relaunch-reacquisition`.
 PR Readiness State: Historical proof complete on `feature/fb-046-active-session-relaunch-reacquisition`; PR #92 merged into `main` at `36cf07495dc8e239b20b11afb5194355b77ffd8b`.
 Release Execution State: `v1.6.10-prebeta` is live at https://github.com/GiribaldiTTV/Nexus-Desktop-AI/releases/tag/v1.6.10-prebeta on commit `36cf07495dc8e239b20b11afb5194355b77ffd8b`.
-Current Branch Objective: close FB-046 post-release canon and admit the first bounded runtime/user-facing FB-047 relaunch-decline preservation slice while preserving selected-only truth until `Workstream` begins.
-Next Legal Phase: Workstream.
-Active Workstream Chain: Release debt is clear; FB-047 now holds the selected-only active Branch Readiness lane on `feature/fb-047-active-session-relaunch-decline-preservation`; the first bounded relaunch-decline preservation slice is admitted; and `Workstream` is the next legal phase.
+Current Branch Objective: complete the full currently implementable FB-047 runtime/user-facing relaunch-decline preservation pass by proving repeated declined incoming launches preserve active ownership and exit truthfully.
+Next Legal Phase: Hardening.
+Active Workstream Chain: Release debt is clear; FB-047 is the active promoted workstream on `feature/fb-047-active-session-relaunch-decline-preservation`; WS-1 is complete and validated; `Backlog Completion State` is `Implemented Complete`; and `Hardening` is the next legal phase.
 
 ## Backlog Governance Sync
 
-Last Reviewed: 2026-04-26 during FB-047 Branch Readiness.
+Last Reviewed: 2026-04-26 during FB-047 Workstream.
 
 Open-candidate priority review:
 
@@ -94,9 +95,9 @@ Open-candidate priority review:
 - FB-044 is now Released / Closed in `v1.6.9-prebeta`.
 - FB-045 is now Released / Closed in `v1.6.9-prebeta`.
 - FB-046 is now Released / Closed in `v1.6.10-prebeta`.
-- FB-047 is selected next, `Registry-only`, and now holds the active Branch Readiness lane on `feature/fb-047-active-session-relaunch-decline-preservation`.
+- FB-047 is now the active promoted workstream on `feature/fb-047-active-session-relaunch-decline-preservation`.
 
-Current-branch clarity: latest public prerelease is `v1.6.10-prebeta`; FB-044 and FB-045 are released and closed in `v1.6.9-prebeta`; FB-046 is released and closed in `v1.6.10-prebeta`; release debt is clear; and FB-047 now holds the selected-only active Branch Readiness lane on `feature/fb-047-active-session-relaunch-decline-preservation`, with the first bounded relaunch-decline preservation slice admitted and `Workstream` next.
+Current-branch clarity: latest public prerelease is `v1.6.10-prebeta`; FB-044 and FB-045 are released and closed in `v1.6.9-prebeta`; FB-046 is released and closed in `v1.6.10-prebeta`; release debt is clear; and FB-047 is now the active promoted workstream on `feature/fb-047-active-session-relaunch-decline-preservation`, with WS-1 complete, `Backlog Completion State` at `Implemented Complete`, and `Hardening` next.
 
 ## Registry Items
 
@@ -258,16 +259,17 @@ Why it matters: The repo now proves who owns the runtime after relaunch, when th
 
 ### [ID: FB-047] Active-session relaunch decline session-preservation proof
 
-Status: Branch Readiness complete
-Record State: Registry-only
+Status: In Progress
+Record State: Promoted
 Priority: High
-Selection / Unblock: Selected during FB-046 PR Readiness because accepted relaunch is now fully proven, but the complementary decline path still lacks first-class proof that declining replacement preserves the settled active session, keeps single-instance ownership with that session, and terminates the incoming launch truthfully without dual ownership or false replacement-session markers. `v1.6.10-prebeta` is now published and validated, updated `main` is revalidated, and Branch Readiness has admitted the first bounded relaunch-decline preservation slice on `feature/fb-047-active-session-relaunch-decline-preservation`.
-Next Workstream: Selected
-Branch Creation Gate: Cleared. `v1.6.10-prebeta` is published and validated, updated `main` is revalidated, and FB-047 Branch Readiness has admitted the first bounded relaunch-decline preservation slice.
+Selection / Unblock: Selected during FB-046 PR Readiness because accepted relaunch is now fully proven, but the complementary decline path still lacked first-class proof that declining replacement preserves the settled active session, keeps single-instance ownership with that session, and terminates the incoming launch truthfully without dual ownership or false replacement-session markers. `v1.6.10-prebeta` is now published and validated, updated `main` is revalidated, Branch Readiness has completed, and Workstream promotion is now active on `feature/fb-047-active-session-relaunch-decline-preservation`.
+Next Workstream: Active current workstream. No successor is selected yet.
+Branch Creation Gate: Historical complete. `v1.6.10-prebeta` was published and validated, updated `main` was revalidated, and FB-047 Branch Readiness admitted the bounded runtime/user-facing relaunch-decline preservation slice before promotion.
 Branch: feature/fb-047-active-session-relaunch-decline-preservation
-Branch Authority Record: Docs/branch_records/feature_fb_047_active_session_relaunch_decline_preservation.md
-Branch Readiness: Complete. The branch objective, target end-state, admitted WS-1 slice, validation contract, rollback conditions, and same-branch backlog-completion posture are recorded in the active branch authority record.
-Workstream: Not started yet. WS-1 `declined relaunch incoming-launch truthful exit proof` is admitted on this branch, and `Workstream` is next.
+Canonical Workstream Doc: Docs/workstreams/FB-047_active_session_relaunch_decline_preservation.md
+Historical Branch Readiness Record: Docs/branch_records/feature_fb_047_active_session_relaunch_decline_preservation.md
+Branch Readiness: Historical complete. The branch objective, target end-state, admitted WS-1 slice, validation contract, rollback conditions, and same-branch backlog-completion posture remain preserved in the historical branch-readiness record.
+Workstream: WS-1 `declined relaunch incoming-launch truthful exit proof` is complete and validated; harness-driven decline proof now records explicit preserved-session success markers instead of a generic already-running skip; repeated incoming declined launches preserve the active settled session and never emit replacement-session markers; `Backlog Completion State` is `Implemented Complete`; and `Hardening` is next.
 Minimal Scope: Prove and refine the relaunch-decline lane across `desktop/single_instance.py`, `desktop/orin_desktop_launcher.pyw`, `desktop/orin_desktop_main.py`, and the minimum required reusable validator surfaces so declining replacement preserves the active settled session and cleanly terminates the incoming launch without dual ownership or false successor markers.
 Summary: Make relaunch decline as provable and truthful as accepted relaunch.
 Why it matters: The runtime should be just as explicit when the user keeps the current settled session as when the user accepts replacement.

--- a/Docs/prebeta_roadmap.md
+++ b/Docs/prebeta_roadmap.md
@@ -71,7 +71,7 @@ Current merged truth indicates:
 - phase status after `v1.6.10-prebeta` release closure: FB-044 and FB-045 are Released / Closed in `v1.6.9-prebeta`; FB-046 is Released / Closed in `v1.6.10-prebeta`; release debt is clear after publication, validation, and post-release canon closure; and FB-047 is now the active promoted workstream on `feature/fb-047-active-session-relaunch-decline-preservation`.
 - current active workstream: FB-047 Active-session relaunch decline session-preservation proof
 - current branch after `v1.6.10-prebeta` release closure: `feature/fb-047-active-session-relaunch-decline-preservation`
-- next concern: pressure-test the completed FB-047 decline-preservation pass in `Hardening` without widening beyond the bounded runtime/user-facing lane.
+- next concern: run `Live Validation` on the completed and hardened FB-047 decline-preservation pass without widening beyond the bounded runtime/user-facing lane.
 
 That means the released FB-027 interaction baseline, the released FB-036 authoring-and-callable-group milestone, the released FB-041 deterministic callable-group execution milestone, the released FB-037 built-in catalog milestone, the released FB-038 tray quick-task UX milestone, the released FB-039 external trigger intake architecture milestone, the released FB-040 monitoring/thermal architecture milestone, the released FB-031 UI/UX architecture milestone, the released FB-032 source-of-truth migration milestone, the released FB-004 future boot-orchestrator architecture milestone, the released FB-015 plus FB-029 planning milestones, the released FB-030 voice/audio planning milestone, and the released FB-005 bounded workspace-path slice are now part of the current public shared pre-Beta baseline.
 
@@ -108,8 +108,8 @@ Historical Live Validation State: Complete on `feature/fb-046-active-session-rel
 PR Readiness State: Historical proof complete on `feature/fb-046-active-session-relaunch-reacquisition`; PR #92 merged into `main` at `36cf07495dc8e239b20b11afb5194355b77ffd8b`.
 Release Execution State: `v1.6.10-prebeta` is live at https://github.com/GiribaldiTTV/Nexus-Desktop-AI/releases/tag/v1.6.10-prebeta on commit `36cf07495dc8e239b20b11afb5194355b77ffd8b`.
 Current Branch Objective: complete the full currently implementable FB-047 runtime/user-facing relaunch-decline preservation pass by proving repeated declined incoming launches preserve active ownership and exit truthfully.
-Next Legal Phase: Hardening.
-Active Workstream Chain: Release debt is clear; FB-047 is the active promoted workstream on `feature/fb-047-active-session-relaunch-decline-preservation`; WS-1 is complete and validated; `Backlog Completion State` is `Implemented Complete`; and `Hardening` is the next legal phase.
+Next Legal Phase: Live Validation.
+Active Workstream Chain: Release debt is clear; FB-047 is the active promoted workstream on `feature/fb-047-active-session-relaunch-decline-preservation`; WS-1 is complete and validated; H-1 is complete and green; `Backlog Completion State` is `Implemented Complete`; and `Live Validation` is the next legal phase.
 
 ## Current Merged-Unreleased Workstream
 
@@ -137,8 +137,8 @@ record state: `Promoted`
 priority: `High`
 canonical workstream doc: `Docs/workstreams/FB-047_active_session_relaunch_decline_preservation.md`
 branch: `feature/fb-047-active-session-relaunch-decline-preservation`
-phase status: release debt is clear after `v1.6.10-prebeta` publication, validation, and post-release canon closure; FB-047 is now the active promoted workstream on `feature/fb-047-active-session-relaunch-decline-preservation`; WS-1 is complete and validated; `Backlog Completion State` is `Implemented Complete`; and `Hardening` is next.
-next legal seam: `Hardening`
+phase status: release debt is clear after `v1.6.10-prebeta` publication, validation, and post-release canon closure; FB-047 is now the active promoted workstream on `feature/fb-047-active-session-relaunch-decline-preservation`; WS-1 is complete and validated; H-1 is complete and green; `Backlog Completion State` is `Implemented Complete`; and `Live Validation` is next.
+next legal seam: `Live Validation`
 
 ## Latest Released Workstream Context
 
@@ -266,7 +266,7 @@ The 2026-04-23 priority reading is updated during FB-005 Branch Readiness:
 - FB-043 is now Released / Closed in `v1.6.8-prebeta`.
 - FB-044 and FB-045 are now Released / Closed in `v1.6.9-prebeta`.
 
-Current-branch clarity: latest public prerelease is `v1.6.10-prebeta`; FB-044 and FB-045 are released and closed in `v1.6.9-prebeta`; FB-046 is released and closed in `v1.6.10-prebeta`; release debt is clear; and FB-047 is now the active promoted workstream on `feature/fb-047-active-session-relaunch-decline-preservation`, with WS-1 complete, `Backlog Completion State` at `Implemented Complete`, and `Hardening` next.
+Current-branch clarity: latest public prerelease is `v1.6.10-prebeta`; FB-044 and FB-045 are released and closed in `v1.6.9-prebeta`; FB-046 is released and closed in `v1.6.10-prebeta`; release debt is clear; and FB-047 is now the active promoted workstream on `feature/fb-047-active-session-relaunch-decline-preservation`, with WS-1 complete, H-1 complete / green, `Backlog Completion State` at `Implemented Complete`, and `Live Validation` next.
 
 ## Current Merged-Unreleased Workstream
 

--- a/Docs/prebeta_roadmap.md
+++ b/Docs/prebeta_roadmap.md
@@ -105,7 +105,7 @@ Current Branch Readiness State: Not started for FB-048. Branch creation remains 
 Historical Workstream State: FB-047 is merge-target complete and will own merged-unreleased release debt for `v1.6.11-prebeta` after merge; FB-046 is Released / Closed in `v1.6.10-prebeta`; FB-044 and FB-045 remain Released / Closed historical proof in `v1.6.9-prebeta`.
 Historical Hardening State: Complete on `feature/fb-047-active-session-relaunch-decline-preservation`.
 Historical Live Validation State: Complete on `feature/fb-047-active-session-relaunch-decline-preservation`.
-PR Readiness State: Complete on `feature/fb-047-active-session-relaunch-decline-preservation`; PR-1 merge-target canon completeness, PR-2 selected-next successor lock, and PR-3 live PR creation plus validation are complete; PR number and live state are recorded in the canonical workstream doc.
+PR Readiness State: Complete on `feature/fb-047-active-session-relaunch-decline-preservation`; PR-1 merge-target canon completeness, PR-2 selected-next successor lock, and PR-3 live PR creation plus validation are complete; PR #93 is open, non-draft, and mergeable.
 Release Execution State: `v1.6.10-prebeta` is live at https://github.com/GiribaldiTTV/Nexus-Desktop-AI/releases/tag/v1.6.10-prebeta on commit `36cf07495dc8e239b20b11afb5194355b77ffd8b`.
 Release Target: v1.6.11-prebeta
 Release Floor: patch prerelease

--- a/Docs/prebeta_roadmap.md
+++ b/Docs/prebeta_roadmap.md
@@ -67,11 +67,11 @@ Current merged truth indicates:
 - latest public prerelease title: `Pre-Beta v1.6.10`
 - merged unreleased non-doc implementation debt exists: no
 - the latest public released implementation milestones are FB-046 Active-session relaunch reacquisition and settled re-entry proof in `v1.6.10-prebeta`; FB-044 Boot-to-desktop handoff outcome refinement and FB-045 Active-session relaunch outcome refinement remain released in `v1.6.9-prebeta`; FB-043 Top-level desktop entrypoint ownership and `main.py` handoff refinement remains released in `v1.6.8-prebeta`; FB-042 Desktop entrypoint runtime refinement remains released in `v1.6.7-prebeta`; FB-005 Workspace and folder organization remains released in `v1.6.6-prebeta`; FB-030 ORIN voice/audio direction refinement remains released in `v1.6.5-prebeta`; FB-015 Boot and desktop phase-boundary model plus FB-029 ORIN legal-safe rebrand, future ARIA persona option, and repo licensing hardening remain released in `v1.6.4-prebeta`
-- current phase after `v1.6.10-prebeta` release closure: `Branch Readiness`
-- phase status after `v1.6.10-prebeta` release closure: FB-044 and FB-045 are Released / Closed in `v1.6.9-prebeta`; FB-046 is Released / Closed in `v1.6.10-prebeta`; release debt is clear after publication, validation, and post-release canon closure; and FB-047 now holds the selected-only active Branch Readiness lane on `feature/fb-047-active-session-relaunch-decline-preservation`.
-- current active workstream: none; release debt is clear and no promoted implementation workstream is active yet
+- current phase after `v1.6.10-prebeta` release closure: `Workstream`
+- phase status after `v1.6.10-prebeta` release closure: FB-044 and FB-045 are Released / Closed in `v1.6.9-prebeta`; FB-046 is Released / Closed in `v1.6.10-prebeta`; release debt is clear after publication, validation, and post-release canon closure; and FB-047 is now the active promoted workstream on `feature/fb-047-active-session-relaunch-decline-preservation`.
+- current active workstream: FB-047 Active-session relaunch decline session-preservation proof
 - current branch after `v1.6.10-prebeta` release closure: `feature/fb-047-active-session-relaunch-decline-preservation`
-- next concern: complete FB-047 Branch Readiness truth and carry the admitted relaunch-decline preservation slice into `Workstream` without widening beyond the bounded runtime/user-facing lane.
+- next concern: pressure-test the completed FB-047 decline-preservation pass in `Hardening` without widening beyond the bounded runtime/user-facing lane.
 
 That means the released FB-027 interaction baseline, the released FB-036 authoring-and-callable-group milestone, the released FB-041 deterministic callable-group execution milestone, the released FB-037 built-in catalog milestone, the released FB-038 tray quick-task UX milestone, the released FB-039 external trigger intake architecture milestone, the released FB-040 monitoring/thermal architecture milestone, the released FB-031 UI/UX architecture milestone, the released FB-032 source-of-truth migration milestone, the released FB-004 future boot-orchestrator architecture milestone, the released FB-015 plus FB-029 planning milestones, the released FB-030 voice/audio planning milestone, and the released FB-005 bounded workspace-path slice are now part of the current public shared pre-Beta baseline.
 
@@ -86,49 +86,59 @@ Latest Public Release Commit: 36cf07495dc8e239b20b11afb5194355b77ffd8b
 Latest Public Prerelease Publication: https://github.com/GiribaldiTTV/Nexus-Desktop-AI/releases/tag/v1.6.10-prebeta
 Latest Public Prerelease Title: Pre-Beta v1.6.10
 Release Debt: Clear after `v1.6.10-prebeta` publication, validation, and post-release canon closure.
-Current active workstream: None
+Current active workstream: FB-047 Active-session relaunch decline session-preservation proof
 Current Active Workstream Before Release: None
 Current Active Branch: `feature/fb-047-active-session-relaunch-decline-preservation`
 Active Branch Before Release: `None`
-Current Active Branch Authority Record: `Docs/branch_records/feature_fb_047_active_session_relaunch_decline_preservation.md`
-Current Active Canonical Workstream Doc: `None`
+Current Active Branch Authority Record: `None`
+Current Active Canonical Workstream Doc: `Docs/workstreams/FB-047_active_session_relaunch_decline_preservation.md`
 Historical Active Workstream Before Release: FB-046 Active-session relaunch reacquisition and settled re-entry proof
 Historical Active Branch Before Release: `feature/fb-046-active-session-relaunch-reacquisition`
 Earlier Historical Active Workstream Before Release: FB-045 Active-session relaunch outcome refinement
 Earlier Historical Active Branch Before Release: `feature/fb-045-active-session-relaunch-stability`
-Selected Next Workstream: FB-047 Active-session relaunch decline session-preservation proof.
-Selected Next Record State: Registry-only.
-Selected Next Implementation Branch: `feature/fb-047-active-session-relaunch-decline-preservation`
+Selected Next Workstream: None selected while FB-047 remains the active promoted workstream.
+Selected Next Record State: None.
+Selected Next Implementation Branch: `None`
 Repair-Only Branch Handling: `feature/fb-046-post-merge-canon-sync` is a bounded repair-only post-merge canon-sync `feature/` branch and did not imply Branch Readiness admission or active branch truth for FB-046.
 Historical Branch Readiness State: Complete on `feature/fb-046-active-session-relaunch-reacquisition`.
-Current Branch Readiness State: Complete on `feature/fb-047-active-session-relaunch-decline-preservation`. Post-release canon closure is complete, and the first bounded relaunch-decline preservation slice is admitted.
+Current Branch Readiness State: Historical proof complete on `feature/fb-047-active-session-relaunch-decline-preservation`; active execution truth now lives in the promoted canonical workstream doc.
 Historical Workstream State: FB-046 is Released / Closed in `v1.6.10-prebeta`; FB-044 and FB-045 remain Released / Closed historical proof in `v1.6.9-prebeta`.
 Historical Hardening State: Complete on `feature/fb-046-active-session-relaunch-reacquisition`.
 Historical Live Validation State: Complete on `feature/fb-046-active-session-relaunch-reacquisition`.
 PR Readiness State: Historical proof complete on `feature/fb-046-active-session-relaunch-reacquisition`; PR #92 merged into `main` at `36cf07495dc8e239b20b11afb5194355b77ffd8b`.
 Release Execution State: `v1.6.10-prebeta` is live at https://github.com/GiribaldiTTV/Nexus-Desktop-AI/releases/tag/v1.6.10-prebeta on commit `36cf07495dc8e239b20b11afb5194355b77ffd8b`.
-Current Branch Objective: close FB-046 post-release canon and admit the first bounded runtime/user-facing FB-047 relaunch-decline preservation slice while preserving selected-only truth until `Workstream` begins.
-Next Legal Phase: Workstream.
-Active Workstream Chain: Release debt is clear; FB-047 now holds the selected-only active Branch Readiness lane on `feature/fb-047-active-session-relaunch-decline-preservation`; the first bounded relaunch-decline preservation slice is admitted; and `Workstream` is the next legal phase.
+Current Branch Objective: complete the full currently implementable FB-047 runtime/user-facing relaunch-decline preservation pass by proving repeated declined incoming launches preserve active ownership and exit truthfully.
+Next Legal Phase: Hardening.
+Active Workstream Chain: Release debt is clear; FB-047 is the active promoted workstream on `feature/fb-047-active-session-relaunch-decline-preservation`; WS-1 is complete and validated; `Backlog Completion State` is `Implemented Complete`; and `Hardening` is the next legal phase.
 
 ## Current Merged-Unreleased Workstream
 
 None.
 
+## Promoted Canonical Workstreams
+
+- `Docs/workstreams/FB-047_active_session_relaunch_decline_preservation.md`
+- `Docs/workstreams/FB-046_active_session_relaunch_reacquisition.md`
+- `Docs/workstreams/FB-045_active_session_relaunch_outcome_refinement.md`
+- `Docs/workstreams/FB-044_boot_desktop_handoff_outcome_refinement.md`
+
 ## Selected Next Workstream
 
-- ID: `FB-047`
-- Title: `Active-session relaunch decline session-preservation proof`
-- Record State: `Registry-only`
-- Priority: `High`
-- Minimal Scope: Prove and refine the relaunch-decline lane across `desktop/single_instance.py`, `desktop/orin_desktop_launcher.pyw`, `desktop/orin_desktop_main.py`, and the minimum required reusable validator surfaces so declining replacement preserves the active settled session and cleanly terminates the incoming launch without dual ownership or false successor markers.
-- Branch: `feature/fb-047-active-session-relaunch-decline-preservation`
-- Branch Creation Gate: cleared; `v1.6.10-prebeta` is published and validated, updated `main` is revalidated, and FB-047 Branch Readiness has admitted the first bounded runtime/user-facing relaunch-decline preservation slice
-- Selection Basis: FB-047 is the smallest repo-grounded runtime/user-facing successor after FB-046 because accepted relaunch is now fully proven end to end, but the complementary decline path still lacks first-class proof that declining replacement preserves the settled active session, keeps single-instance ownership with that session, and terminates the incoming launch truthfully without dual ownership or false replacement-session success markers.
+`None selected yet while FB-047 remains the active promoted workstream.`
 
 ## Active Promoted Workstream
 
-`None.`
+[Docs/workstreams/FB-047_active_session_relaunch_decline_preservation.md](Docs/workstreams/FB-047_active_session_relaunch_decline_preservation.md)
+
+### FB-047 Active-session relaunch decline session-preservation proof
+
+status: `In Progress`
+record state: `Promoted`
+priority: `High`
+canonical workstream doc: `Docs/workstreams/FB-047_active_session_relaunch_decline_preservation.md`
+branch: `feature/fb-047-active-session-relaunch-decline-preservation`
+phase status: release debt is clear after `v1.6.10-prebeta` publication, validation, and post-release canon closure; FB-047 is now the active promoted workstream on `feature/fb-047-active-session-relaunch-decline-preservation`; WS-1 is complete and validated; `Backlog Completion State` is `Implemented Complete`; and `Hardening` is next.
+next legal seam: `Hardening`
 
 ## Latest Released Workstream Context
 
@@ -139,14 +149,14 @@ record state: `Closed`
 priority: `High`
 canonical workstream doc: `Docs/workstreams/FB-046_active_session_relaunch_reacquisition.md`
 branch: `feature/fb-046-active-session-relaunch-reacquisition`
-phase status: Released / Closed in `v1.6.10-prebeta`; PR #92 merged into `main` at `36cf07495dc8e239b20b11afb5194355b77ffd8b`; the release is live on the same commit; release debt is clear; and FB-047 now holds the selected-only active Branch Readiness lane on `feature/fb-047-active-session-relaunch-decline-preservation`.
+phase status: Released / Closed in `v1.6.10-prebeta`; PR #92 merged into `main` at `36cf07495dc8e239b20b11afb5194355b77ffd8b`; the release is live on the same commit; release debt is clear; and FB-047 is now the active promoted workstream on `feature/fb-047-active-session-relaunch-decline-preservation`.
 next legal seam: none; this record is now historical released truth
 Release Target: `v1.6.10-prebeta`
 Release Floor: `patch prerelease`
 Version Rationale: FB-046 delivers a bounded runtime/user-facing relaunch-reacquisition refinement on the existing desktop startup family without opening a new product lane or materially expanded feature family.
 Release Scope: completed FB-046 WS-1 accepted relaunch replacement-session settled re-entry proof, H-1 relaunch lifecycle hardening, LV-1 real desktop shortcut evidence, reusable validation evidence, merged-unreleased release-debt truth, and selected-next FB-047 successor lock for the bounded runtime/user-facing lane only.
 Release Artifacts: Tag `v1.6.10-prebeta`; release title `Pre-Beta v1.6.10`; rich Markdown release notes summarize the bounded FB-046 relaunch-reacquisition runtime/user-facing package, real shortcut evidence, and the FB-047 successor lane without repeating the release title inside the notes body, and GitHub-generated `## What's Changed` plus `**Full Changelog**:` must be included.
-Post-Release Truth: FB-046 is Released / Closed in `v1.6.10-prebeta`; release debt is clear; and FB-047 now holds the selected-only active Branch Readiness lane on `feature/fb-047-active-session-relaunch-decline-preservation` until `Workstream` promotion begins.
+Post-Release Truth: FB-046 is Released / Closed in `v1.6.10-prebeta`; release debt is clear; and FB-047 is now the active promoted workstream on `feature/fb-047-active-session-relaunch-decline-preservation`.
 minimal scope: complete the bounded accepted relaunch lane across `desktop/single_instance.py`, `desktop/orin_desktop_launcher.pyw`, `desktop/orin_desktop_main.py`, `dev/orin_desktop_entrypoint_validation.py`, and `dev/orin_boot_transition_verification.py` so the replacement session reacquires the guard and returns to authoritative settled without widening into `main.py`, `Audio/`, `logs/`, `jarvis_visual/`, installer work, or broader boot-orchestrator implementation
 branch-readiness carry-forward: preserved in `Docs/branch_records/feature_fb_046_active_session_relaunch_reacquisition.md`
 
@@ -256,7 +266,7 @@ The 2026-04-23 priority reading is updated during FB-005 Branch Readiness:
 - FB-043 is now Released / Closed in `v1.6.8-prebeta`.
 - FB-044 and FB-045 are now Released / Closed in `v1.6.9-prebeta`.
 
-Current-branch clarity: latest public prerelease is `v1.6.10-prebeta`; FB-044 and FB-045 are released and closed in `v1.6.9-prebeta`; FB-046 is released and closed in `v1.6.10-prebeta`; release debt is clear; and FB-047 now holds the selected-only active Branch Readiness lane on `feature/fb-047-active-session-relaunch-decline-preservation`, with the first bounded relaunch-decline preservation slice admitted and `Workstream` next.
+Current-branch clarity: latest public prerelease is `v1.6.10-prebeta`; FB-044 and FB-045 are released and closed in `v1.6.9-prebeta`; FB-046 is released and closed in `v1.6.10-prebeta`; release debt is clear; and FB-047 is now the active promoted workstream on `feature/fb-047-active-session-relaunch-decline-preservation`, with WS-1 complete, `Backlog Completion State` at `Implemented Complete`, and `Hardening` next.
 
 ## Current Merged-Unreleased Workstream
 

--- a/Docs/prebeta_roadmap.md
+++ b/Docs/prebeta_roadmap.md
@@ -65,55 +65,70 @@ Current merged truth indicates:
 - latest public release commit: `36cf07495dc8e239b20b11afb5194355b77ffd8b`
 - latest public prerelease publication: `https://github.com/GiribaldiTTV/Nexus-Desktop-AI/releases/tag/v1.6.10-prebeta`
 - latest public prerelease title: `Pre-Beta v1.6.10`
-- merged unreleased non-doc implementation debt exists: no
+- merged unreleased non-doc implementation debt exists: yes
 - the latest public released implementation milestones are FB-046 Active-session relaunch reacquisition and settled re-entry proof in `v1.6.10-prebeta`; FB-044 Boot-to-desktop handoff outcome refinement and FB-045 Active-session relaunch outcome refinement remain released in `v1.6.9-prebeta`; FB-043 Top-level desktop entrypoint ownership and `main.py` handoff refinement remains released in `v1.6.8-prebeta`; FB-042 Desktop entrypoint runtime refinement remains released in `v1.6.7-prebeta`; FB-005 Workspace and folder organization remains released in `v1.6.6-prebeta`; FB-030 ORIN voice/audio direction refinement remains released in `v1.6.5-prebeta`; FB-015 Boot and desktop phase-boundary model plus FB-029 ORIN legal-safe rebrand, future ARIA persona option, and repo licensing hardening remain released in `v1.6.4-prebeta`
-- current phase after `v1.6.10-prebeta` release closure: `Workstream`
-- phase status after `v1.6.10-prebeta` release closure: FB-044 and FB-045 are Released / Closed in `v1.6.9-prebeta`; FB-046 is Released / Closed in `v1.6.10-prebeta`; release debt is clear after publication, validation, and post-release canon closure; and FB-047 is now the active promoted workstream on `feature/fb-047-active-session-relaunch-decline-preservation`.
-- current active workstream: FB-047 Active-session relaunch decline session-preservation proof
-- current branch after `v1.6.10-prebeta` release closure: `feature/fb-047-active-session-relaunch-decline-preservation`
-- next concern: prepare `PR Readiness` for the completed and live-validated FB-047 decline-preservation pass without widening beyond the bounded runtime/user-facing lane.
+- current phase after `v1.6.10-prebeta` release closure: `Release Readiness`
+- phase status after `v1.6.10-prebeta` release closure: FB-044 and FB-045 are Released / Closed in `v1.6.9-prebeta`; FB-046 is Released / Closed in `v1.6.10-prebeta`; after merge, FB-047 is the merged-unreleased release-debt owner for `v1.6.11-prebeta`; release debt is active after merge until publication, validation, and post-release canon closure complete; and FB-048 is selected next, `Registry-only`, and branch-not-created.
+- current active workstream: none; merged-unreleased release-debt owner is FB-047 Active-session relaunch decline session-preservation proof
+- current branch after `v1.6.10-prebeta` release closure: none on merge-target canon
+- next concern: validate the merged-unreleased FB-047 decline-preservation package in `Release Readiness` for `v1.6.11-prebeta` while preserving FB-048 as selected next and branch-not-created.
 
 That means the released FB-027 interaction baseline, the released FB-036 authoring-and-callable-group milestone, the released FB-041 deterministic callable-group execution milestone, the released FB-037 built-in catalog milestone, the released FB-038 tray quick-task UX milestone, the released FB-039 external trigger intake architecture milestone, the released FB-040 monitoring/thermal architecture milestone, the released FB-031 UI/UX architecture milestone, the released FB-032 source-of-truth migration milestone, the released FB-004 future boot-orchestrator architecture milestone, the released FB-015 plus FB-029 planning milestones, the released FB-030 voice/audio planning milestone, and the released FB-005 bounded workspace-path slice are now part of the current public shared pre-Beta baseline.
 
 ## Current Branch Execution Posture
 
-Merged-Unreleased Release-Debt Owner: None.
-Repo State: Active Branch.
+Merged-Unreleased Release-Debt Owner: FB-047 Active-session relaunch decline session-preservation proof.
+Repo State: No Active Branch.
 Merged-Main Repo State: No Active Branch.
 
 Latest Public Prerelease: v1.6.10-prebeta
 Latest Public Release Commit: 36cf07495dc8e239b20b11afb5194355b77ffd8b
 Latest Public Prerelease Publication: https://github.com/GiribaldiTTV/Nexus-Desktop-AI/releases/tag/v1.6.10-prebeta
 Latest Public Prerelease Title: Pre-Beta v1.6.10
-Release Debt: Clear after `v1.6.10-prebeta` publication, validation, and post-release canon closure.
-Current active workstream: FB-047 Active-session relaunch decline session-preservation proof
-Current Active Workstream Before Release: None
-Current Active Branch: `feature/fb-047-active-session-relaunch-decline-preservation`
-Active Branch Before Release: `None`
+Release Debt: Active after merge until `v1.6.11-prebeta` is published, validated, and post-release canon closure completes.
+Current active workstream: None
+Current Active Workstream Before Release: FB-047 Active-session relaunch decline session-preservation proof
+Current Active Branch: `None`
+Active Branch Before Release: `feature/fb-047-active-session-relaunch-decline-preservation`
 Current Active Branch Authority Record: `None`
-Current Active Canonical Workstream Doc: `Docs/workstreams/FB-047_active_session_relaunch_decline_preservation.md`
-Historical Active Workstream Before Release: FB-046 Active-session relaunch reacquisition and settled re-entry proof
-Historical Active Branch Before Release: `feature/fb-046-active-session-relaunch-reacquisition`
-Earlier Historical Active Workstream Before Release: FB-045 Active-session relaunch outcome refinement
-Earlier Historical Active Branch Before Release: `feature/fb-045-active-session-relaunch-stability`
-Selected Next Workstream: None selected while FB-047 remains the active promoted workstream.
-Selected Next Record State: None.
-Selected Next Implementation Branch: `None`
+Current Active Canonical Workstream Doc: `None`
+Historical Active Workstream Before Release: FB-047 Active-session relaunch decline session-preservation proof
+Historical Active Branch Before Release: `feature/fb-047-active-session-relaunch-decline-preservation`
+Earlier Historical Active Workstream Before Release: FB-046 Active-session relaunch reacquisition and settled re-entry proof
+Earlier Historical Active Branch Before Release: `feature/fb-046-active-session-relaunch-reacquisition`
+Selected Next Workstream: FB-048 Active-session relaunch signal-failure and wait-timeout truth.
+Selected Next Record State: Registry-only.
+Selected Next Implementation Branch: `Not created`
 Repair-Only Branch Handling: `feature/fb-046-post-merge-canon-sync` is a bounded repair-only post-merge canon-sync `feature/` branch and did not imply Branch Readiness admission or active branch truth for FB-046.
-Historical Branch Readiness State: Complete on `feature/fb-046-active-session-relaunch-reacquisition`.
-Current Branch Readiness State: Historical proof complete on `feature/fb-047-active-session-relaunch-decline-preservation`; active execution truth now lives in the promoted canonical workstream doc.
-Historical Workstream State: FB-046 is Released / Closed in `v1.6.10-prebeta`; FB-044 and FB-045 remain Released / Closed historical proof in `v1.6.9-prebeta`.
-Historical Hardening State: Complete on `feature/fb-046-active-session-relaunch-reacquisition`.
-Historical Live Validation State: Complete on `feature/fb-046-active-session-relaunch-reacquisition`.
-PR Readiness State: Historical proof complete on `feature/fb-046-active-session-relaunch-reacquisition`; PR #92 merged into `main` at `36cf07495dc8e239b20b11afb5194355b77ffd8b`.
+Historical Branch Readiness State: Complete on `feature/fb-047-active-session-relaunch-decline-preservation`.
+Current Branch Readiness State: Not started for FB-048. Branch creation remains blocked until `v1.6.11-prebeta` is published and validated, updated `main` is revalidated, and FB-048 Branch Readiness admits the first bounded relaunch signal-failure and wait-timeout truth slice.
+Historical Workstream State: FB-047 is merge-target complete and will own merged-unreleased release debt for `v1.6.11-prebeta` after merge; FB-046 is Released / Closed in `v1.6.10-prebeta`; FB-044 and FB-045 remain Released / Closed historical proof in `v1.6.9-prebeta`.
+Historical Hardening State: Complete on `feature/fb-047-active-session-relaunch-decline-preservation`.
+Historical Live Validation State: Complete on `feature/fb-047-active-session-relaunch-decline-preservation`.
+PR Readiness State: Complete on `feature/fb-047-active-session-relaunch-decline-preservation`; PR-1 merge-target canon completeness, PR-2 selected-next successor lock, and PR-3 live PR creation plus validation are complete; PR number and live state are recorded in the canonical workstream doc.
 Release Execution State: `v1.6.10-prebeta` is live at https://github.com/GiribaldiTTV/Nexus-Desktop-AI/releases/tag/v1.6.10-prebeta on commit `36cf07495dc8e239b20b11afb5194355b77ffd8b`.
-Current Branch Objective: complete the full currently implementable FB-047 runtime/user-facing relaunch-decline preservation pass by proving repeated declined incoming launches preserve active ownership and exit truthfully.
-Next Legal Phase: PR Readiness.
-Active Workstream Chain: Release debt is clear; FB-047 is the active promoted workstream on `feature/fb-047-active-session-relaunch-decline-preservation`; WS-1 is complete and validated; H-1 is complete and green; LV-1 is complete and green; `Backlog Completion State` is `Implemented Complete`; and `PR Readiness` is the next legal phase.
+Release Target: v1.6.11-prebeta
+Release Floor: patch prerelease
+Version Rationale: FB-047 delivers a bounded runtime/user-facing relaunch-decline preservation refinement on the existing desktop startup family without opening a new product lane or materially expanded feature family, so the next release remains a patch prerelease.
+Release Scope: completed FB-047 WS-1 declined relaunch incoming-launch truthful exit proof, H-1 decline lifecycle hardening, LV-1 real desktop shortcut evidence, reusable validation evidence, merged-unreleased release-debt truth, and selected-next FB-048 successor lock for the bounded runtime/user-facing lane only.
+Release Artifacts: Tag v1.6.11-prebeta; release title Pre-Beta v1.6.11; rich Markdown release notes summarize the bounded FB-047 relaunch-decline preservation runtime/user-facing package, real shortcut evidence, and the FB-048 successor lane without repeating the release title inside the notes body, and GitHub-generated `## What's Changed` plus `**Full Changelog**:` must be included.
+Post-Release Truth: FB-047 is Released / Closed in `v1.6.11-prebeta` after publication and validation; release debt then clears; and FB-048 remains selected next, `Registry-only`, and branch-not-created until updated `main` is revalidated and Branch Readiness admits the first bounded relaunch signal-failure and wait-timeout truth slice.
+Next-Branch Creation Gate: After `v1.6.11-prebeta` is published and validated, updated `main` is revalidated, and FB-048 Branch Readiness admits the first bounded runtime/user-facing relaunch signal-failure and wait-timeout truth slice; branch creation remains blocked until then.
+Current Branch Objective: carry the merged-unreleased FB-047 relaunch-decline preservation package through file-frozen `Release Readiness` on updated `main` after merge while preserving FB-048 as selected next and branch-not-created.
+Next Legal Phase: Release Readiness.
+Active Workstream Chain: FB-047 is merge-target complete and prepared to own merged-unreleased release debt for `v1.6.11-prebeta`; WS-1, H-1, and LV-1 are complete and green; PR-1 merge-target canon completeness, PR-2 selected-next successor lock, and PR-3 live PR creation plus validation are complete; FB-048 is selected next, `Registry-only`, and branch-not-created; and `Release Readiness` is the next legal phase after merge.
 
-## Current Merged-Unreleased Workstream
+## Merged-Unreleased Release-Debt Owner
 
-None.
+ID: FB-047
+Title: Active-session relaunch decline session-preservation proof
+Record State: Promoted
+Release Target: v1.6.11-prebeta
+Release Floor: patch prerelease
+Version Rationale: FB-047 delivers a bounded runtime/user-facing relaunch-decline preservation refinement on the existing desktop startup family without opening a new product lane or materially expanded feature family.
+Release Scope: completed FB-047 WS-1 declined relaunch incoming-launch truthful exit proof, H-1 decline lifecycle hardening, LV-1 real desktop shortcut evidence, reusable validation evidence, merged-unreleased release-debt truth, and selected-next FB-048 successor lock for the bounded runtime/user-facing lane only
+Release Artifacts: Tag v1.6.11-prebeta; release title Pre-Beta v1.6.11; rich Markdown release notes summarize the bounded FB-047 relaunch-decline preservation runtime/user-facing package, real shortcut evidence, and the FB-048 successor lane without repeating the release title inside the notes body, and GitHub-generated `## What's Changed` plus `**Full Changelog**:` must be included
+Post-Release Truth: FB-047 becomes Released / Closed in `v1.6.11-prebeta` after publication and validation; release debt then clears; and FB-048 remains selected next, Registry-only, and branch-not-created until updated main is revalidated and Branch Readiness admits the first relaunch signal-failure and wait-timeout truth slice
 
 ## Promoted Canonical Workstreams
 
@@ -124,7 +139,14 @@ None.
 
 ## Selected Next Workstream
 
-`None selected yet while FB-047 remains the active promoted workstream.`
+- ID: `FB-048`
+- Title: `Active-session relaunch signal-failure and wait-timeout truth`
+- Record State: `Registry-only`
+- Priority: `High`
+- Minimal Scope: Prove and refine the accepted relaunch failure lane across `desktop/single_instance.py`, `desktop/orin_desktop_launcher.pyw`, `desktop/orin_desktop_main.py`, and the minimum required reusable validator surfaces so relaunch-signal failure or reacquire wait-timeout preserves truthful ownership, emits explicit failure-path markers, and avoids false replacement-session or guard-transfer claims.
+- Branch: Not created
+- Branch Creation Gate: after `v1.6.11-prebeta` is published and validated, updated `main` is revalidated, and FB-048 Branch Readiness admits the first bounded runtime/user-facing relaunch signal-failure and wait-timeout truth slice
+- Selection Basis: FB-048 is the smallest repo-grounded runtime/user-facing successor after FB-047 because accepted relaunch success and declined relaunch preservation are now first-class proven surfaces, but the accepted incoming-launch failure lane still lacks equivalent proof when relaunch signaling fails or the current session does not release before the reacquire wait deadline.
 
 ## Active Promoted Workstream
 
@@ -132,13 +154,19 @@ None.
 
 ### FB-047 Active-session relaunch decline session-preservation proof
 
-status: `In Progress`
+status: `merged unreleased`
 record state: `Promoted`
 priority: `High`
 canonical workstream doc: `Docs/workstreams/FB-047_active_session_relaunch_decline_preservation.md`
 branch: `feature/fb-047-active-session-relaunch-decline-preservation`
-phase status: release debt is clear after `v1.6.10-prebeta` publication, validation, and post-release canon closure; FB-047 is now the active promoted workstream on `feature/fb-047-active-session-relaunch-decline-preservation`; WS-1 is complete and validated; H-1 is complete and green; LV-1 is complete and green; `Backlog Completion State` is `Implemented Complete`; and `PR Readiness` is next.
-next legal seam: `PR Readiness`
+phase status: merge-target complete release-debt owner after merge; WS-1 declined relaunch incoming-launch truthful exit proof is complete and validated; H-1 decline lifecycle hardening is complete and green; LV-1 live validation is complete and green with real shortcut evidence; `Backlog Completion State` is `Implemented Complete`; and `Release Readiness` is next after merge
+next legal seam: `Release Readiness`
+Release Target: `v1.6.11-prebeta`
+Release Floor: `patch prerelease`
+Version Rationale: FB-047 delivers a bounded runtime/user-facing relaunch-decline preservation refinement on the existing desktop startup family without opening a new product lane or materially expanded feature family.
+Release Scope: completed FB-047 WS-1 declined relaunch incoming-launch truthful exit proof, H-1 decline lifecycle hardening, LV-1 real desktop shortcut evidence, reusable validation evidence, merged-unreleased release-debt truth, and selected-next FB-048 successor lock for the bounded runtime/user-facing lane only.
+Release Artifacts: Tag `v1.6.11-prebeta`; release title `Pre-Beta v1.6.11`; rich Markdown release notes summarize the bounded FB-047 relaunch-decline preservation runtime/user-facing package, real shortcut evidence, and the FB-048 successor lane without repeating the release title inside the notes body, and GitHub-generated `## What's Changed` plus `**Full Changelog**:` must be included.
+Post-Release Truth: FB-047 is Released / Closed in `v1.6.11-prebeta` after publication and validation; release debt then clears; and FB-048 remains selected next, `Registry-only`, and branch-not-created until updated `main` is revalidated and Branch Readiness admits the first bounded relaunch signal-failure and wait-timeout truth slice.
 
 ## Latest Released Workstream Context
 
@@ -149,14 +177,14 @@ record state: `Closed`
 priority: `High`
 canonical workstream doc: `Docs/workstreams/FB-046_active_session_relaunch_reacquisition.md`
 branch: `feature/fb-046-active-session-relaunch-reacquisition`
-phase status: Released / Closed in `v1.6.10-prebeta`; PR #92 merged into `main` at `36cf07495dc8e239b20b11afb5194355b77ffd8b`; the release is live on the same commit; release debt is clear; and FB-047 is now the active promoted workstream on `feature/fb-047-active-session-relaunch-decline-preservation`.
+phase status: Released / Closed in `v1.6.10-prebeta`; PR #92 merged into `main` at `36cf07495dc8e239b20b11afb5194355b77ffd8b`; the release is live on the same commit; and after merge FB-047 becomes the merged-unreleased release-debt owner for `v1.6.11-prebeta`, while FB-048 is selected next, `Registry-only`, and branch-not-created.
 next legal seam: none; this record is now historical released truth
 Release Target: `v1.6.10-prebeta`
 Release Floor: `patch prerelease`
 Version Rationale: FB-046 delivers a bounded runtime/user-facing relaunch-reacquisition refinement on the existing desktop startup family without opening a new product lane or materially expanded feature family.
 Release Scope: completed FB-046 WS-1 accepted relaunch replacement-session settled re-entry proof, H-1 relaunch lifecycle hardening, LV-1 real desktop shortcut evidence, reusable validation evidence, merged-unreleased release-debt truth, and selected-next FB-047 successor lock for the bounded runtime/user-facing lane only.
 Release Artifacts: Tag `v1.6.10-prebeta`; release title `Pre-Beta v1.6.10`; rich Markdown release notes summarize the bounded FB-046 relaunch-reacquisition runtime/user-facing package, real shortcut evidence, and the FB-047 successor lane without repeating the release title inside the notes body, and GitHub-generated `## What's Changed` plus `**Full Changelog**:` must be included.
-Post-Release Truth: FB-046 is Released / Closed in `v1.6.10-prebeta`; release debt is clear; and FB-047 is now the active promoted workstream on `feature/fb-047-active-session-relaunch-decline-preservation`.
+Post-Release Truth: FB-046 is Released / Closed in `v1.6.10-prebeta`; release debt is clear; and after merge FB-047 becomes the merged-unreleased release-debt owner for `v1.6.11-prebeta`, while FB-048 is selected next, `Registry-only`, and branch-not-created.
 minimal scope: complete the bounded accepted relaunch lane across `desktop/single_instance.py`, `desktop/orin_desktop_launcher.pyw`, `desktop/orin_desktop_main.py`, `dev/orin_desktop_entrypoint_validation.py`, and `dev/orin_boot_transition_verification.py` so the replacement session reacquires the guard and returns to authoritative settled without widening into `main.py`, `Audio/`, `logs/`, `jarvis_visual/`, installer work, or broader boot-orchestrator implementation
 branch-readiness carry-forward: preserved in `Docs/branch_records/feature_fb_046_active_session_relaunch_reacquisition.md`
 

--- a/Docs/prebeta_roadmap.md
+++ b/Docs/prebeta_roadmap.md
@@ -71,7 +71,7 @@ Current merged truth indicates:
 - phase status after `v1.6.10-prebeta` release closure: FB-044 and FB-045 are Released / Closed in `v1.6.9-prebeta`; FB-046 is Released / Closed in `v1.6.10-prebeta`; release debt is clear after publication, validation, and post-release canon closure; and FB-047 is now the active promoted workstream on `feature/fb-047-active-session-relaunch-decline-preservation`.
 - current active workstream: FB-047 Active-session relaunch decline session-preservation proof
 - current branch after `v1.6.10-prebeta` release closure: `feature/fb-047-active-session-relaunch-decline-preservation`
-- next concern: run `Live Validation` on the completed and hardened FB-047 decline-preservation pass without widening beyond the bounded runtime/user-facing lane.
+- next concern: prepare `PR Readiness` for the completed and live-validated FB-047 decline-preservation pass without widening beyond the bounded runtime/user-facing lane.
 
 That means the released FB-027 interaction baseline, the released FB-036 authoring-and-callable-group milestone, the released FB-041 deterministic callable-group execution milestone, the released FB-037 built-in catalog milestone, the released FB-038 tray quick-task UX milestone, the released FB-039 external trigger intake architecture milestone, the released FB-040 monitoring/thermal architecture milestone, the released FB-031 UI/UX architecture milestone, the released FB-032 source-of-truth migration milestone, the released FB-004 future boot-orchestrator architecture milestone, the released FB-015 plus FB-029 planning milestones, the released FB-030 voice/audio planning milestone, and the released FB-005 bounded workspace-path slice are now part of the current public shared pre-Beta baseline.
 
@@ -108,8 +108,8 @@ Historical Live Validation State: Complete on `feature/fb-046-active-session-rel
 PR Readiness State: Historical proof complete on `feature/fb-046-active-session-relaunch-reacquisition`; PR #92 merged into `main` at `36cf07495dc8e239b20b11afb5194355b77ffd8b`.
 Release Execution State: `v1.6.10-prebeta` is live at https://github.com/GiribaldiTTV/Nexus-Desktop-AI/releases/tag/v1.6.10-prebeta on commit `36cf07495dc8e239b20b11afb5194355b77ffd8b`.
 Current Branch Objective: complete the full currently implementable FB-047 runtime/user-facing relaunch-decline preservation pass by proving repeated declined incoming launches preserve active ownership and exit truthfully.
-Next Legal Phase: Live Validation.
-Active Workstream Chain: Release debt is clear; FB-047 is the active promoted workstream on `feature/fb-047-active-session-relaunch-decline-preservation`; WS-1 is complete and validated; H-1 is complete and green; `Backlog Completion State` is `Implemented Complete`; and `Live Validation` is the next legal phase.
+Next Legal Phase: PR Readiness.
+Active Workstream Chain: Release debt is clear; FB-047 is the active promoted workstream on `feature/fb-047-active-session-relaunch-decline-preservation`; WS-1 is complete and validated; H-1 is complete and green; LV-1 is complete and green; `Backlog Completion State` is `Implemented Complete`; and `PR Readiness` is the next legal phase.
 
 ## Current Merged-Unreleased Workstream
 
@@ -137,8 +137,8 @@ record state: `Promoted`
 priority: `High`
 canonical workstream doc: `Docs/workstreams/FB-047_active_session_relaunch_decline_preservation.md`
 branch: `feature/fb-047-active-session-relaunch-decline-preservation`
-phase status: release debt is clear after `v1.6.10-prebeta` publication, validation, and post-release canon closure; FB-047 is now the active promoted workstream on `feature/fb-047-active-session-relaunch-decline-preservation`; WS-1 is complete and validated; H-1 is complete and green; `Backlog Completion State` is `Implemented Complete`; and `Live Validation` is next.
-next legal seam: `Live Validation`
+phase status: release debt is clear after `v1.6.10-prebeta` publication, validation, and post-release canon closure; FB-047 is now the active promoted workstream on `feature/fb-047-active-session-relaunch-decline-preservation`; WS-1 is complete and validated; H-1 is complete and green; LV-1 is complete and green; `Backlog Completion State` is `Implemented Complete`; and `PR Readiness` is next.
+next legal seam: `PR Readiness`
 
 ## Latest Released Workstream Context
 
@@ -266,7 +266,7 @@ The 2026-04-23 priority reading is updated during FB-005 Branch Readiness:
 - FB-043 is now Released / Closed in `v1.6.8-prebeta`.
 - FB-044 and FB-045 are now Released / Closed in `v1.6.9-prebeta`.
 
-Current-branch clarity: latest public prerelease is `v1.6.10-prebeta`; FB-044 and FB-045 are released and closed in `v1.6.9-prebeta`; FB-046 is released and closed in `v1.6.10-prebeta`; release debt is clear; and FB-047 is now the active promoted workstream on `feature/fb-047-active-session-relaunch-decline-preservation`, with WS-1 complete, H-1 complete / green, `Backlog Completion State` at `Implemented Complete`, and `Live Validation` next.
+Current-branch clarity: latest public prerelease is `v1.6.10-prebeta`; FB-044 and FB-045 are released and closed in `v1.6.9-prebeta`; FB-046 is released and closed in `v1.6.10-prebeta`; release debt is clear; and FB-047 is now the active promoted workstream on `feature/fb-047-active-session-relaunch-decline-preservation`, with WS-1 complete, H-1 complete / green, LV-1 complete / green, `Backlog Completion State` at `Implemented Complete`, and `PR Readiness` next.
 
 ## Current Merged-Unreleased Workstream
 

--- a/Docs/prebeta_roadmap.md
+++ b/Docs/prebeta_roadmap.md
@@ -61,36 +61,36 @@ Use these release-state values when relevant:
 
 Current merged truth indicates:
 
-- latest public prerelease: `v1.6.9-prebeta`
-- latest public release commit: `348fd55b944435e3cae80b97acd0bb857fd65d56`
-- latest public prerelease publication: `https://github.com/GiribaldiTTV/Nexus-Desktop-AI/releases/tag/v1.6.9-prebeta`
-- latest public prerelease title: `Pre-Beta v1.6.9`
-- merged unreleased non-doc implementation debt exists: yes
-- the latest public released implementation milestones are FB-044 Boot-to-desktop handoff outcome refinement and FB-045 Active-session relaunch outcome refinement in `v1.6.9-prebeta`; FB-043 Top-level desktop entrypoint ownership and `main.py` handoff refinement remains released in `v1.6.8-prebeta`; FB-042 Desktop entrypoint runtime refinement remains released in `v1.6.7-prebeta`; FB-005 Workspace and folder organization remains released in `v1.6.6-prebeta`; FB-030 ORIN voice/audio direction refinement remains released in `v1.6.5-prebeta`; FB-015 Boot and desktop phase-boundary model plus FB-029 ORIN legal-safe rebrand, future ARIA persona option, and repo licensing hardening remain released in `v1.6.4-prebeta`
-- current phase after `v1.6.9-prebeta` release closure: `Release Readiness`
-- phase status after `v1.6.9-prebeta` release closure: FB-044 and FB-045 are Released / Closed in `v1.6.9-prebeta`; after merge, FB-046 is the merged-unreleased release-debt owner for `v1.6.10-prebeta`; release debt is active after merge until publication, validation, and post-release canon closure complete; and FB-047 is selected next, `Registry-only`, and branch-not-created.
-- current active workstream: none; merged-unreleased release-debt owner is FB-046 Active-session relaunch reacquisition and settled re-entry proof
-- current branch after `v1.6.9-prebeta` release closure: none on merge-target canon
-- next concern: validate the merged-unreleased FB-046 relaunch-reacquisition package in `Release Readiness` for `v1.6.10-prebeta` while preserving FB-047 as selected next and branch-not-created.
+- latest public prerelease: `v1.6.10-prebeta`
+- latest public release commit: `36cf07495dc8e239b20b11afb5194355b77ffd8b`
+- latest public prerelease publication: `https://github.com/GiribaldiTTV/Nexus-Desktop-AI/releases/tag/v1.6.10-prebeta`
+- latest public prerelease title: `Pre-Beta v1.6.10`
+- merged unreleased non-doc implementation debt exists: no
+- the latest public released implementation milestones are FB-046 Active-session relaunch reacquisition and settled re-entry proof in `v1.6.10-prebeta`; FB-044 Boot-to-desktop handoff outcome refinement and FB-045 Active-session relaunch outcome refinement remain released in `v1.6.9-prebeta`; FB-043 Top-level desktop entrypoint ownership and `main.py` handoff refinement remains released in `v1.6.8-prebeta`; FB-042 Desktop entrypoint runtime refinement remains released in `v1.6.7-prebeta`; FB-005 Workspace and folder organization remains released in `v1.6.6-prebeta`; FB-030 ORIN voice/audio direction refinement remains released in `v1.6.5-prebeta`; FB-015 Boot and desktop phase-boundary model plus FB-029 ORIN legal-safe rebrand, future ARIA persona option, and repo licensing hardening remain released in `v1.6.4-prebeta`
+- current phase after `v1.6.10-prebeta` release closure: `Branch Readiness`
+- phase status after `v1.6.10-prebeta` release closure: FB-044 and FB-045 are Released / Closed in `v1.6.9-prebeta`; FB-046 is Released / Closed in `v1.6.10-prebeta`; release debt is clear after publication, validation, and post-release canon closure; and FB-047 now holds the selected-only active Branch Readiness lane on `feature/fb-047-active-session-relaunch-decline-preservation`.
+- current active workstream: none; release debt is clear and no promoted implementation workstream is active yet
+- current branch after `v1.6.10-prebeta` release closure: `feature/fb-047-active-session-relaunch-decline-preservation`
+- next concern: complete FB-047 Branch Readiness truth and carry the admitted relaunch-decline preservation slice into `Workstream` without widening beyond the bounded runtime/user-facing lane.
 
 That means the released FB-027 interaction baseline, the released FB-036 authoring-and-callable-group milestone, the released FB-041 deterministic callable-group execution milestone, the released FB-037 built-in catalog milestone, the released FB-038 tray quick-task UX milestone, the released FB-039 external trigger intake architecture milestone, the released FB-040 monitoring/thermal architecture milestone, the released FB-031 UI/UX architecture milestone, the released FB-032 source-of-truth migration milestone, the released FB-004 future boot-orchestrator architecture milestone, the released FB-015 plus FB-029 planning milestones, the released FB-030 voice/audio planning milestone, and the released FB-005 bounded workspace-path slice are now part of the current public shared pre-Beta baseline.
 
 ## Current Branch Execution Posture
 
-Merged-Unreleased Release-Debt Owner: FB-046 Active-session relaunch reacquisition and settled re-entry proof.
-Repo State: No Active Branch.
+Merged-Unreleased Release-Debt Owner: None.
+Repo State: Active Branch.
 Merged-Main Repo State: No Active Branch.
 
-Latest Public Prerelease: v1.6.9-prebeta
-Latest Public Release Commit: 348fd55b944435e3cae80b97acd0bb857fd65d56
-Latest Public Prerelease Publication: https://github.com/GiribaldiTTV/Nexus-Desktop-AI/releases/tag/v1.6.9-prebeta
-Latest Public Prerelease Title: Pre-Beta v1.6.9
-Release Debt: Active after merge until `v1.6.10-prebeta` is published, validated, and post-release canon closure completes.
+Latest Public Prerelease: v1.6.10-prebeta
+Latest Public Release Commit: 36cf07495dc8e239b20b11afb5194355b77ffd8b
+Latest Public Prerelease Publication: https://github.com/GiribaldiTTV/Nexus-Desktop-AI/releases/tag/v1.6.10-prebeta
+Latest Public Prerelease Title: Pre-Beta v1.6.10
+Release Debt: Clear after `v1.6.10-prebeta` publication, validation, and post-release canon closure.
 Current active workstream: None
-Current Active Workstream Before Release: FB-046 Active-session relaunch reacquisition and settled re-entry proof
-Current Active Branch: `None`
-Active Branch Before Release: `feature/fb-046-active-session-relaunch-reacquisition`
-Current Active Branch Authority Record: `None`
+Current Active Workstream Before Release: None
+Current Active Branch: `feature/fb-047-active-session-relaunch-decline-preservation`
+Active Branch Before Release: `None`
+Current Active Branch Authority Record: `Docs/branch_records/feature_fb_047_active_session_relaunch_decline_preservation.md`
 Current Active Canonical Workstream Doc: `None`
 Historical Active Workstream Before Release: FB-046 Active-session relaunch reacquisition and settled re-entry proof
 Historical Active Branch Before Release: `feature/fb-046-active-session-relaunch-reacquisition`
@@ -98,37 +98,22 @@ Earlier Historical Active Workstream Before Release: FB-045 Active-session relau
 Earlier Historical Active Branch Before Release: `feature/fb-045-active-session-relaunch-stability`
 Selected Next Workstream: FB-047 Active-session relaunch decline session-preservation proof.
 Selected Next Record State: Registry-only.
-Selected Next Implementation Branch: `Not created`
+Selected Next Implementation Branch: `feature/fb-047-active-session-relaunch-decline-preservation`
 Repair-Only Branch Handling: `feature/fb-046-post-merge-canon-sync` is a bounded repair-only post-merge canon-sync `feature/` branch and did not imply Branch Readiness admission or active branch truth for FB-046.
 Historical Branch Readiness State: Complete on `feature/fb-046-active-session-relaunch-reacquisition`.
-Current Branch Readiness State: Not started for FB-047. Branch creation remains blocked until `v1.6.10-prebeta` is published and validated, updated `main` is revalidated, and FB-047 Branch Readiness admits the first bounded relaunch-decline preservation slice.
-Historical Workstream State: FB-046 is merge-target complete and will own merged-unreleased release debt for `v1.6.10-prebeta` after merge; FB-044 and FB-045 remain Released / Closed historical proof in `v1.6.9-prebeta`.
+Current Branch Readiness State: Complete on `feature/fb-047-active-session-relaunch-decline-preservation`. Post-release canon closure is complete, and the first bounded relaunch-decline preservation slice is admitted.
+Historical Workstream State: FB-046 is Released / Closed in `v1.6.10-prebeta`; FB-044 and FB-045 remain Released / Closed historical proof in `v1.6.9-prebeta`.
 Historical Hardening State: Complete on `feature/fb-046-active-session-relaunch-reacquisition`.
 Historical Live Validation State: Complete on `feature/fb-046-active-session-relaunch-reacquisition`.
-PR Readiness State: Complete on `feature/fb-046-active-session-relaunch-reacquisition`; PR-1 merge-target canon completeness, PR-2 selected-next successor lock, and PR-3 live PR creation plus validation are complete; PR #92 is open and mergeable.
-Release Execution State: `v1.6.9-prebeta` is live at https://github.com/GiribaldiTTV/Nexus-Desktop-AI/releases/tag/v1.6.9-prebeta on commit `348fd55b944435e3cae80b97acd0bb857fd65d56`.
-Release Target: v1.6.10-prebeta
-Release Floor: patch prerelease
-Version Rationale: FB-046 delivers a bounded runtime/user-facing relaunch-reacquisition refinement on the existing desktop startup family without opening a new product lane or materially expanded feature family, so the next release remains a patch prerelease.
-Release Scope: completed FB-046 WS-1 accepted relaunch replacement-session settled re-entry proof, H-1 relaunch lifecycle hardening, LV-1 real desktop shortcut evidence, reusable validation evidence, merged-unreleased release-debt truth, and selected-next FB-047 successor lock for the bounded runtime/user-facing lane only.
-Release Artifacts: Tag v1.6.10-prebeta; release title Pre-Beta v1.6.10; rich Markdown release notes summarize the bounded FB-046 relaunch-reacquisition runtime/user-facing package, real shortcut evidence, and the FB-047 successor lane without repeating the release title inside the notes body, and GitHub-generated `## What's Changed` plus `**Full Changelog**:` must be included.
-Post-Release Truth: FB-046 is Released / Closed in `v1.6.10-prebeta` after publication and validation; release debt then clears; and FB-047 remains selected next, `Registry-only`, and branch-not-created until updated `main` is revalidated and Branch Readiness admits the first bounded relaunch-decline preservation slice.
-Next-Branch Creation Gate: After `v1.6.10-prebeta` is published and validated, updated `main` is revalidated, and FB-047 Branch Readiness admits the first bounded runtime/user-facing relaunch-decline preservation slice; branch creation remains blocked until then.
-Current Branch Objective: carry the merged-unreleased FB-046 relaunch-reacquisition package through file-frozen `Release Readiness` on updated `main` after merge while preserving FB-047 as selected next and branch-not-created.
-Next Legal Phase: Release Readiness.
-Active Workstream Chain: FB-046 is merge-target complete and prepared to own merged-unreleased release debt for `v1.6.10-prebeta`; WS-1, H-1, and LV-1 are complete and green; PR-1 merge-target canon completeness, PR-2 selected-next successor lock, and PR-3 live PR creation plus validation are complete; FB-047 is selected next, `Registry-only`, and branch-not-created; and `Release Readiness` is the next legal phase after merge.
+PR Readiness State: Historical proof complete on `feature/fb-046-active-session-relaunch-reacquisition`; PR #92 merged into `main` at `36cf07495dc8e239b20b11afb5194355b77ffd8b`.
+Release Execution State: `v1.6.10-prebeta` is live at https://github.com/GiribaldiTTV/Nexus-Desktop-AI/releases/tag/v1.6.10-prebeta on commit `36cf07495dc8e239b20b11afb5194355b77ffd8b`.
+Current Branch Objective: close FB-046 post-release canon and admit the first bounded runtime/user-facing FB-047 relaunch-decline preservation slice while preserving selected-only truth until `Workstream` begins.
+Next Legal Phase: Workstream.
+Active Workstream Chain: Release debt is clear; FB-047 now holds the selected-only active Branch Readiness lane on `feature/fb-047-active-session-relaunch-decline-preservation`; the first bounded relaunch-decline preservation slice is admitted; and `Workstream` is the next legal phase.
 
-## Merged-Unreleased Release-Debt Owner
+## Current Merged-Unreleased Workstream
 
-ID: FB-046
-Title: Active-session relaunch reacquisition and settled re-entry proof
-Record State: Promoted
-Release Target: v1.6.10-prebeta
-Release Floor: patch prerelease
-Version Rationale: FB-046 delivers a bounded runtime/user-facing relaunch-reacquisition refinement on the existing desktop startup family without opening a new product lane or materially expanded feature family.
-Release Scope: completed FB-046 WS-1 accepted relaunch replacement-session settled re-entry proof, H-1 relaunch lifecycle hardening, LV-1 real desktop shortcut evidence, reusable validation evidence, merged-unreleased release-debt truth, and selected-next FB-047 successor lock for the bounded runtime/user-facing lane only
-Release Artifacts: Tag v1.6.10-prebeta; release title Pre-Beta v1.6.10; rich Markdown release notes summarize the bounded FB-046 relaunch-reacquisition runtime/user-facing package, real shortcut evidence, and the FB-047 successor lane without repeating the release title inside the notes body, and GitHub-generated `## What's Changed` plus `**Full Changelog**:` must be included
-Post-Release Truth: FB-046 becomes Released / Closed in v1.6.10-prebeta after publication and validation; release debt then clears; and FB-047 remains selected next, Registry-only, and branch-not-created until updated main is revalidated and Branch Readiness admits the first relaunch-decline preservation slice
+None.
 
 ## Selected Next Workstream
 
@@ -137,33 +122,33 @@ Post-Release Truth: FB-046 becomes Released / Closed in v1.6.10-prebeta after pu
 - Record State: `Registry-only`
 - Priority: `High`
 - Minimal Scope: Prove and refine the relaunch-decline lane across `desktop/single_instance.py`, `desktop/orin_desktop_launcher.pyw`, `desktop/orin_desktop_main.py`, and the minimum required reusable validator surfaces so declining replacement preserves the active settled session and cleanly terminates the incoming launch without dual ownership or false successor markers.
-- Branch: Not created
-- Branch Creation Gate: after `v1.6.10-prebeta` is published and validated, updated `main` is revalidated, and FB-047 Branch Readiness admits the first bounded runtime/user-facing relaunch-decline preservation slice
+- Branch: `feature/fb-047-active-session-relaunch-decline-preservation`
+- Branch Creation Gate: cleared; `v1.6.10-prebeta` is published and validated, updated `main` is revalidated, and FB-047 Branch Readiness has admitted the first bounded runtime/user-facing relaunch-decline preservation slice
 - Selection Basis: FB-047 is the smallest repo-grounded runtime/user-facing successor after FB-046 because accepted relaunch is now fully proven end to end, but the complementary decline path still lacks first-class proof that declining replacement preserves the settled active session, keeps single-instance ownership with that session, and terminates the incoming launch truthfully without dual ownership or false replacement-session success markers.
 
 ## Active Promoted Workstream
 
-`Docs/workstreams/FB-046_active_session_relaunch_reacquisition.md`
+`None.`
+
+## Latest Released Workstream Context
 
 ### FB-046 Active-session relaunch reacquisition and settled re-entry proof
 
-status: `merged unreleased`
-record state: `Promoted`
+status: `released`
+record state: `Closed`
 priority: `High`
 canonical workstream doc: `Docs/workstreams/FB-046_active_session_relaunch_reacquisition.md`
 branch: `feature/fb-046-active-session-relaunch-reacquisition`
-phase status: merge-target complete release-debt owner after merge; WS-1 accepted relaunch replacement-session settled re-entry proof is complete and validated; H-1 relaunch lifecycle hardening is complete and green; LV-1 live validation is complete and green with real shortcut evidence; `Backlog Completion State` is `Implemented Complete`; and `Release Readiness` is next after merge
-next legal seam: `Release Readiness`
+phase status: Released / Closed in `v1.6.10-prebeta`; PR #92 merged into `main` at `36cf07495dc8e239b20b11afb5194355b77ffd8b`; the release is live on the same commit; release debt is clear; and FB-047 now holds the selected-only active Branch Readiness lane on `feature/fb-047-active-session-relaunch-decline-preservation`.
+next legal seam: none; this record is now historical released truth
 Release Target: `v1.6.10-prebeta`
 Release Floor: `patch prerelease`
 Version Rationale: FB-046 delivers a bounded runtime/user-facing relaunch-reacquisition refinement on the existing desktop startup family without opening a new product lane or materially expanded feature family.
 Release Scope: completed FB-046 WS-1 accepted relaunch replacement-session settled re-entry proof, H-1 relaunch lifecycle hardening, LV-1 real desktop shortcut evidence, reusable validation evidence, merged-unreleased release-debt truth, and selected-next FB-047 successor lock for the bounded runtime/user-facing lane only.
 Release Artifacts: Tag `v1.6.10-prebeta`; release title `Pre-Beta v1.6.10`; rich Markdown release notes summarize the bounded FB-046 relaunch-reacquisition runtime/user-facing package, real shortcut evidence, and the FB-047 successor lane without repeating the release title inside the notes body, and GitHub-generated `## What's Changed` plus `**Full Changelog**:` must be included.
-Post-Release Truth: FB-046 is Released / Closed in `v1.6.10-prebeta` after publication and validation; release debt then clears; and FB-047 remains selected next, `Registry-only`, and branch-not-created until updated `main` is revalidated and Branch Readiness admits the first bounded relaunch-decline preservation slice.
+Post-Release Truth: FB-046 is Released / Closed in `v1.6.10-prebeta`; release debt is clear; and FB-047 now holds the selected-only active Branch Readiness lane on `feature/fb-047-active-session-relaunch-decline-preservation` until `Workstream` promotion begins.
 minimal scope: complete the bounded accepted relaunch lane across `desktop/single_instance.py`, `desktop/orin_desktop_launcher.pyw`, `desktop/orin_desktop_main.py`, `dev/orin_desktop_entrypoint_validation.py`, and `dev/orin_boot_transition_verification.py` so the replacement session reacquires the guard and returns to authoritative settled without widening into `main.py`, `Audio/`, `logs/`, `jarvis_visual/`, installer work, or broader boot-orchestrator implementation
 branch-readiness carry-forward: preserved in `Docs/branch_records/feature_fb_046_active_session_relaunch_reacquisition.md`
-
-## Latest Released Workstream Context
 
 ### FB-044 Boot-to-desktop handoff outcome refinement
 
@@ -271,7 +256,7 @@ The 2026-04-23 priority reading is updated during FB-005 Branch Readiness:
 - FB-043 is now Released / Closed in `v1.6.8-prebeta`.
 - FB-044 and FB-045 are now Released / Closed in `v1.6.9-prebeta`.
 
-Current-branch clarity: latest public prerelease is `v1.6.9-prebeta`; FB-044 and FB-045 are released and closed; release debt is clear; and FB-046 now holds the selected-only active Branch Readiness lane on `feature/fb-046-active-session-relaunch-reacquisition`, with the first bounded relaunch-reacquisition slice admitted and `Workstream` next.
+Current-branch clarity: latest public prerelease is `v1.6.10-prebeta`; FB-044 and FB-045 are released and closed in `v1.6.9-prebeta`; FB-046 is released and closed in `v1.6.10-prebeta`; release debt is clear; and FB-047 now holds the selected-only active Branch Readiness lane on `feature/fb-047-active-session-relaunch-decline-preservation`, with the first bounded relaunch-decline preservation slice admitted and `Workstream` next.
 
 ## Current Merged-Unreleased Workstream
 

--- a/Docs/workstreams/FB-046_active_session_relaunch_reacquisition.md
+++ b/Docs/workstreams/FB-046_active_session_relaunch_reacquisition.md
@@ -7,11 +7,11 @@
 
 ## Record State
 
-- `Promoted`
+- `Closed`
 
 ## Status
 
-- `Merged unreleased (v1.6.10-prebeta)`
+- `Released (v1.6.10-prebeta)`
 
 ## Target Version
 
@@ -23,22 +23,20 @@
 
 ## Current Phase
 
-- Phase: `Release Readiness`
+- Phase: `Release Execution`
 
 ## Phase Status
 
-Merged-Unreleased Release-Debt Owner: FB-046 Active-session relaunch reacquisition and settled re-entry proof
-Repo State: `No Active Branch`
-Repo State: No Active Branch
-Historical Active Branch Before Merge: feature/fb-046-active-session-relaunch-reacquisition
+Repo State: `Historical Traceability`
+Historical Branch: feature/fb-046-active-session-relaunch-reacquisition
 Historical Active Canonical Workstream Doc Before Merge: Docs/workstreams/FB-046_active_session_relaunch_reacquisition.md
-Latest Public Prerelease: v1.6.9-prebeta
-Latest Public Release Commit: 348fd55b944435e3cae80b97acd0bb857fd65d56
-Latest Public Prerelease Publication: https://github.com/GiribaldiTTV/Nexus-Desktop-AI/releases/tag/v1.6.9-prebeta
-Latest Public Prerelease Title: Pre-Beta v1.6.9
-FB-044 and FB-045 are Released / Closed historical proof in v1.6.9-prebeta.
-Release debt is active after merge until v1.6.10-prebeta is published, validated, and post-release canon closure completes.
-Active seam: None. Merge-target release-debt framing is prepared; PR-1 merge-target canon packaging and PR-2 selected-next successor lock are prepared on this branch; and live PR creation plus validation is the remaining PR Readiness gate before merged-main Release Readiness can actually run.
+Latest Public Prerelease: v1.6.10-prebeta
+Latest Public Release Commit: 36cf07495dc8e239b20b11afb5194355b77ffd8b
+Latest Public Prerelease Publication: https://github.com/GiribaldiTTV/Nexus-Desktop-AI/releases/tag/v1.6.10-prebeta
+Latest Public Prerelease Title: Pre-Beta v1.6.10
+FB-046 is Released / Closed historical proof in v1.6.10-prebeta.
+Release debt is clear after publication, validation, and post-release canon closure.
+Active seam: None. This record is now preserved released historical truth.
 
 ## Branch Class
 
@@ -69,7 +67,7 @@ None.
 
 ## Next Legal Phase
 
-- `Release Readiness`
+- `None`
 
 ## Purpose / Why It Matters
 

--- a/Docs/workstreams/FB-046_active_session_relaunch_reacquisition.md
+++ b/Docs/workstreams/FB-046_active_session_relaunch_reacquisition.md
@@ -36,7 +36,7 @@ Latest Public Prerelease Publication: https://github.com/GiribaldiTTV/Nexus-Desk
 Latest Public Prerelease Title: Pre-Beta v1.6.10
 FB-046 is Released / Closed historical proof in v1.6.10-prebeta.
 Release debt is clear after publication, validation, and post-release canon closure.
-Current successor lane: FB-047 is now the active promoted workstream on `feature/fb-047-active-session-relaunch-decline-preservation`; WS-1 declined relaunch incoming-launch truthful exit proof is complete and validated there, and `Hardening` is next.
+Current successor lane: FB-047 is now the active promoted workstream on `feature/fb-047-active-session-relaunch-decline-preservation`; WS-1 declined relaunch incoming-launch truthful exit proof is complete and validated there, H-1 decline-lifecycle hardening is complete / green, and `Live Validation` is next.
 Active seam: None. This record is now preserved released historical truth.
 
 ## Branch Class

--- a/Docs/workstreams/FB-046_active_session_relaunch_reacquisition.md
+++ b/Docs/workstreams/FB-046_active_session_relaunch_reacquisition.md
@@ -36,6 +36,7 @@ Latest Public Prerelease Publication: https://github.com/GiribaldiTTV/Nexus-Desk
 Latest Public Prerelease Title: Pre-Beta v1.6.10
 FB-046 is Released / Closed historical proof in v1.6.10-prebeta.
 Release debt is clear after publication, validation, and post-release canon closure.
+Current successor lane: FB-047 is now the active promoted workstream on `feature/fb-047-active-session-relaunch-decline-preservation`; WS-1 declined relaunch incoming-launch truthful exit proof is complete and validated there, and `Hardening` is next.
 Active seam: None. This record is now preserved released historical truth.
 
 ## Branch Class

--- a/Docs/workstreams/FB-046_active_session_relaunch_reacquisition.md
+++ b/Docs/workstreams/FB-046_active_session_relaunch_reacquisition.md
@@ -36,7 +36,7 @@ Latest Public Prerelease Publication: https://github.com/GiribaldiTTV/Nexus-Desk
 Latest Public Prerelease Title: Pre-Beta v1.6.10
 FB-046 is Released / Closed historical proof in v1.6.10-prebeta.
 Release debt is clear after publication, validation, and post-release canon closure.
-Current successor lane: FB-047 is now the active promoted workstream on `feature/fb-047-active-session-relaunch-decline-preservation`; WS-1 declined relaunch incoming-launch truthful exit proof is complete and validated there, H-1 decline-lifecycle hardening is complete / green, and `Live Validation` is next.
+Current successor lane: FB-047 is now the active promoted workstream on `feature/fb-047-active-session-relaunch-decline-preservation`; WS-1 declined relaunch incoming-launch truthful exit proof is complete and validated there, H-1 decline-lifecycle hardening is complete / green, LV-1 is complete / green, and `PR Readiness` is next.
 Active seam: None. This record is now preserved released historical truth.
 
 ## Branch Class

--- a/Docs/workstreams/FB-047_active_session_relaunch_decline_preservation.md
+++ b/Docs/workstreams/FB-047_active_session_relaunch_decline_preservation.md
@@ -19,7 +19,7 @@
 
 ## Current Phase
 
-- Phase: `Hardening`
+- Phase: `Live Validation`
 
 ## Phase Status
 
@@ -33,7 +33,7 @@ Latest Public Prerelease Title: `Pre-Beta v1.6.10`
 FB-046 is `Released / Closed` historical proof in `v1.6.10-prebeta`.
 Release debt is clear after publication, validation, and post-release canon closure.
 FB-047 is now the active promoted workstream on this branch.
-WS-1 is complete / validated, H-1 is complete / green, `Backlog Completion State` is `Implemented Complete`, and `Live Validation` is next.
+WS-1 is complete / validated, H-1 is complete / green, LV-1 is complete / green, `Backlog Completion State` is `Implemented Complete`, and `PR Readiness` is next.
 Active seam: `None.`
 
 ## Branch Class
@@ -65,7 +65,7 @@ None.
 
 ## Next Legal Phase
 
-- `Live Validation`
+- `PR Readiness`
 
 ## Purpose / Why It Matters
 
@@ -241,21 +241,56 @@ H-1 pressure-tested the completed FB-047 decline-preservation lane across rapid 
 - Mixed decline/accept proof now distinguishes preserved-session logs, declined incoming-launch logs, and accepted replacement-session logs by content instead of fragile file-order assumptions.
 - The shipped startup route, accepted-relaunch proof, repeated-launch proof, and explicit dev-boot proof remain green after the added decline-lane pressure coverage.
 
+## Live Validation Record
+
+LV-1 validates the completed FB-047 relaunch-decline preservation slice chain against live repo truth, the declared real desktop shortcut path, explicit dev boot-proof evidence, exact User Test Summary state, and branch cleanliness. This pass stays bounded to the admitted relaunch/runtime ownership surfaces and does not reopen `main.py`, `Audio/`, `logs/`, `jarvis_visual/`, installer work, or broader boot-orchestrator scope.
+
+### Live Validation Findings
+
+- Repo Truth Alignment: `Docs/feature_backlog.md`, `Docs/prebeta_roadmap.md`, and this workstream record align on FB-047 as the active promoted runtime/user-facing implementation workstream, latest public prerelease `v1.6.10-prebeta`, WS-1 complete, H-1 complete, and PR Readiness next after LV-1 completion.
+- Branch Truth Alignment: the checked-out branch is `feature/fb-047-active-session-relaunch-decline-preservation`, aligned with origin on the hardened decline-lifecycle baseline before this LV-1 pass.
+- User-Facing Shortcut Applicability: applicable and exercised. FB-047 changes user-facing relaunch-decline ownership truth on the shipped desktop runtime family, so final Live Validation used the real declared desktop shortcut rather than helper-only proof as the final user-facing shortcut gate.
+- Real Shortcut Gate Result: PASS. Launching through `C:\Users\anden\OneDrive\Desktop\Nexus Desktop Launcher.lnk` exercised the active branch runtime, produced dedicated evidence under `dev/logs/fb_047_live_validation/20260426_124943/desktop_shortcut_gate`, reached launcher-owned `DESKTOP_SETTLED_OBSERVED|state=dormant`, reached renderer `STARTUP_READY`, recorded `WINDOW_SHOW_REQUESTED` and `TRAY_ENTRY_READY|available=true`, reached the authoritative settled marker, and completed on the clean-shutdown lifecycle path with no launcher failure flow.
+- Production Launch Path Evidence: PASS. Fresh reusable entrypoint validation still proves the VBS default path, VBS fallback path, direct `main.py` desktop handoff, repeated-launch stability, accepted relaunch, slow accepted relaunch, declined relaunch, rapid consecutive declined launches, mixed decline/accept relaunch sequencing, relaunch after recoverable post-settled exit, rapid consecutive accepted relaunch cycles, and no-dual-ownership guard behavior on the active branch.
+- Explicit Dev Boot-Proof Route Evidence: PASS. `python dev\orin_boot_transition_verification.py` still proves the explicit `auto_handoff_skip_import` boot-profile route reaches the ordered boot markers, converges on the authoritative settled marker, and exits cleanly.
+- Decline Lifecycle Integrity: PASS. Real execution on the declared shortcut route lands on valid clean termination after settled; fresh reusable multi-session proof demonstrates that declined incoming launches preserve the active settled owner, emit explicit decline success markers, never leak replacement-session markers, and only transfer ownership in the later accepted phase of a mixed decline/accept sequence.
+- User Test Summary Applicability: focused waiver. The completed FB-047 delta is the full currently implementable relaunch-decline preservation pass for this backlog item, but it does not add a new settings journey, persisted user-content path, or broader operator workflow that a filled manual User Test Summary would materially validate beyond the captured real-shortcut evidence, reusable multi-session decline and mixed decline/accept proof, production-path validation, and explicit dev boot proof.
+- Desktop Export Applicability: no desktop `User Test Summary.txt` export is required for LV-1 because User Test Summary results are waived for this focused relaunch-decline refinement.
+- Cleanup: the real shortcut pass left no residual launcher/runtime processes after shutdown and post-validation cleanup.
+
+### Live Validation Completion Decision
+
+- LV-1 Result: `Complete / green with real desktop shortcut evidence and waiver-based User Test Summary digestion recorded`
+- User-facing shortcut gate: `PASS` with exact markers in `## User Test Summary`
+- User Test Summary results gate: `WAIVED` with exact markers in `## User Test Summary`
+- Validation Layer: repo-truth alignment, real desktop shortcut launch evidence, reusable production-path validation, explicit dev boot proof, reusable decline-lifecycle proof, and governance validation
+- Continue/Stop Decision: stop at the Live Validation phase boundary after validation because FB-047 LV-1 proof is green and the next normal phase is `PR Readiness`.
+
+### LV-1 Validation Results
+
+- Real desktop shortcut gate: PASS; report `dev/logs/fb_047_live_validation/20260426_124943/desktop_shortcut_gate/DesktopShortcutGateReport.json`
+- `python dev\orin_desktop_entrypoint_validation.py`: PASS
+  - report: `dev/logs/desktop_entrypoint_validation/reports/DesktopEntrypointValidationReport_20260426_125222.txt`
+- `python dev\orin_boot_transition_verification.py`: PASS
+  - report: `dev/logs/boot_transition_verification/reports/BootTransitionVerificationReport_20260426_125009.txt`
+- `python dev\orin_branch_governance_validation.py`: PASS
+- `git diff --check`: PASS
+- LV-1 phase-state scan: PASS; current authority surfaces report FB-047 Live Validation complete and PR Readiness as the next legal phase.
+
 ## User Test Summary
 
-User-Facing Shortcut Path: `Pending Live Validation classification`
-User-Facing Shortcut Validation: `Pending`
-User Test Summary Results: `Pending`
-
-- Workstream proof currently rests on reusable production-path validation and explicit dev-boot proof.
-- Live Validation will classify real desktop shortcut applicability and the exact User Test Summary state for this lane.
+- User-Facing Shortcut Path: `C:\Users\anden\OneDrive\Desktop\Nexus Desktop Launcher.lnk`
+- User-Facing Shortcut Validation: `PASS`
+- User Test Summary Results: `WAIVED`
+- User Test Summary Waiver Reason: The completed FB-047 delta is the full currently implementable relaunch-decline preservation pass for the existing desktop runtime path and is already covered by fresh real-shortcut evidence, reusable multi-session decline and mixed decline/accept proof, production-path validation, and explicit dev boot verification. It does not add a new settings journey, persisted user-content path, or broader operator workflow that a filled manual User Test Summary would materially validate beyond that captured evidence.
+- Desktop User Test Summary Export: `Not required; waiver path`
 
 ## Seam Continuation Decision
 
-Continue Decision: `Continue`
-Next Active Seam: `Live Validation`
-Stop Condition: `Stop after FB-047 Live Validation only if repo truth, real shortcut applicability, User Test Summary classification, or decline-path ownership truth regresses beyond the admitted runtime/user-facing lane.`
-Continuation Action: `Run FB-047 Live Validation on this same branch, classify real desktop shortcut applicability and User Test Summary status, and confirm the hardened decline-preservation proof stays green on the shipped route.`
+Continue Decision: `Advance after LV-1 because backlog completion is implemented complete and the next legal phase is PR Readiness`
+Next Active Seam: `None`
+Stop Condition: `Reached PR Readiness gate after LV-1 completion`
+Continuation Action: `Prepare merge-target canon, selected-next truth, PR package details, and live PR state for the completed relaunch-decline preservation slice`
 
 ## Active Seam
 
@@ -263,4 +298,5 @@ Active seam: `None.`
 
 - WS-1 is complete and validated.
 - H-1 is complete and green.
-- `Live Validation` is now the next legal phase.
+- LV-1 is complete and green.
+- `PR Readiness` is now the next legal phase.

--- a/Docs/workstreams/FB-047_active_session_relaunch_decline_preservation.md
+++ b/Docs/workstreams/FB-047_active_session_relaunch_decline_preservation.md
@@ -11,7 +11,11 @@
 
 ## Status
 
-- `In Progress`
+- `Merged unreleased (v1.6.11-prebeta)`
+
+## Target Version
+
+- `v1.6.11-prebeta`
 
 ## Canonical Branch
 
@@ -19,22 +23,22 @@
 
 ## Current Phase
 
-- Phase: `Live Validation`
+- Phase: `Release Readiness`
 
 ## Phase Status
 
-Repo State: `Active Branch`
-Current Active Branch: `feature/fb-047-active-session-relaunch-decline-preservation`
-Current Active Canonical Workstream Doc: `Docs/workstreams/FB-047_active_session_relaunch_decline_preservation.md`
+Merged-Unreleased Release-Debt Owner: FB-047 Active-session relaunch decline session-preservation proof
+Repo State: `No Active Branch`
+Repo State: No Active Branch
+Historical Active Branch Before Merge: `feature/fb-047-active-session-relaunch-decline-preservation`
+Historical Active Canonical Workstream Doc Before Merge: `Docs/workstreams/FB-047_active_session_relaunch_decline_preservation.md`
 Latest Public Prerelease: `v1.6.10-prebeta`
 Latest Public Release Commit: `36cf07495dc8e239b20b11afb5194355b77ffd8b`
 Latest Public Prerelease Publication: `https://github.com/GiribaldiTTV/Nexus-Desktop-AI/releases/tag/v1.6.10-prebeta`
 Latest Public Prerelease Title: `Pre-Beta v1.6.10`
 FB-046 is `Released / Closed` historical proof in `v1.6.10-prebeta`.
-Release debt is clear after publication, validation, and post-release canon closure.
-FB-047 is now the active promoted workstream on this branch.
-WS-1 is complete / validated, H-1 is complete / green, LV-1 is complete / green, `Backlog Completion State` is `Implemented Complete`, and `PR Readiness` is next.
-Active seam: `None.`
+Release debt is active after merge until `v1.6.11-prebeta` is published, validated, and post-release canon closure completes.
+Active seam: `None.` PR Readiness is complete, FB-048 is selected next as a branch-not-created `Registry-only` successor, and merged-main `Release Readiness` is next after merge.
 
 ## Branch Class
 
@@ -65,7 +69,7 @@ None.
 
 ## Next Legal Phase
 
-- `PR Readiness`
+- `Release Readiness`
 
 ## Purpose / Why It Matters
 
@@ -287,10 +291,10 @@ LV-1 validates the completed FB-047 relaunch-decline preservation slice chain ag
 
 ## Seam Continuation Decision
 
-Continue Decision: `Advance after LV-1 because backlog completion is implemented complete and the next legal phase is PR Readiness`
+Continue Decision: `Advance after PR-3 because backlog completion is implemented complete, PR Readiness is complete, and the next legal phase after merge is Release Readiness`
 Next Active Seam: `None`
-Stop Condition: `Reached PR Readiness gate after LV-1 completion`
-Continuation Action: `Prepare merge-target canon, selected-next truth, PR package details, and live PR state for the completed relaunch-decline preservation slice`
+Stop Condition: `Reached Release Readiness gate after PR package completion`
+Continuation Action: `Run file-frozen Release Readiness on updated main for v1.6.11-prebeta after merge`
 
 ## Active Seam
 
@@ -299,4 +303,101 @@ Active seam: `None.`
 - WS-1 is complete and validated.
 - H-1 is complete and green.
 - LV-1 is complete and green.
-- `PR Readiness` is now the next legal phase.
+- `Release Readiness` is now the next legal phase after merge.
+
+## Governance Drift Audit
+
+Governance Drift Found: No.
+
+- Merge-target canon is synchronized to merged-unreleased release-debt truth before PR green.
+- `Repo State` is `No Active Branch` in merge-target surfaces, so this package does not depend on a later post-merge active-branch cleanup.
+- FB-048 is explicitly selected next with `Branch: Not created`, so successor admission is not being confused with branch existence.
+- No docs-only bypass, planning-loop bypass, repair-only branch posture, or hidden continuation language is being used to claim partial completion for FB-047.
+
+## Historical PR Package State
+
+Historical Merged-Unreleased Release-Debt Owner At PR Package Time: FB-047 Active-session relaunch decline session-preservation proof
+Historical Repo State At PR Package Time: No Active Branch
+Target Version: v1.6.11-prebeta
+Latest Public Prerelease: v1.6.10-prebeta
+Release Debt: Active after merge until `v1.6.11-prebeta` is published, validated, and post-release canon closure completes
+Release Target: v1.6.11-prebeta
+Release Title: Pre-Beta v1.6.11
+Release Floor: patch prerelease
+Version Rationale: FB-047 remains a bounded runtime/user-facing relaunch-decline preservation refinement on the existing desktop startup family; it does not introduce a new product lane or materially expanded capability family
+Release Scope: completed FB-047 WS-1 declined relaunch incoming-launch truthful exit proof, H-1 decline lifecycle hardening, LV-1 real desktop shortcut evidence, reusable validation evidence, merged-unreleased release-debt truth, and selected-next FB-048 successor lock for the bounded runtime/user-facing lane only
+Release Artifacts: Tag v1.6.11-prebeta; release title Pre-Beta v1.6.11; rich Markdown release notes summarize the bounded FB-047 relaunch-decline preservation runtime/user-facing package, real shortcut evidence, and the FB-048 successor lane without repeating the release title inside the notes body, and GitHub-generated `## What's Changed` plus `**Full Changelog**:` must be included
+Post-Release Truth: FB-047 is Released / Closed in `v1.6.11-prebeta` after publication and validation; release debt then clears, and FB-048 Branch Readiness may begin only after updated `main` is revalidated and the first bounded runtime/user-facing relaunch signal-failure and wait-timeout truth slice is admitted
+Selected Next Workstream: FB-048 Active-session relaunch signal-failure and wait-timeout truth
+Next-Branch Creation Gate: After `v1.6.11-prebeta` is published and validated, updated `main` is revalidated, and FB-048 Branch Readiness admits the first bounded runtime/user-facing relaunch signal-failure and wait-timeout truth slice; branch creation remains blocked until then
+
+## Post-Merge State
+
+- Post-merge repo state: `No Active Branch` because FB-047 will own merged-unreleased release debt on `main` for `v1.6.11-prebeta`.
+- Pending release scope after merge: the completed bounded FB-047 relaunch-decline preservation slice chain only.
+- Successor state after merge: FB-048 remains selected next, `Registry-only`, and branch-not-created until `v1.6.11-prebeta` is published, validated, updated `main` is revalidated, and bounded Branch Readiness admits the first relaunch signal-failure and wait-timeout truth slice.
+
+## Release Window Audit
+
+Release Window Audit: PASS
+Window Scope: FB-047 WS-1 declined relaunch incoming-launch truthful exit proof, H-1 decline lifecycle hardening, LV-1 real shortcut validation, merge-target release-debt framing for `v1.6.11-prebeta`, and successor-lock selection of FB-048.
+Known Window Blockers Reviewed: missing merged-unreleased release-debt framing; missing selected-next successor lock after FB-047 completion; risk of self-selection drift; missing live PR state; and risk of widening beyond the bounded relaunch-decline lane.
+Remaining Known Release Blockers: None
+Another Pre-Release Repair PR Required: NO
+Release Window Split Waiver: None
+
+## PR Readiness Record
+
+PR Readiness validates the completed bounded FB-047 runtime slice chain for merge to `main`. This record aligns the `v1.6.11-prebeta` release-debt package, selects the next runtime/user-facing workstream, prepares durable PR package details, and then records live PR validation before reporting green.
+
+### PR-1 Merge-Target Canon Findings
+
+- Merge Target: `main`.
+- Head Branch: `feature/fb-047-active-session-relaunch-decline-preservation`.
+- Source-of-Truth Alignment: PASS. `Docs/Main.md`, `Docs/feature_backlog.md`, `Docs/prebeta_roadmap.md`, `Docs/workstreams/index.md`, and this workstream record align on FB-047 as the merged-unreleased release-debt owner for `v1.6.11-prebeta`.
+- Release-Debt Framing: PASS. `v1.6.10-prebeta` is the latest public prerelease; after merge, FB-047 becomes the merged-unreleased release-debt owner for `v1.6.11-prebeta`.
+- Release Target: `v1.6.11-prebeta`.
+- Release Title: `Pre-Beta v1.6.11`.
+- Release Floor: `patch prerelease`.
+- Version Rationale: `patch prerelease` remains required because the delivered FB-047 delta is a bounded runtime/user-facing relaunch-decline preservation refinement on the existing desktop startup family, not a new capability lane or materially expanded feature family.
+- Release Scope: complete WS-1 declined relaunch incoming-launch truthful exit proof, H-1 decline lifecycle hardening, LV-1 real shortcut evidence, selected-next successor lock, and PR package history.
+- Release Artifacts: Tag `v1.6.11-prebeta`; release title `Pre-Beta v1.6.11`; rich Markdown release notes summarize the bounded FB-047 relaunch-decline preservation runtime/user-facing package without repeating the release title inside the notes body, and GitHub-generated `## What's Changed` plus `**Full Changelog**:` must be included.
+- Post-Release Truth: FB-047 is Released / Closed in `v1.6.11-prebeta` after publication and validation; release debt then clears, and FB-048 Branch Readiness may begin only after updated `main` is revalidated and the first bounded runtime/user-facing relaunch signal-failure and wait-timeout truth slice is admitted.
+
+### PR-2 Selected-Next Workstream Findings
+
+- Selected Next Workstream: FB-048 Active-session relaunch signal-failure and wait-timeout truth.
+- Selected Next Basis: FB-048 is the smallest repo-grounded runtime/user-facing successor after FB-047 because accepted relaunch success and declined relaunch preservation are now first-class proven surfaces, but the accepted incoming-launch failure lane still lacks equivalent proof when relaunch signaling fails or the current session does not release before the reacquire wait deadline.
+- Selected Next Record State At PR Package Time: `Registry-only`.
+- Selected Next Implementation Branch At PR Package Time: Not created.
+- Branch Creation Gate At PR Package Time: After `v1.6.11-prebeta` is published and validated, updated `main` is revalidated, and FB-048 Branch Readiness admits the first bounded runtime/user-facing relaunch signal-failure and wait-timeout truth slice.
+- Branch Containment At PR Package Time: PASS. No local or remote branch exists for FB-048, and no open FB-048 PR exists.
+
+### PR-3 PR Package Details
+
+- PR Title: `FB-047 Active-Session Relaunch Decline Preservation`
+- Base Branch: `main`
+- Head Branch: `feature/fb-047-active-session-relaunch-decline-preservation`
+- PR Summary: Deliver the bounded FB-047 runtime/user-facing relaunch-decline preservation slice by proving declined incoming launches preserve the settled active session, keep single-instance ownership with that session, and exit truthfully without false replacement-session markers; preserving real desktop shortcut and explicit dev boot proof; aligning merge-target canon for `v1.6.11-prebeta`; and selecting FB-048 as the next relaunch signal-failure and wait-timeout truth lane.
+- PR URL: pending live creation
+- PR State At PR Package Time: pending live creation
+- Review Thread State: pending live creation
+- Merge Readiness At PR Package Time: pending live creation
+
+### PR Readiness Completion Decision
+
+- PR-1 Result: Complete / green.
+- PR-2 Result: Complete / green.
+- PR-3 Result: Pending live PR creation and validation.
+- Decline Lifecycle Integrity: declined incoming launches now preserve the active settled owner, emit explicit preserved-session success markers, never leak replacement-session markers, and keep accepted-relaunch transfer truth isolated to the accept lane.
+- Next legal action after merge: file-frozen Release Readiness on updated `main` for `v1.6.11-prebeta`.
+
+### PR Readiness Validation Results
+
+- `python dev\orin_branch_governance_validation.py`: PASS; merged-unreleased release-debt package truth is green.
+- `python dev\orin_branch_governance_validation.py --pr-readiness-gate`: pending live PR creation and state validation.
+- `git diff --check`: PASS.
+- User-facing shortcut gate: PASS with exact markers in `## User Test Summary`.
+- User Test Summary results gate: WAIVED with exact markers in `## User Test Summary`.
+- Next-workstream selection gate: PASS. FB-048 is selected next, `Registry-only`, and branch-not-created.
+- Live PR state: pending live creation.

--- a/Docs/workstreams/FB-047_active_session_relaunch_decline_preservation.md
+++ b/Docs/workstreams/FB-047_active_session_relaunch_decline_preservation.md
@@ -1,0 +1,220 @@
+# FB-047 Active-Session Relaunch Decline Preservation
+
+## Identity
+
+- ID: `FB-047`
+- Title: `Active-session relaunch decline session-preservation proof`
+
+## Record State
+
+- `Promoted`
+
+## Status
+
+- `In Progress`
+
+## Canonical Branch
+
+- `feature/fb-047-active-session-relaunch-decline-preservation`
+
+## Current Phase
+
+- Phase: `Workstream`
+
+## Phase Status
+
+Repo State: `Active Branch`
+Current Active Branch: `feature/fb-047-active-session-relaunch-decline-preservation`
+Current Active Canonical Workstream Doc: `Docs/workstreams/FB-047_active_session_relaunch_decline_preservation.md`
+Latest Public Prerelease: `v1.6.10-prebeta`
+Latest Public Release Commit: `36cf07495dc8e239b20b11afb5194355b77ffd8b`
+Latest Public Prerelease Publication: `https://github.com/GiribaldiTTV/Nexus-Desktop-AI/releases/tag/v1.6.10-prebeta`
+Latest Public Prerelease Title: `Pre-Beta v1.6.10`
+FB-046 is `Released / Closed` historical proof in `v1.6.10-prebeta`.
+Release debt is clear after publication, validation, and post-release canon closure.
+FB-047 is now the active promoted workstream on this branch.
+WS-1 is complete / validated, `Backlog Completion State` is `Implemented Complete`, and `Hardening` is next.
+Active seam: `None.`
+
+## Branch Class
+
+- `implementation`
+
+## Blockers
+
+None.
+
+## Entry Basis
+
+- `v1.6.10-prebeta` is published and validated on commit `36cf07495dc8e239b20b11afb5194355b77ffd8b`.
+- FB-046 is live released, and merged-unreleased release debt is clear after publication, validation, and post-release canon closure.
+- Accepted relaunch is already proven end to end across shutdown, single-instance release, guard reacquisition, replacement-session settled re-entry, and truthful post-settled lifecycle handling.
+- What was still missing was equally truthful proof for the complementary decline lane: when an incoming launch reaches an already-settled active session and replacement is declined, the repo needed to prove that the active session stays owner, the incoming launch exits cleanly, and no replacement-session markers leak into that path.
+
+## Exit Criteria
+
+- declined relaunch is proven end to end across launcher path, single-instance guard truth, and reusable validators
+- the active settled session remains owner and unchanged while incoming launches are declined
+- incoming declined launches exit truthfully without replacement-session activation, settled, or guard-release markers
+- repeated incoming declined launches stay single-owner and do not widen into dual-ownership ambiguity
+- the branch does not leave `Workstream` until FB-047 records `Backlog Completion State`
+
+## Rollback Target
+
+- `Workstream`
+
+## Next Legal Phase
+
+- `Hardening`
+
+## Purpose / Why It Matters
+
+FB-047 exists to make relaunch decline just as truthful as accepted relaunch. The runtime already knew how to keep the current session when replacement was declined, but the repo still described that path too loosely. The remaining job was to stop treating it like a generic already-running skip and prove the exact outcome: the active settled session stayed owner, the incoming launch exited cleanly, and no replacement-session lifecycle markers were emitted.
+
+## Scope
+
+- bounded declined-relaunch lifecycle refinement across `desktop/single_instance.py`, `desktop/orin_desktop_launcher.pyw`, and `dev/orin_desktop_entrypoint_validation.py`
+- reusable validation proof that the active session remains owner while repeated incoming declined launches exit truthfully
+- direct canon updates needed to promote FB-047 into active workstream truth and preserve the historical FB-046 Branch Readiness record
+- for FB-047, `bounded` describes scope and blast radius, not partiality; this branch is the full currently implementable FB-047 runtime/user-facing pass unless a later canon change explicitly broadens FB-047 or a new backlog item is opened
+
+## Non-Goals
+
+- no `main.py` ownership rewrite
+- no `Audio/` changes
+- no `logs/` ownership changes
+- no `jarvis_visual/` relocation or reorganization
+- no installer or shortcut-registration redesign
+- no broader boot-orchestrator implementation
+- no accepted-relaunch semantics rewrite beyond preserving already-green proof
+
+## Planning-Loop Guardrail
+
+Implementation Delta Class: `runtime/user-facing`
+Docs-Only Workstream: `No`
+Planning-Loop Bypass User Approval: `None`
+Planning-Loop Bypass Reason: `None`
+
+- FB-047 remains a real runtime/user-facing implementation lane and must not collapse back into planning-only narration.
+
+## Slice Continuation Policy
+
+Slice Continuation Default: `Same-branch backlog completion`
+Backlog-Split User Approval: `None`
+Backlog-Split Reason: `None`
+
+- WS-1 is the first completed FB-047 slice, not a branch cap.
+- Additional FB-047 slices would continue on this same branch if more implementable relaunch-decline work remained.
+- For the current FB-047 definition, that continuation rule is now satisfied: no additional implementable FB-047 runtime slices remain on this branch.
+
+## Backlog Completion Status
+
+Backlog Completion State: `Implemented Complete`
+Remaining Implementable Work: `None`
+Future-Dependent Blockers: `None`
+
+- This branch now represents the full currently implementable FB-047 runtime/user-facing pass.
+- Future relaunch-decline or ownership issues should create a new backlog item or explicitly broaden FB-047 in source truth before more FB-047 slice work is claimed.
+
+## Validation Contract
+
+- run `python -m py_compile desktop\single_instance.py desktop\orin_desktop_launcher.pyw desktop\orin_desktop_main.py dev\orin_desktop_entrypoint_validation.py dev\orin_boot_transition_verification.py`
+- run `python dev\orin_desktop_entrypoint_validation.py`
+- run `python dev\orin_boot_transition_verification.py`
+- run `python dev\orin_branch_governance_validation.py`
+- run `git diff --check`
+- preserve proof that default launch, accepted relaunch, repeated launch, and explicit dev-boot paths remain green while declined relaunch becomes first-class preserved-session truth
+
+## Artifact History
+
+- `dev/orin_desktop_entrypoint_validation.py`
+  - Classification: `Reusable`
+  - Purpose: validates canonical production launch paths, accepted relaunch, repeated launch, and now repeated declined incoming-launch preservation proof
+  - Reuse: continue extending this helper before creating another overlapping relaunch validator
+- `dev/orin_boot_transition_verification.py`
+  - Classification: `Reusable`
+  - Purpose: proves explicit dev boot still converges on the same authoritative settled truth while relaunch semantics evolve around it
+  - Reuse: preserve this helper as the explicit dev-boot truth owner when relaunch ownership changes
+
+## Admitted Implementation Slice
+
+### WS-1 declined relaunch incoming-launch truthful exit proof
+
+- Status: `Complete / validated`
+- Goal: prove and refine end-to-end declined relaunch so the active settled session remains owner, incoming launches exit cleanly, and no replacement-session lifecycle markers appear
+- Exact Affected Paths:
+  - `desktop/single_instance.py`
+  - `desktop/orin_desktop_launcher.pyw`
+  - `dev/orin_desktop_entrypoint_validation.py`
+  - `Docs/workstreams/FB-047_active_session_relaunch_decline_preservation.md`
+  - `Docs/workstreams/index.md`
+  - `Docs/feature_backlog.md`
+  - `Docs/prebeta_roadmap.md`
+  - `Docs/Main.md`
+  - `Docs/branch_records/index.md`
+  - `Docs/branch_records/feature_fb_047_active_session_relaunch_decline_preservation.md`
+  - `Docs/workstreams/FB-046_active_session_relaunch_reacquisition.md`
+
+### WS-1 Implementation Results
+
+- `desktop/single_instance.py` now exposes a harness-only auto-decline relaunch path so declined replacement can be exercised without dialog-click masking and without altering production prompt behavior.
+- `desktop/orin_desktop_launcher.pyw` now classifies declined replacement as an explicit clean incoming-launch outcome with `RELAUNCH_DECLINED_SESSION_PRESERVED` instead of collapsing that path into the generic `ALREADY_RUNNING` skip marker.
+- `dev/orin_desktop_entrypoint_validation.py` now runs a real declined-relaunch cycle with repeated incoming launches and proves:
+  - the original session reaches `DESKTOP_OUTCOME|SETTLED|state=dormant`
+  - incoming launches detect the single-instance conflict and record decline markers
+  - the active session never receives a relaunch request
+  - incoming declined launches never emit replacement-session, reacquire, settled, or guard-release markers
+  - the preserved active session completes on a truthful clean-shutdown or already-valid post-settled recoverable lane without dual ownership
+- Existing accepted-relaunch, repeated-launch, startup, and explicit dev-boot proof paths stayed green.
+
+### WS-1 Validation Results
+
+- `python -m py_compile desktop\single_instance.py desktop\orin_desktop_launcher.pyw desktop\orin_desktop_main.py dev\orin_desktop_entrypoint_validation.py dev\orin_boot_transition_verification.py`: PASS
+- `python dev\orin_desktop_entrypoint_validation.py`: PASS
+  - report: `dev/logs/desktop_entrypoint_validation/reports/DesktopEntrypointValidationReport_20260426_114807.txt`
+- `python dev\orin_boot_transition_verification.py`: PASS
+  - report: `dev/logs/boot_transition_verification/reports/BootTransitionVerificationReport_20260426_114236.txt`
+- `python dev\orin_branch_governance_validation.py`: PASS
+- `git diff --check`: PASS with line-ending normalization warnings only
+
+## Decline Lifecycle Result
+
+Declined relaunch is now a first-class proven lifecycle:
+
+- session 1 reaches `DESKTOP_OUTCOME|SETTLED|state=dormant`
+- incoming launch 1 detects active ownership, records decline, and exits cleanly
+- incoming launch 2 does the same without changing ownership or emitting replacement-session truth
+- the preserved active session remains the sole runtime owner until its own later lifecycle completion
+
+The proof now stops at the right boundary and says what actually happened, rather than implying that a conflict alone is enough to explain the outcome.
+
+## Ownership Integrity
+
+Single-instance ownership remains with the active settled session throughout the decline lane:
+
+- no relaunch request reaches the active session
+- no replacement-session reacquire or settled markers appear on incoming declined launches
+- no dual ownership or false replacement-session success surface appears during repeated incoming launches
+
+## User Test Summary
+
+User-Facing Shortcut Path: `Pending Live Validation classification`
+User-Facing Shortcut Validation: `Pending`
+User Test Summary Results: `Pending`
+
+- Workstream proof currently rests on reusable production-path validation and explicit dev-boot proof.
+- Live Validation will classify real desktop shortcut applicability and the exact User Test Summary state for this lane.
+
+## Seam Continuation Decision
+
+Continue Decision: `Continue`
+Next Active Seam: `Hardening`
+Stop Condition: `Stop after FB-047 Hardening only if startup, accepted-relaunch proof, or decline-path ownership truth regresses beyond the admitted runtime/user-facing lane.`
+Continuation Action: `Pressure-test the completed decline-preservation pass on this same branch, preserve active-session ownership through repeated declined incoming launches, and keep accepted-relaunch plus default startup proof green.`
+
+## Active Seam
+
+Active seam: `None.`
+
+- WS-1 is complete and validated.
+- `Hardening` is now the next legal phase.

--- a/Docs/workstreams/FB-047_active_session_relaunch_decline_preservation.md
+++ b/Docs/workstreams/FB-047_active_session_relaunch_decline_preservation.md
@@ -19,7 +19,7 @@
 
 ## Current Phase
 
-- Phase: `Workstream`
+- Phase: `Hardening`
 
 ## Phase Status
 
@@ -33,7 +33,7 @@ Latest Public Prerelease Title: `Pre-Beta v1.6.10`
 FB-046 is `Released / Closed` historical proof in `v1.6.10-prebeta`.
 Release debt is clear after publication, validation, and post-release canon closure.
 FB-047 is now the active promoted workstream on this branch.
-WS-1 is complete / validated, `Backlog Completion State` is `Implemented Complete`, and `Hardening` is next.
+WS-1 is complete / validated, H-1 is complete / green, `Backlog Completion State` is `Implemented Complete`, and `Live Validation` is next.
 Active seam: `None.`
 
 ## Branch Class
@@ -65,7 +65,7 @@ None.
 
 ## Next Legal Phase
 
-- `Hardening`
+- `Live Validation`
 
 ## Purpose / Why It Matters
 
@@ -196,6 +196,51 @@ Single-instance ownership remains with the active settled session throughout the
 - no replacement-session reacquire or settled markers appear on incoming declined launches
 - no dual ownership or false replacement-session success surface appears during repeated incoming launches
 
+## H-1 Hardening Record
+
+H-1 pressure-tested the completed FB-047 decline-preservation lane across rapid repeated declined incoming launches, replacement-session marker timing, single-instance guard ownership under timing stress, mixed decline/accept sequences, and validator classification consistency without widening beyond the admitted runtime/user-facing surfaces.
+
+### Hardening Findings
+
+- Rapid consecutive declined incoming launches remain single-owner: the active settled session stays unchanged, and each incoming launch records conflict plus decline before exiting cleanly.
+- Replacement-session success markers do not appear on declined incoming launches, and no guard-transfer or reacquire markers leak into decline-only scenarios.
+- Mixed decline/accept sequences stay truthful: decline preserves the original owner, and guard transfer occurs only in the later accepted relaunch phase after the original session receives relaunch and release markers.
+- The main hidden coupling was in validator evidence attribution and wrapper lifecycle timing, not in the runtime decline lane itself. Multi-session scenarios needed content-based session identification and could not treat the `cscript` wrapper exit as authoritative runtime completion.
+- Accepted-relaunch, repeated-launch, default startup, and explicit dev-boot proof paths all remained green while the decline-specific pressure tests expanded.
+
+### Hardening Corrections
+
+- `dev/orin_desktop_entrypoint_validation.py` now identifies follow-on runtime logs in relaunch scenarios by session evidence instead of sorted filename order.
+- `dev/orin_desktop_entrypoint_validation.py` now adds reusable coverage for:
+  - rapid consecutive declined relaunch cycles
+  - mixed decline-then-accept relaunch sequencing
+  - decline-path marker timing under repeated incoming launches
+- Multi-session VBS observation loops no longer treat early `cscript` wrapper exit as proof that the underlying launcher/runtime lifecycle has completed.
+- No broader runtime correction was needed in `desktop/single_instance.py` or `desktop/orin_desktop_launcher.pyw`; the decline ownership model itself held under the new pressure tests.
+
+### H-1 Completion Decision
+
+- H-1 Result: `Complete / green`
+- Remaining implementable work inside FB-047: `None`
+- Stop condition: phase boundary reached; Hardening is complete after H-1.
+
+### H-1 Validation Results
+
+- `python -m py_compile desktop\single_instance.py desktop\orin_desktop_launcher.pyw desktop\orin_desktop_main.py dev\orin_desktop_entrypoint_validation.py dev\orin_boot_transition_verification.py`: PASS
+- `python dev\orin_desktop_entrypoint_validation.py`: PASS
+  - report: `dev/logs/desktop_entrypoint_validation/reports/DesktopEntrypointValidationReport_20260426_123114.txt`
+- `python dev\orin_boot_transition_verification.py`: PASS
+  - report: `dev/logs/boot_transition_verification/reports/BootTransitionVerificationReport_20260426_123137.txt`
+- `python dev\orin_branch_governance_validation.py`: PASS
+- `git diff --check`: PASS with line-ending normalization warnings only
+
+### H-1 Stability Notes
+
+- The active settled session remains the sole owner across repeated declined incoming launches, even when those launches arrive in rapid succession.
+- Replacement-session truth remains exclusive to accepted relaunch; declined incoming launches never emit reacquire, replacement-session active, or replacement-session settled markers.
+- Mixed decline/accept proof now distinguishes preserved-session logs, declined incoming-launch logs, and accepted replacement-session logs by content instead of fragile file-order assumptions.
+- The shipped startup route, accepted-relaunch proof, repeated-launch proof, and explicit dev-boot proof remain green after the added decline-lane pressure coverage.
+
 ## User Test Summary
 
 User-Facing Shortcut Path: `Pending Live Validation classification`
@@ -208,13 +253,14 @@ User Test Summary Results: `Pending`
 ## Seam Continuation Decision
 
 Continue Decision: `Continue`
-Next Active Seam: `Hardening`
-Stop Condition: `Stop after FB-047 Hardening only if startup, accepted-relaunch proof, or decline-path ownership truth regresses beyond the admitted runtime/user-facing lane.`
-Continuation Action: `Pressure-test the completed decline-preservation pass on this same branch, preserve active-session ownership through repeated declined incoming launches, and keep accepted-relaunch plus default startup proof green.`
+Next Active Seam: `Live Validation`
+Stop Condition: `Stop after FB-047 Live Validation only if repo truth, real shortcut applicability, User Test Summary classification, or decline-path ownership truth regresses beyond the admitted runtime/user-facing lane.`
+Continuation Action: `Run FB-047 Live Validation on this same branch, classify real desktop shortcut applicability and User Test Summary status, and confirm the hardened decline-preservation proof stays green on the shipped route.`
 
 ## Active Seam
 
 Active seam: `None.`
 
 - WS-1 is complete and validated.
-- `Hardening` is now the next legal phase.
+- H-1 is complete and green.
+- `Live Validation` is now the next legal phase.

--- a/Docs/workstreams/FB-047_active_session_relaunch_decline_preservation.md
+++ b/Docs/workstreams/FB-047_active_session_relaunch_decline_preservation.md
@@ -379,25 +379,25 @@ PR Readiness validates the completed bounded FB-047 runtime slice chain for merg
 - Base Branch: `main`
 - Head Branch: `feature/fb-047-active-session-relaunch-decline-preservation`
 - PR Summary: Deliver the bounded FB-047 runtime/user-facing relaunch-decline preservation slice by proving declined incoming launches preserve the settled active session, keep single-instance ownership with that session, and exit truthfully without false replacement-session markers; preserving real desktop shortcut and explicit dev boot proof; aligning merge-target canon for `v1.6.11-prebeta`; and selecting FB-048 as the next relaunch signal-failure and wait-timeout truth lane.
-- PR URL: pending live creation
-- PR State At PR Package Time: pending live creation
-- Review Thread State: pending live creation
-- Merge Readiness At PR Package Time: pending live creation
+- PR URL: https://github.com/GiribaldiTTV/Nexus-Desktop-AI/pull/93
+- PR State At PR Package Time: OPEN, non-draft, base `main`, head `feature/fb-047-active-session-relaunch-decline-preservation`.
+- Review Thread State: PASS. Zero top-level PR comments and zero submitted reviews at PR package time.
+- Merge Readiness At PR Package Time: MERGEABLE.
 
 ### PR Readiness Completion Decision
 
 - PR-1 Result: Complete / green.
 - PR-2 Result: Complete / green.
-- PR-3 Result: Pending live PR creation and validation.
+- PR-3 Result: Complete / green.
 - Decline Lifecycle Integrity: declined incoming launches now preserve the active settled owner, emit explicit preserved-session success markers, never leak replacement-session markers, and keep accepted-relaunch transfer truth isolated to the accept lane.
 - Next legal action after merge: file-frozen Release Readiness on updated `main` for `v1.6.11-prebeta`.
 
 ### PR Readiness Validation Results
 
 - `python dev\orin_branch_governance_validation.py`: PASS; merged-unreleased release-debt package truth is green.
-- `python dev\orin_branch_governance_validation.py --pr-readiness-gate`: pending live PR creation and state validation.
+- `python dev\orin_branch_governance_validation.py --pr-readiness-gate`: PASS after live PR creation and state validation.
 - `git diff --check`: PASS.
 - User-facing shortcut gate: PASS with exact markers in `## User Test Summary`.
 - User Test Summary results gate: WAIVED with exact markers in `## User Test Summary`.
 - Next-workstream selection gate: PASS. FB-048 is selected next, `Registry-only`, and branch-not-created.
-- Live PR state: pending live creation.
+- Live PR state: PASS. PR #93 is `OPEN`, non-draft, base `main`, head `feature/fb-047-active-session-relaunch-decline-preservation`, and mergeability is `MERGEABLE`.

--- a/Docs/workstreams/index.md
+++ b/Docs/workstreams/index.md
@@ -83,14 +83,14 @@ For an active or recently closed canonical workstream, keep these durable tracea
 Active here means the current promoted truth owner.
 That may be an executable branch owner or another explicitly promoted current-truth owner.
 
-- `Docs/workstreams/FB-047_active_session_relaunch_decline_preservation.md`
+- `None.`
 
 ### Merged / Release Debt Owners
 
 Merged / Release Debt Owners are promoted implementation workstreams whose implementation branch is merge-target complete but whose public release packaging has not yet cleared release debt.
 These records are not active implementation branch owners after merge.
 
-`None.`
+- `Docs/workstreams/FB-047_active_session_relaunch_decline_preservation.md`
 
 ### Closed
 

--- a/Docs/workstreams/index.md
+++ b/Docs/workstreams/index.md
@@ -83,7 +83,7 @@ For an active or recently closed canonical workstream, keep these durable tracea
 Active here means the current promoted truth owner.
 That may be an executable branch owner or another explicitly promoted current-truth owner.
 
-- `None.`
+- `Docs/workstreams/FB-047_active_session_relaunch_decline_preservation.md`
 
 ### Merged / Release Debt Owners
 

--- a/Docs/workstreams/index.md
+++ b/Docs/workstreams/index.md
@@ -90,10 +90,11 @@ That may be an executable branch owner or another explicitly promoted current-tr
 Merged / Release Debt Owners are promoted implementation workstreams whose implementation branch is merge-target complete but whose public release packaging has not yet cleared release debt.
 These records are not active implementation branch owners after merge.
 
-- `Docs/workstreams/FB-046_active_session_relaunch_reacquisition.md`
+`None.`
 
 ### Closed
 
+- `Docs/workstreams/FB-046_active_session_relaunch_reacquisition.md`
 - `Docs/workstreams/FB-045_active_session_relaunch_outcome_refinement.md`
 - `Docs/workstreams/FB-044_boot_desktop_handoff_outcome_refinement.md`
 - `Docs/workstreams/FB-043_top_level_entrypoint_handoff_refinement.md`

--- a/desktop/orin_desktop_launcher.pyw
+++ b/desktop/orin_desktop_launcher.pyw
@@ -1357,12 +1357,15 @@ def finalize_failure(
 def main():
     run_id = create_run_id()
     single_instance_state = {
+        "declined_relaunch": False,
         "replacement_session": False,
         "replacement_session_settled_recorded": False,
         "released": False,
     }
 
     def log_single_instance_event(event):
+        if event in {"REPLACE_PROMPT_DECLINED", "REPLACE_PROMPT_AUTO_DECLINED"}:
+            single_instance_state["declined_relaunch"] = True
         if event in {"RELAUNCH_ACQUIRED_AFTER_WAIT", "RELAUNCH_REPLACEMENT_SESSION_CONFIRMED"}:
             single_instance_state["replacement_session"] = True
         runtime(f"Single-instance flow: {event}")
@@ -1405,8 +1408,17 @@ def main():
         secondary_button_text="Keep Current Session",
         event_logger=log_single_instance_event,
     ):
-        runtime("Launcher start blocked: Nexus Desktop AI is already running")
-        runtime_event("STATUS", "SKIP", "LAUNCHER_RUNTIME", "ALREADY_RUNNING")
+        if single_instance_state["declined_relaunch"]:
+            runtime("Incoming launch exited cleanly: current session preserved after relaunch decline")
+            runtime_event(
+                "STATUS",
+                "SUCCESS",
+                "LAUNCHER_RUNTIME",
+                "RELAUNCH_DECLINED_SESSION_PRESERVED",
+            )
+        else:
+            runtime("Launcher start blocked: Nexus Desktop AI is already running")
+            runtime_event("STATUS", "SKIP", "LAUNCHER_RUNTIME", "ALREADY_RUNNING")
         return 0
 
     ensure_crash_dir("launcher startup")

--- a/desktop/single_instance.py
+++ b/desktop/single_instance.py
@@ -63,6 +63,11 @@ def harness_auto_accept_relaunch():
     return value in {"1", "true", "yes", "on"}
 
 
+def harness_auto_decline_relaunch():
+    value = (os.environ.get("JARVIS_HARNESS_AUTO_DECLINE_RELAUNCH") or "").strip().casefold()
+    return value in {"1", "true", "yes", "on"}
+
+
 class SingleInstanceGuard:
     def __init__(self, mutex_name: str):
         self.mutex_name = mutex_name
@@ -387,6 +392,9 @@ def acquire_or_prompt_replace(
 
     if harness_auto_accept_relaunch():
         log_event("REPLACE_PROMPT_AUTO_ACCEPTED")
+    elif harness_auto_decline_relaunch():
+        log_event("REPLACE_PROMPT_AUTO_DECLINED")
+        return False
     else:
         if not show_replace_running_dialog(
             title,

--- a/dev/orin_desktop_entrypoint_validation.py
+++ b/dev/orin_desktop_entrypoint_validation.py
@@ -1090,8 +1090,6 @@ def run_accepted_relaunch_cycle_scenario(
                     if any(AUTHORITATIVE_DESKTOP_SETTLED_MARKER in line for line in first_runtime_lines):
                         first_settled_seen = True
                         break
-                if first_proc.poll() is not None:
-                    break
                 time.sleep(0.2)
 
             second_env = build_harness_env(
@@ -1124,8 +1122,6 @@ def run_accepted_relaunch_cycle_scenario(
                     AUTHORITATIVE_DESKTOP_SETTLED_MARKER in line for line in second_runtime_lines
                 )
                 if second_reacquired_seen and second_settled_seen:
-                    break
-                if second_proc.poll() is not None:
                     break
                 time.sleep(0.2)
 
@@ -1476,16 +1472,16 @@ def run_relaunch_after_recoverable_exit_scenario():
             second_deadline = time.time() + 25.0
             while time.time() < second_deadline:
                 runtime_logs = files_matching_sorted(scenario_root, "Runtime_")
-                if len(runtime_logs) >= 2:
-                    second_runtime_log = runtime_logs[-1]
+                new_second_logs = [path for path in runtime_logs if path != first_runtime_log]
+                if new_second_logs and not second_runtime_log:
+                    second_runtime_log = new_second_logs[0]
+                if second_runtime_log:
                     second_runtime_lines = read_lines(second_runtime_log)
                     second_settled_seen = any(
                         AUTHORITATIVE_DESKTOP_SETTLED_MARKER in line for line in second_runtime_lines
                     )
                     if second_settled_seen:
                         break
-                if second_proc.poll() is not None:
-                    break
                 time.sleep(0.2)
 
             if second_settled_seen:
@@ -1711,8 +1707,6 @@ def run_rapid_consecutive_accepted_relaunch_cycles_scenario():
                     runtime_lines[0] = read_lines(runtime_logs[0])
                     if any(AUTHORITATIVE_DESKTOP_SETTLED_MARKER in line for line in runtime_lines[0]):
                         break
-                if processes[0].poll() is not None:
-                    break
                 time.sleep(0.2)
 
             processes[1] = subprocess.Popen(
@@ -1741,8 +1735,6 @@ def run_rapid_consecutive_accepted_relaunch_cycles_scenario():
                     )
                     if second_reacquired_seen and second_settled_seen:
                         break
-                if processes[1].poll() is not None:
-                    break
                 time.sleep(0.2)
 
             processes[2] = subprocess.Popen(
@@ -1771,8 +1763,6 @@ def run_rapid_consecutive_accepted_relaunch_cycles_scenario():
                     )
                     if third_reacquired_seen and third_settled_seen:
                         break
-                if processes[2].poll() is not None:
-                    break
                 time.sleep(0.2)
 
             if runtime_logs[2] and any(
@@ -2049,8 +2039,6 @@ def run_declined_relaunch_cycle_scenario():
                     if any(AUTHORITATIVE_DESKTOP_SETTLED_MARKER in line for line in first_runtime_lines):
                         first_settled_seen = True
                         break
-                if first_proc.poll() is not None:
-                    break
                 time.sleep(0.2)
 
             for index in range(len(incoming_procs)):
@@ -2352,6 +2340,831 @@ def run_declined_relaunch_cycle_scenario():
         "runtime_log": first_runtime_log,
         "stdout": "\n".join(part for part in [first_stdout, *incoming_stdouts] if part),
         "stderr": "\n".join(part for part in [first_stderr, *incoming_stderrs] if part),
+        "checks": checks,
+    }
+
+
+def run_rapid_consecutive_declined_relaunch_cycles_scenario():
+    scenario_name = "vbs_consecutive_declined_relaunch_cycles"
+    scenario_root = os.path.join(BASE_LOG_ROOT, scenario_name)
+    preexisting_processes_before, preexisting_processes_killed, preexisting_processes_after = (
+        cleanup_launch_chain_processes_for_log_root(BASE_LOG_ROOT)
+    )
+    reset_dir(scenario_root)
+    scenario_root_entries_after_reset = dir_entry_names(scenario_root)
+
+    cscript_command = resolve_cscript_command()
+    launch_command = cscript_command + ["//nologo", ENTRYPOINT_SCRIPT] if cscript_command else []
+    first_env = build_harness_env(scenario_root)
+    decline_env = build_harness_env(
+        scenario_root,
+        extra_env={"JARVIS_HARNESS_AUTO_DECLINE_RELAUNCH": "1"},
+    )
+
+    first_proc = None
+    incoming_procs = [None, None, None]
+    first_stdout = ""
+    first_stderr = ""
+    incoming_stdouts = ["", "", ""]
+    incoming_stderrs = ["", "", ""]
+    first_runtime_log = ""
+    incoming_runtime_logs = ["", "", ""]
+    first_runtime_lines = []
+    incoming_runtime_lines = [[], [], []]
+    first_settled_seen = False
+    active_session_changed_before_manual_shutdown = False
+    shutdown_hotkey_sent = False
+    shutdown_hotkey_detail = "hotkey not sent"
+    shutdown_hotkey_attempts = 0
+
+    try:
+        if scenario_root_entries_after_reset or not launch_command:
+            pass
+        else:
+            first_proc = subprocess.Popen(
+                launch_command,
+                cwd=ROOT_DIR,
+                env=first_env,
+                **hidden_subprocess_kwargs(),
+            )
+
+            first_deadline = time.time() + 25.0
+            while time.time() < first_deadline:
+                runtime_logs = files_matching_sorted(scenario_root, "Runtime_")
+                if runtime_logs and not first_runtime_log:
+                    first_runtime_log = runtime_logs[0]
+                if first_runtime_log:
+                    first_runtime_lines = read_lines(first_runtime_log)
+                    if any(AUTHORITATIVE_DESKTOP_SETTLED_MARKER in line for line in first_runtime_lines):
+                        first_settled_seen = True
+                        break
+                time.sleep(0.2)
+
+            for index in range(len(incoming_procs)):
+                incoming_procs[index] = subprocess.Popen(
+                    launch_command,
+                    cwd=ROOT_DIR,
+                    env=decline_env,
+                    **hidden_subprocess_kwargs(),
+                )
+
+            decline_deadline = time.time() + 20.0
+            while time.time() < decline_deadline:
+                runtime_logs = files_matching_sorted(scenario_root, "Runtime_")
+                known_logs = {first_runtime_log, *[path for path in incoming_runtime_logs if path]}
+                new_logs = [path for path in runtime_logs if path not in known_logs]
+                while new_logs:
+                    next_missing_index = next(
+                        (index for index, path in enumerate(incoming_runtime_logs) if not path),
+                        None,
+                    )
+                    if next_missing_index is None:
+                        break
+                    incoming_runtime_logs[next_missing_index] = new_logs.pop(0)
+
+                if first_runtime_log:
+                    first_runtime_lines = read_lines(first_runtime_log)
+                    if any("RENDERER_MAIN|RELAUNCH_REQUEST_RECEIVED" in line for line in first_runtime_lines):
+                        active_session_changed_before_manual_shutdown = True
+                    if any("RENDERER_MAIN|SHUTDOWN_REQUESTED" in line for line in first_runtime_lines):
+                        active_session_changed_before_manual_shutdown = True
+                    if any(SINGLE_INSTANCE_RELEASED_MARKER in line for line in first_runtime_lines):
+                        active_session_changed_before_manual_shutdown = True
+                    if any(
+                        RELAUNCH_REPLACEMENT_SESSION_ACTIVE_MARKER in line
+                        or RELAUNCH_REPLACEMENT_SESSION_SETTLED_MARKER in line
+                        for line in first_runtime_lines
+                    ):
+                        active_session_changed_before_manual_shutdown = True
+
+                all_declines_completed = True
+                for index, runtime_log in enumerate(incoming_runtime_logs):
+                    if not runtime_log:
+                        all_declines_completed = False
+                        continue
+                    incoming_runtime_lines[index] = read_lines(runtime_log)
+                    if not any(
+                        RELAUNCH_DECLINED_SESSION_PRESERVED_MARKER in line
+                        for line in incoming_runtime_lines[index]
+                    ):
+                        all_declines_completed = False
+
+                if all_declines_completed:
+                    break
+                time.sleep(0.1)
+
+            if first_settled_seen:
+                shutdown_hotkey_attempts += 1
+                shutdown_hotkey_sent, shutdown_hotkey_detail = send_shutdown_hotkey()
+
+            shutdown_deadline = time.time() + 20.0
+            while time.time() < shutdown_deadline:
+                first_runtime_lines = read_lines(first_runtime_log)
+                shutdown_seen = any(
+                    "RENDERER_MAIN|SHUTDOWN_REQUESTED" in line for line in first_runtime_lines
+                )
+                exit_seen = any(
+                    "RENDERER_MAIN|EVENT_LOOP_EXIT|code=0" in line for line in first_runtime_lines
+                )
+                release_seen = any(
+                    SINGLE_INSTANCE_RELEASED_MARKER in line for line in first_runtime_lines
+                )
+
+                if shutdown_hotkey_sent and not shutdown_seen and shutdown_hotkey_attempts < 2:
+                    shutdown_hotkey_attempts += 1
+                    shutdown_hotkey_sent, shutdown_hotkey_detail = send_shutdown_hotkey()
+
+                if shutdown_seen and exit_seen and release_seen:
+                    break
+                time.sleep(0.2)
+    finally:
+        all_procs = [first_proc, *incoming_procs]
+        for index, proc in enumerate(all_procs):
+            if proc is None:
+                continue
+            try:
+                if proc.poll() is None:
+                    terminate_process_tree(proc)
+                stdout_text, stderr_text = proc.communicate(timeout=5)
+            except Exception:
+                stdout_text = ""
+                stderr_text = ""
+
+            if index == 0:
+                first_stdout = (stdout_text or "").strip()
+                first_stderr = (stderr_text or "").strip()
+            else:
+                incoming_stdouts[index - 1] = (stdout_text or "").strip()
+                incoming_stderrs[index - 1] = (stderr_text or "").strip()
+
+    first_runtime_lines = read_lines(first_runtime_log)
+    incoming_runtime_lines = [read_lines(path) for path in incoming_runtime_logs]
+
+    residual_launch_chain_processes_before, residual_launch_chain_killed, residual_launch_chain_processes_after = (
+        cleanup_launch_chain_processes_for_log_root(BASE_LOG_ROOT)
+    )
+
+    first_settled_index = first_marker_index(first_runtime_lines, AUTHORITATIVE_DESKTOP_SETTLED_MARKER)
+    first_relaunch_request_index = first_marker_index(first_runtime_lines, "RENDERER_MAIN|RELAUNCH_REQUEST_RECEIVED")
+    first_shutdown_index = first_marker_index(first_runtime_lines, "RENDERER_MAIN|SHUTDOWN_REQUESTED")
+    first_exit_index = first_marker_index(first_runtime_lines, "RENDERER_MAIN|EVENT_LOOP_EXIT|code=0")
+    first_recoverable_complete_index = first_marker_index(
+        first_runtime_lines,
+        POST_SETTLED_RECOVERABLE_COMPLETE_MARKER,
+    )
+    first_release_index = first_marker_index(first_runtime_lines, SINGLE_INSTANCE_RELEASED_MARKER)
+
+    incoming_indexes = []
+    for lines in incoming_runtime_lines:
+        incoming_indexes.append(
+            {
+                "conflict": first_marker_index(lines, "SINGLE_INSTANCE_CONFLICT_DETECTED"),
+                "prompt_decline": max(
+                    first_marker_index(lines, "REPLACE_PROMPT_DECLINED"),
+                    first_marker_index(lines, "REPLACE_PROMPT_AUTO_DECLINED"),
+                ),
+                "decline_success": first_marker_index(lines, RELAUNCH_DECLINED_SESSION_PRESERVED_MARKER),
+                "already_running": first_marker_index(
+                    lines,
+                    "STATUS|SKIP|LAUNCHER_RUNTIME|ALREADY_RUNNING",
+                ),
+                "runtime_start": first_marker_index(lines, "STATUS|START|LAUNCHER_RUNTIME"),
+                "renderer_spawn": first_marker_index(
+                    lines,
+                    "STATUS|SUCCESS|RENDERER_PROCESS_SPAWN",
+                ),
+                "prompt_accept": max(
+                    first_marker_index(lines, "REPLACE_PROMPT_ACCEPTED"),
+                    first_marker_index(lines, "REPLACE_PROMPT_AUTO_ACCEPTED"),
+                ),
+                "signal_sent": first_marker_index(lines, "RELAUNCH_SIGNAL_SENT"),
+                "reacquire": first_marker_index(lines, "RELAUNCH_ACQUIRED_AFTER_WAIT"),
+                "replacement_confirmed": first_marker_index(
+                    lines,
+                    "RELAUNCH_REPLACEMENT_SESSION_CONFIRMED",
+                ),
+                "replacement_active": first_marker_index(
+                    lines,
+                    RELAUNCH_REPLACEMENT_SESSION_ACTIVE_MARKER,
+                ),
+                "settled": first_marker_index(lines, AUTHORITATIVE_DESKTOP_SETTLED_MARKER),
+                "replacement_settled": first_marker_index(
+                    lines,
+                    RELAUNCH_REPLACEMENT_SESSION_SETTLED_MARKER,
+                ),
+                "release": first_marker_index(lines, SINGLE_INSTANCE_RELEASED_MARKER),
+            }
+        )
+
+    ordering_detail = (
+        f"first_settled={first_settled_index}, first_relaunch_request={first_relaunch_request_index}, "
+        f"first_shutdown={first_shutdown_index}, first_exit={first_exit_index}, "
+        f"first_recoverable_complete={first_recoverable_complete_index}, first_release={first_release_index}, "
+        f"incoming1={incoming_indexes[0]}, incoming2={incoming_indexes[1]}, incoming3={incoming_indexes[2]}"
+    )
+
+    checks = {
+        "cscript_available": line_status(
+            bool(cscript_command),
+            cscript_command[0] if cscript_command else "missing Windows Script Host entrypoint",
+        ),
+        "scenario_log_root_cleared_before_launch": line_status(
+            not scenario_root_entries_after_reset,
+            "empty" if not scenario_root_entries_after_reset else ", ".join(scenario_root_entries_after_reset[:5]),
+        ),
+        "four_runtime_logs_created": line_status(
+            bool(first_runtime_log)
+            and all(incoming_runtime_logs)
+            and len({first_runtime_log, *incoming_runtime_logs}) == 4,
+            ", ".join(path or "missing" for path in [first_runtime_log, *incoming_runtime_logs]),
+        ),
+        "active_session_reached_settled_before_rapid_declines": line_status(
+            first_settled_index >= 0,
+            AUTHORITATIVE_DESKTOP_SETTLED_MARKER if first_settled_index >= 0 else "missing authoritative settled marker",
+        ),
+        "active_session_unchanged_during_rapid_declines": line_status(
+            not active_session_changed_before_manual_shutdown and first_relaunch_request_index < 0,
+            ordering_detail,
+        ),
+        "active_session_lifecycle_completed_after_rapid_declines": line_status(
+            (
+                first_shutdown_index > first_settled_index >= 0
+                and first_exit_index > first_shutdown_index
+                and first_release_index > first_exit_index
+            )
+            or (
+                first_recoverable_complete_index > first_settled_index >= 0
+                and first_release_index > first_recoverable_complete_index
+            ),
+            ordering_detail,
+        ),
+        "incoming_launches_conflict_and_decline_under_timing_stress": line_status(
+            all(
+                info["conflict"] >= 0 and info["prompt_decline"] > info["conflict"] >= 0
+                for info in incoming_indexes
+            ),
+            ordering_detail,
+        ),
+        "incoming_launches_record_preserved_session_success_under_timing_stress": line_status(
+            all(
+                info["decline_success"] > info["prompt_decline"] >= 0
+                for info in incoming_indexes
+            ),
+            ordering_detail,
+        ),
+        "incoming_launches_never_start_runtime_ownership_under_timing_stress": line_status(
+            all(
+                info["runtime_start"] < 0 and info["renderer_spawn"] < 0 and info["settled"] < 0
+                for info in incoming_indexes
+            ),
+            ordering_detail,
+        ),
+        "incoming_launches_emit_no_replacement_markers_under_timing_stress": line_status(
+            all(
+                info["prompt_accept"] < 0
+                and info["signal_sent"] < 0
+                and info["reacquire"] < 0
+                and info["replacement_confirmed"] < 0
+                and info["replacement_active"] < 0
+                and info["replacement_settled"] < 0
+                and info["release"] < 0
+                for info in incoming_indexes
+            ),
+            ordering_detail,
+        ),
+        "incoming_launches_generic_already_running_marker_absent_under_timing_stress": line_status(
+            all(info["already_running"] < 0 for info in incoming_indexes),
+            ordering_detail,
+        ),
+        "incoming_launches_no_failure_flow_under_timing_stress": line_status(
+            all(
+                not any("STATUS|SUCCESS|LAUNCHER_RUNTIME|FAILURE_FLOW_COMPLETE" in line for line in lines)
+                for lines in incoming_runtime_lines
+            ),
+            "STATUS|SUCCESS|LAUNCHER_RUNTIME|FAILURE_FLOW_COMPLETE absent",
+        ),
+        "no_relaunch_wait_timeout_in_declined_incoming_launches": line_status(
+            all(
+                not any("RELAUNCH_WAIT_TIMEOUT" in line for line in lines)
+                for lines in incoming_runtime_lines
+            ),
+            "RELAUNCH_WAIT_TIMEOUT absent",
+        ),
+        "single_instance_guard_remained_with_active_session_under_timing_stress": line_status(
+            first_relaunch_request_index < 0
+            and all(info["reacquire"] < 0 for info in incoming_indexes)
+            and (
+                first_release_index > first_exit_index >= 0
+                or first_release_index > first_recoverable_complete_index >= 0
+            ),
+            ordering_detail,
+        ),
+        "traceback_absent": line_status(
+            "Traceback" not in first_stderr
+            and all("Traceback" not in stderr for stderr in incoming_stderrs),
+            "\n".join(
+                part for part in [first_stderr, *incoming_stderrs, first_stdout, *incoming_stdouts] if part
+            ) or "no traceback in launcher output",
+        ),
+        "scenario_preflight_cleanup_optional": line_status(
+            not preexisting_processes_after,
+            "no prior validation-owned launcher/runtime processes detected"
+            if not preexisting_processes_before
+            else (
+                f"detected {len(preexisting_processes_before)} prior process(es); "
+                f"killed={','.join(str(pid) for pid in preexisting_processes_killed) or 'none'}"
+            ),
+        ),
+        "launch_chain_cleanup_optional": line_status(
+            not residual_launch_chain_processes_after,
+            "no residual validation-owned launcher/runtime processes detected"
+            if not residual_launch_chain_processes_before
+            else (
+                f"detected {len(residual_launch_chain_processes_before)} residual process(es); "
+                f"killed={','.join(str(pid) for pid in residual_launch_chain_killed) or 'none'}"
+            ),
+        ),
+    }
+
+    return {
+        "scenario_name": scenario_name,
+        "log_root": scenario_root,
+        "runtime_log": first_runtime_log,
+        "stdout": "\n".join(part for part in [first_stdout, *incoming_stdouts] if part),
+        "stderr": "\n".join(part for part in [first_stderr, *incoming_stderrs] if part),
+        "checks": checks,
+    }
+
+
+def run_mixed_decline_then_accept_relaunch_scenario():
+    scenario_name = "vbs_decline_then_accept_relaunch_cycle"
+    scenario_root = os.path.join(BASE_LOG_ROOT, scenario_name)
+    preexisting_processes_before, preexisting_processes_killed, preexisting_processes_after = (
+        cleanup_launch_chain_processes_for_log_root(BASE_LOG_ROOT)
+    )
+    reset_dir(scenario_root)
+    scenario_root_entries_after_reset = dir_entry_names(scenario_root)
+
+    cscript_command = resolve_cscript_command()
+    launch_command = cscript_command + ["//nologo", ENTRYPOINT_SCRIPT] if cscript_command else []
+    first_env = build_harness_env(scenario_root)
+    decline_env = build_harness_env(
+        scenario_root,
+        extra_env={"JARVIS_HARNESS_AUTO_DECLINE_RELAUNCH": "1"},
+    )
+    accept_env = build_harness_env(
+        scenario_root,
+        extra_env={"JARVIS_HARNESS_AUTO_ACCEPT_RELAUNCH": "1"},
+    )
+
+    first_proc = None
+    decline_proc = None
+    accept_proc = None
+    first_stdout = ""
+    first_stderr = ""
+    decline_stdout = ""
+    decline_stderr = ""
+    accept_stdout = ""
+    accept_stderr = ""
+    first_runtime_log = ""
+    decline_runtime_log = ""
+    accept_runtime_log = ""
+    first_runtime_lines = []
+    decline_runtime_lines = []
+    accept_runtime_lines = []
+    first_settled_seen = False
+    active_session_changed_before_accept = False
+    accept_settled_seen = False
+    accept_shutdown_hotkey_sent = False
+    accept_shutdown_hotkey_detail = "hotkey not sent"
+    accept_shutdown_hotkey_attempts = 0
+
+    try:
+        if scenario_root_entries_after_reset or not launch_command:
+            pass
+        else:
+            first_proc = subprocess.Popen(
+                launch_command,
+                cwd=ROOT_DIR,
+                env=first_env,
+                **hidden_subprocess_kwargs(),
+            )
+
+            first_deadline = time.time() + 25.0
+            while time.time() < first_deadline:
+                runtime_logs = files_matching_sorted(scenario_root, "Runtime_")
+                if runtime_logs and not first_runtime_log:
+                    first_runtime_log = runtime_logs[0]
+                if first_runtime_log:
+                    first_runtime_lines = read_lines(first_runtime_log)
+                    if any(AUTHORITATIVE_DESKTOP_SETTLED_MARKER in line for line in first_runtime_lines):
+                        first_settled_seen = True
+                        break
+                if first_proc.poll() is not None:
+                    break
+                time.sleep(0.2)
+
+            decline_proc = subprocess.Popen(
+                launch_command,
+                cwd=ROOT_DIR,
+                env=decline_env,
+                **hidden_subprocess_kwargs(),
+            )
+
+            decline_deadline = time.time() + 15.0
+            while time.time() < decline_deadline:
+                runtime_logs = files_matching_sorted(scenario_root, "Runtime_")
+                new_decline_logs = [path for path in runtime_logs if path != first_runtime_log]
+                if new_decline_logs and not decline_runtime_log:
+                    decline_runtime_log = new_decline_logs[0]
+
+                if first_runtime_log:
+                    first_runtime_lines = read_lines(first_runtime_log)
+                    if any("RENDERER_MAIN|RELAUNCH_REQUEST_RECEIVED" in line for line in first_runtime_lines):
+                        active_session_changed_before_accept = True
+                    if any("RENDERER_MAIN|SHUTDOWN_REQUESTED" in line for line in first_runtime_lines):
+                        active_session_changed_before_accept = True
+                    if any(SINGLE_INSTANCE_RELEASED_MARKER in line for line in first_runtime_lines):
+                        active_session_changed_before_accept = True
+                    if any(
+                        RELAUNCH_REPLACEMENT_SESSION_ACTIVE_MARKER in line
+                        or RELAUNCH_REPLACEMENT_SESSION_SETTLED_MARKER in line
+                        for line in first_runtime_lines
+                    ):
+                        active_session_changed_before_accept = True
+
+                if decline_runtime_log:
+                    decline_runtime_lines = read_lines(decline_runtime_log)
+                    if any(
+                        RELAUNCH_DECLINED_SESSION_PRESERVED_MARKER in line
+                        for line in decline_runtime_lines
+                    ):
+                        break
+                if decline_proc.poll() is not None and decline_runtime_log:
+                    break
+                time.sleep(0.2)
+
+            accept_proc = subprocess.Popen(
+                launch_command,
+                cwd=ROOT_DIR,
+                env=accept_env,
+                **hidden_subprocess_kwargs(),
+            )
+
+            accept_deadline = time.time() + 35.0
+            while time.time() < accept_deadline:
+                runtime_logs = files_matching_sorted(scenario_root, "Runtime_")
+                known_logs = {first_runtime_log, decline_runtime_log}
+                new_accept_logs = [path for path in runtime_logs if path not in known_logs]
+                if new_accept_logs and not accept_runtime_log:
+                    accept_runtime_log = new_accept_logs[0]
+
+                if accept_runtime_log:
+                    accept_runtime_lines = read_lines(accept_runtime_log)
+                    accept_reacquired_seen = any(
+                        "RELAUNCH_ACQUIRED_AFTER_WAIT" in line for line in accept_runtime_lines
+                    )
+                    accept_settled_seen = any(
+                        AUTHORITATIVE_DESKTOP_SETTLED_MARKER in line for line in accept_runtime_lines
+                    )
+                    if accept_reacquired_seen and accept_settled_seen:
+                        break
+                time.sleep(0.2)
+
+            if accept_settled_seen:
+                accept_shutdown_hotkey_attempts += 1
+                accept_shutdown_hotkey_sent, accept_shutdown_hotkey_detail = send_shutdown_hotkey()
+
+            shutdown_deadline = time.time() + 20.0
+            while time.time() < shutdown_deadline:
+                accept_runtime_lines = read_lines(accept_runtime_log)
+                accept_shutdown_seen = any(
+                    "RENDERER_MAIN|SHUTDOWN_REQUESTED" in line for line in accept_runtime_lines
+                )
+                accept_exit_seen = any(
+                    "RENDERER_MAIN|EVENT_LOOP_EXIT|code=0" in line for line in accept_runtime_lines
+                )
+                accept_release_seen = any(
+                    SINGLE_INSTANCE_RELEASED_MARKER in line for line in accept_runtime_lines
+                )
+                if (
+                    accept_settled_seen
+                    and accept_shutdown_hotkey_sent
+                    and not accept_shutdown_seen
+                    and accept_shutdown_hotkey_attempts < 2
+                ):
+                    accept_shutdown_hotkey_attempts += 1
+                    accept_shutdown_hotkey_sent, accept_shutdown_hotkey_detail = send_shutdown_hotkey()
+                if accept_shutdown_seen and accept_exit_seen and accept_release_seen:
+                    break
+                if accept_proc is not None and accept_proc.poll() is not None and accept_release_seen:
+                    break
+                time.sleep(0.2)
+    finally:
+        for proc in (first_proc, decline_proc, accept_proc):
+            if proc is None:
+                continue
+            try:
+                if proc.poll() is None:
+                    terminate_process_tree(proc)
+                stdout_text, stderr_text = proc.communicate(timeout=5)
+            except Exception:
+                stdout_text = ""
+                stderr_text = ""
+            if proc is first_proc:
+                first_stdout = (stdout_text or "").strip()
+                first_stderr = (stderr_text or "").strip()
+            elif proc is decline_proc:
+                decline_stdout = (stdout_text or "").strip()
+                decline_stderr = (stderr_text or "").strip()
+            else:
+                accept_stdout = (stdout_text or "").strip()
+                accept_stderr = (stderr_text or "").strip()
+
+    all_runtime_logs = files_matching_sorted(scenario_root, "Runtime_")
+    classified_first_runtime_log = ""
+    classified_decline_runtime_log = ""
+    classified_accept_runtime_log = ""
+    for runtime_log in all_runtime_logs:
+        lines = read_lines(runtime_log)
+        if any(RELAUNCH_DECLINED_SESSION_PRESERVED_MARKER in line for line in lines):
+            classified_decline_runtime_log = runtime_log
+            continue
+        if any("RELAUNCH_ACQUIRED_AFTER_WAIT" in line for line in lines) or any(
+            RELAUNCH_REPLACEMENT_SESSION_ACTIVE_MARKER in line for line in lines
+        ):
+            classified_accept_runtime_log = runtime_log
+            continue
+        if any(AUTHORITATIVE_DESKTOP_SETTLED_MARKER in line for line in lines):
+            classified_first_runtime_log = runtime_log
+
+    if classified_first_runtime_log and classified_decline_runtime_log and classified_accept_runtime_log:
+        first_runtime_log = classified_first_runtime_log
+        decline_runtime_log = classified_decline_runtime_log
+        accept_runtime_log = classified_accept_runtime_log
+
+    first_runtime_lines = read_lines(first_runtime_log)
+    decline_runtime_lines = read_lines(decline_runtime_log)
+    accept_runtime_lines = read_lines(accept_runtime_log)
+    residual_launch_chain_processes_before, residual_launch_chain_killed, residual_launch_chain_processes_after = (
+        cleanup_launch_chain_processes_for_log_root(BASE_LOG_ROOT)
+    )
+
+    first_settled_index = first_marker_index(first_runtime_lines, AUTHORITATIVE_DESKTOP_SETTLED_MARKER)
+    first_relaunch_request_index = first_marker_index(first_runtime_lines, "RENDERER_MAIN|RELAUNCH_REQUEST_RECEIVED")
+    first_shutdown_index = first_marker_index(first_runtime_lines, "RENDERER_MAIN|SHUTDOWN_REQUESTED")
+    first_exit_index = first_marker_index(first_runtime_lines, "RENDERER_MAIN|EVENT_LOOP_EXIT|code=0")
+    first_release_index = first_marker_index(first_runtime_lines, SINGLE_INSTANCE_RELEASED_MARKER)
+
+    decline_conflict_index = first_marker_index(decline_runtime_lines, "SINGLE_INSTANCE_CONFLICT_DETECTED")
+    decline_prompt_decline_index = max(
+        first_marker_index(decline_runtime_lines, "REPLACE_PROMPT_DECLINED"),
+        first_marker_index(decline_runtime_lines, "REPLACE_PROMPT_AUTO_DECLINED"),
+    )
+    decline_success_index = first_marker_index(
+        decline_runtime_lines,
+        RELAUNCH_DECLINED_SESSION_PRESERVED_MARKER,
+    )
+    decline_runtime_start_index = first_marker_index(
+        decline_runtime_lines,
+        "STATUS|START|LAUNCHER_RUNTIME",
+    )
+    decline_renderer_spawn_index = first_marker_index(
+        decline_runtime_lines,
+        "STATUS|SUCCESS|RENDERER_PROCESS_SPAWN",
+    )
+    decline_prompt_accept_index = max(
+        first_marker_index(decline_runtime_lines, "REPLACE_PROMPT_ACCEPTED"),
+        first_marker_index(decline_runtime_lines, "REPLACE_PROMPT_AUTO_ACCEPTED"),
+    )
+    decline_signal_sent_index = first_marker_index(decline_runtime_lines, "RELAUNCH_SIGNAL_SENT")
+    decline_reacquire_index = first_marker_index(decline_runtime_lines, "RELAUNCH_ACQUIRED_AFTER_WAIT")
+    decline_replacement_active_index = first_marker_index(
+        decline_runtime_lines,
+        RELAUNCH_REPLACEMENT_SESSION_ACTIVE_MARKER,
+    )
+    decline_replacement_settled_index = first_marker_index(
+        decline_runtime_lines,
+        RELAUNCH_REPLACEMENT_SESSION_SETTLED_MARKER,
+    )
+    decline_release_index = first_marker_index(decline_runtime_lines, SINGLE_INSTANCE_RELEASED_MARKER)
+    decline_settled_index = first_marker_index(decline_runtime_lines, AUTHORITATIVE_DESKTOP_SETTLED_MARKER)
+
+    accept_conflict_index = first_marker_index(accept_runtime_lines, "SINGLE_INSTANCE_CONFLICT_DETECTED")
+    accept_prompt_accept_index = max(
+        first_marker_index(accept_runtime_lines, "REPLACE_PROMPT_ACCEPTED"),
+        first_marker_index(accept_runtime_lines, "REPLACE_PROMPT_AUTO_ACCEPTED"),
+    )
+    accept_signal_sent_index = first_marker_index(accept_runtime_lines, "RELAUNCH_SIGNAL_SENT")
+    accept_reacquire_index = first_marker_index(accept_runtime_lines, "RELAUNCH_ACQUIRED_AFTER_WAIT")
+    accept_replacement_confirmed_index = first_marker_index(
+        accept_runtime_lines,
+        "RELAUNCH_REPLACEMENT_SESSION_CONFIRMED",
+    )
+    accept_replacement_active_index = first_marker_index(
+        accept_runtime_lines,
+        RELAUNCH_REPLACEMENT_SESSION_ACTIVE_MARKER,
+    )
+    accept_settled_index = first_marker_index(accept_runtime_lines, AUTHORITATIVE_DESKTOP_SETTLED_MARKER)
+    accept_launcher_settled_observed_index = first_marker_index(
+        accept_runtime_lines,
+        LAUNCHER_SETTLED_OBSERVED_MARKER,
+    )
+    accept_replacement_settled_index = first_marker_index(
+        accept_runtime_lines,
+        RELAUNCH_REPLACEMENT_SESSION_SETTLED_MARKER,
+    )
+    accept_recoverable_complete_index = first_marker_index(
+        accept_runtime_lines,
+        POST_SETTLED_RECOVERABLE_COMPLETE_MARKER,
+    )
+    accept_shutdown_index = first_marker_index(accept_runtime_lines, "RENDERER_MAIN|SHUTDOWN_REQUESTED")
+    accept_exit_index = first_marker_index(accept_runtime_lines, "RENDERER_MAIN|EVENT_LOOP_EXIT|code=0")
+    accept_release_index = first_marker_index(accept_runtime_lines, SINGLE_INSTANCE_RELEASED_MARKER)
+    accept_decline_index = max(
+        first_marker_index(accept_runtime_lines, "REPLACE_PROMPT_DECLINED"),
+        first_marker_index(accept_runtime_lines, "REPLACE_PROMPT_AUTO_DECLINED"),
+    )
+    accept_decline_success_index = first_marker_index(
+        accept_runtime_lines,
+        RELAUNCH_DECLINED_SESSION_PRESERVED_MARKER,
+    )
+
+    ordering_detail = (
+        f"first_settled={first_settled_index}, first_relaunch_request={first_relaunch_request_index}, "
+        f"first_shutdown={first_shutdown_index}, first_exit={first_exit_index}, first_release={first_release_index}, "
+        f"decline_conflict={decline_conflict_index}, decline_prompt_decline={decline_prompt_decline_index}, "
+        f"decline_success={decline_success_index}, decline_runtime_start={decline_runtime_start_index}, "
+        f"decline_signal_sent={decline_signal_sent_index}, decline_reacquire={decline_reacquire_index}, "
+        f"decline_replacement_active={decline_replacement_active_index}, decline_settled={decline_settled_index}, "
+        f"accept_conflict={accept_conflict_index}, accept_prompt_accept={accept_prompt_accept_index}, "
+        f"accept_signal_sent={accept_signal_sent_index}, accept_reacquire={accept_reacquire_index}, "
+        f"accept_replacement_confirmed={accept_replacement_confirmed_index}, accept_replacement_active={accept_replacement_active_index}, "
+        f"accept_settled={accept_settled_index}, accept_replacement_settled={accept_replacement_settled_index}, "
+        f"accept_shutdown={accept_shutdown_index}, accept_exit={accept_exit_index}, "
+        f"accept_recoverable_complete={accept_recoverable_complete_index}, accept_release={accept_release_index}"
+    )
+
+    checks = {
+        "cscript_available": line_status(
+            bool(cscript_command),
+            cscript_command[0] if cscript_command else "missing Windows Script Host entrypoint",
+        ),
+        "scenario_log_root_cleared_before_launch": line_status(
+            not scenario_root_entries_after_reset,
+            "empty" if not scenario_root_entries_after_reset else ", ".join(scenario_root_entries_after_reset[:5]),
+        ),
+        "three_runtime_logs_created": line_status(
+            all([first_runtime_log, decline_runtime_log, accept_runtime_log])
+            and len({first_runtime_log, decline_runtime_log, accept_runtime_log}) == 3,
+            ", ".join(path or "missing" for path in [first_runtime_log, decline_runtime_log, accept_runtime_log]),
+        ),
+        "active_session_settled_before_decline_then_accept": line_status(
+            first_settled_index >= 0,
+            AUTHORITATIVE_DESKTOP_SETTLED_MARKER if first_settled_index >= 0 else "missing authoritative settled marker",
+        ),
+        "active_session_preserved_during_decline_phase": line_status(
+            not active_session_changed_before_accept,
+            ordering_detail,
+        ),
+        "declined_incoming_launch_conflict_and_decline": line_status(
+            decline_conflict_index >= 0 and decline_prompt_decline_index > decline_conflict_index >= 0,
+            ordering_detail,
+        ),
+        "declined_incoming_launch_records_preserved_session_success": line_status(
+            decline_success_index > decline_prompt_decline_index >= 0,
+            ordering_detail,
+        ),
+        "declined_incoming_launch_never_starts_runtime_ownership": line_status(
+            decline_runtime_start_index < 0
+            and decline_renderer_spawn_index < 0
+            and decline_settled_index < 0,
+            ordering_detail,
+        ),
+        "declined_incoming_launch_emits_no_replacement_markers": line_status(
+            decline_prompt_accept_index < 0
+            and decline_signal_sent_index < 0
+            and decline_reacquire_index < 0
+            and decline_replacement_active_index < 0
+            and decline_replacement_settled_index < 0
+            and decline_release_index < 0,
+            ordering_detail,
+        ),
+        "active_session_receives_relaunch_only_in_accept_phase": line_status(
+            not active_session_changed_before_accept and first_relaunch_request_index >= 0,
+            ordering_detail,
+        ),
+        "active_session_released_for_accept_phase": line_status(
+            first_shutdown_index > first_relaunch_request_index >= 0
+            and first_exit_index > first_shutdown_index
+            and first_release_index > first_exit_index,
+            ordering_detail,
+        ),
+        "accepted_incoming_launch_conflict_and_accept": line_status(
+            accept_conflict_index >= 0 and accept_prompt_accept_index > accept_conflict_index >= 0,
+            ordering_detail,
+        ),
+        "accepted_incoming_launch_signal_sent": line_status(
+            accept_signal_sent_index > accept_prompt_accept_index >= 0,
+            ordering_detail,
+        ),
+        "accepted_incoming_launch_reacquired_after_wait": line_status(
+            accept_reacquire_index > accept_signal_sent_index >= 0
+            and accept_replacement_confirmed_index >= accept_reacquire_index,
+            ordering_detail,
+        ),
+        "accepted_replacement_session_settled_after_reacquire": line_status(
+            accept_replacement_active_index > accept_reacquire_index >= 0
+            and accept_settled_index > accept_replacement_active_index
+            and accept_launcher_settled_observed_index >= accept_settled_index
+            and accept_replacement_settled_index > accept_settled_index,
+            ordering_detail,
+        ),
+        "accepted_incoming_launch_has_no_decline_markers": line_status(
+            accept_decline_index < 0 and accept_decline_success_index < 0,
+            ordering_detail,
+        ),
+        "accepted_replacement_markers_not_premature_after_decline_phase": line_status(
+            accept_replacement_active_index >= accept_reacquire_index >= 0
+            and accept_replacement_settled_index > accept_settled_index > accept_replacement_active_index,
+            ordering_detail,
+        ),
+        "accepted_session_shutdown_hotkey_optional": line_status(
+            True,
+            accept_shutdown_hotkey_detail if accept_shutdown_hotkey_sent else "not needed before lifecycle completion",
+        ),
+        "accepted_session_lifecycle_completed_after_settled": line_status(
+            (
+                accept_shutdown_index > accept_settled_index >= 0
+                and accept_exit_index > accept_shutdown_index
+                and accept_release_index > accept_exit_index
+            )
+            or (
+                accept_recoverable_complete_index > accept_settled_index >= 0
+                and accept_release_index > accept_recoverable_complete_index
+            ),
+            ordering_detail,
+        ),
+        "single_instance_guard_transfers_only_in_accept_phase": line_status(
+            decline_reacquire_index < 0
+            and decline_release_index < 0
+            and accept_reacquire_index >= 0
+            and first_release_index > first_exit_index >= 0,
+            ordering_detail,
+        ),
+        "no_failure_flow_in_mixed_decline_accept_incoming_launches": line_status(
+            not any("STATUS|SUCCESS|LAUNCHER_RUNTIME|FAILURE_FLOW_COMPLETE" in line for line in decline_runtime_lines)
+            and not any("STATUS|SUCCESS|LAUNCHER_RUNTIME|FAILURE_FLOW_COMPLETE" in line for line in accept_runtime_lines),
+            "STATUS|SUCCESS|LAUNCHER_RUNTIME|FAILURE_FLOW_COMPLETE absent",
+        ),
+        "traceback_absent": line_status(
+            all(
+                "Traceback" not in stderr
+                for stderr in (first_stderr, decline_stderr, accept_stderr)
+            ),
+            "\n".join(
+                part
+                for part in (
+                    first_stderr,
+                    decline_stderr,
+                    accept_stderr,
+                    first_stdout,
+                    decline_stdout,
+                    accept_stdout,
+                )
+                if part
+            ) or "no traceback in launcher output",
+        ),
+        "scenario_preflight_cleanup_optional": line_status(
+            not preexisting_processes_after,
+            "no prior validation-owned launcher/runtime processes detected"
+            if not preexisting_processes_before
+            else (
+                f"detected {len(preexisting_processes_before)} prior process(es); "
+                f"killed={','.join(str(pid) for pid in preexisting_processes_killed) or 'none'}"
+            ),
+        ),
+        "launch_chain_cleanup_optional": line_status(
+            not residual_launch_chain_processes_after,
+            "no residual validation-owned launcher/runtime processes detected"
+            if not residual_launch_chain_processes_before
+            else (
+                f"detected {len(residual_launch_chain_processes_before)} residual process(es); "
+                f"killed={','.join(str(pid) for pid in residual_launch_chain_killed) or 'none'}"
+            ),
+        ),
+    }
+
+    return {
+        "scenario_name": scenario_name,
+        "log_root": scenario_root,
+        "runtime_log": accept_runtime_log or decline_runtime_log or first_runtime_log,
+        "stdout": "\n".join(
+            part for part in (first_stdout, decline_stdout, accept_stdout) if part
+        ),
+        "stderr": "\n".join(
+            part for part in (first_stderr, decline_stderr, accept_stderr) if part
+        ),
         "checks": checks,
     }
 
@@ -3214,6 +4027,8 @@ def run_validation():
         {"JARVIS_HARNESS_RELAUNCH_SHUTDOWN_DELAY_SECONDS": "1.6"},
     )
     declined_relaunch_result = run_declined_relaunch_cycle_scenario()
+    rapid_declined_relaunch_result = run_rapid_consecutive_declined_relaunch_cycles_scenario()
+    mixed_decline_accept_result = run_mixed_decline_then_accept_relaunch_scenario()
     relaunch_after_recoverable_result = run_relaunch_after_recoverable_exit_scenario()
     consecutive_relaunch_cycles_result = run_rapid_consecutive_accepted_relaunch_cycles_scenario()
     main_invalid_argument_result = run_main_invalid_argument_scenario()
@@ -3250,6 +4065,10 @@ def run_validation():
         checks[f"{accepted_relaunch_slow_shutdown_result['scenario_name']}::{check_name}"] = check_result
     for check_name, check_result in declined_relaunch_result["checks"].items():
         checks[f"{declined_relaunch_result['scenario_name']}::{check_name}"] = check_result
+    for check_name, check_result in rapid_declined_relaunch_result["checks"].items():
+        checks[f"{rapid_declined_relaunch_result['scenario_name']}::{check_name}"] = check_result
+    for check_name, check_result in mixed_decline_accept_result["checks"].items():
+        checks[f"{mixed_decline_accept_result['scenario_name']}::{check_name}"] = check_result
     for check_name, check_result in relaunch_after_recoverable_result["checks"].items():
         checks[f"{relaunch_after_recoverable_result['scenario_name']}::{check_name}"] = check_result
     for check_name, check_result in consecutive_relaunch_cycles_result["checks"].items():
@@ -3282,6 +4101,9 @@ def run_validation():
             repeated_entrypoint_result,
             accepted_relaunch_result,
             accepted_relaunch_slow_shutdown_result,
+            declined_relaunch_result,
+            rapid_declined_relaunch_result,
+            mixed_decline_accept_result,
             relaunch_after_recoverable_result,
             consecutive_relaunch_cycles_result,
             main_invalid_argument_result,

--- a/dev/orin_desktop_entrypoint_validation.py
+++ b/dev/orin_desktop_entrypoint_validation.py
@@ -61,6 +61,9 @@ RELAUNCH_REPLACEMENT_SESSION_ACTIVE_MARKER = (
 RELAUNCH_REPLACEMENT_SESSION_SETTLED_MARKER = (
     "STATUS|SUCCESS|LAUNCHER_RUNTIME|RELAUNCH_REPLACEMENT_SESSION_SETTLED|state=dormant"
 )
+RELAUNCH_DECLINED_SESSION_PRESERVED_MARKER = (
+    "STATUS|SUCCESS|LAUNCHER_RUNTIME|RELAUNCH_DECLINED_SESSION_PRESERVED"
+)
 SINGLE_INSTANCE_RELEASED_MARKER = "STATUS|TRACE|LAUNCHER_RUNTIME|SINGLE_INSTANCE_RELEASED"
 
 EXPECTED_MILESTONES = [
@@ -1181,6 +1184,10 @@ def run_accepted_relaunch_cycle_scenario(
     first_relaunch_request_index = first_marker_index(first_runtime_lines, "RENDERER_MAIN|RELAUNCH_REQUEST_RECEIVED")
     first_shutdown_index = first_marker_index(first_runtime_lines, "RENDERER_MAIN|SHUTDOWN_REQUESTED")
     first_exit_index = first_marker_index(first_runtime_lines, "RENDERER_MAIN|EVENT_LOOP_EXIT|code=0")
+    first_recoverable_complete_index = first_marker_index(
+        first_runtime_lines,
+        POST_SETTLED_RECOVERABLE_COMPLETE_MARKER,
+    )
     first_release_index = first_marker_index(first_runtime_lines, SINGLE_INSTANCE_RELEASED_MARKER)
     first_replacement_active_index = first_marker_index(
         first_runtime_lines,
@@ -1984,6 +1991,367 @@ def run_rapid_consecutive_accepted_relaunch_cycles_scenario():
         "runtime_log": runtime_logs[2] or runtime_logs[1] or runtime_logs[0],
         "stdout": "\n".join(part for part in stdouts if part),
         "stderr": "\n".join(part for part in stderrs if part),
+        "checks": checks,
+    }
+
+
+def run_declined_relaunch_cycle_scenario():
+    scenario_name = "vbs_declined_relaunch_cycle"
+    scenario_root = os.path.join(BASE_LOG_ROOT, scenario_name)
+    preexisting_processes_before, preexisting_processes_killed, preexisting_processes_after = (
+        cleanup_launch_chain_processes_for_log_root(BASE_LOG_ROOT)
+    )
+    reset_dir(scenario_root)
+    scenario_root_entries_after_reset = dir_entry_names(scenario_root)
+
+    cscript_command = resolve_cscript_command()
+    launch_command = cscript_command + ["//nologo", ENTRYPOINT_SCRIPT] if cscript_command else []
+    first_env = build_harness_env(scenario_root)
+    decline_env = build_harness_env(
+        scenario_root,
+        extra_env={"JARVIS_HARNESS_AUTO_DECLINE_RELAUNCH": "1"},
+    )
+
+    first_proc = None
+    incoming_procs = [None, None]
+    first_stdout = ""
+    first_stderr = ""
+    incoming_stdouts = ["", ""]
+    incoming_stderrs = ["", ""]
+    first_runtime_log = ""
+    incoming_runtime_logs = ["", ""]
+    first_runtime_lines = []
+    incoming_runtime_lines = [[], []]
+    first_settled_seen = False
+    active_session_changed_before_manual_shutdown = False
+    shutdown_hotkey_sent = False
+    shutdown_hotkey_detail = "hotkey not sent"
+    shutdown_hotkey_attempts = 0
+
+    try:
+        if scenario_root_entries_after_reset or not launch_command:
+            pass
+        else:
+            first_proc = subprocess.Popen(
+                launch_command,
+                cwd=ROOT_DIR,
+                env=first_env,
+                **hidden_subprocess_kwargs(),
+            )
+
+            first_deadline = time.time() + 25.0
+            while time.time() < first_deadline:
+                runtime_logs = files_matching_sorted(scenario_root, "Runtime_")
+                if runtime_logs and not first_runtime_log:
+                    first_runtime_log = runtime_logs[0]
+                if first_runtime_log:
+                    first_runtime_lines = read_lines(first_runtime_log)
+                    if any(AUTHORITATIVE_DESKTOP_SETTLED_MARKER in line for line in first_runtime_lines):
+                        first_settled_seen = True
+                        break
+                if first_proc.poll() is not None:
+                    break
+                time.sleep(0.2)
+
+            for index in range(len(incoming_procs)):
+                incoming_procs[index] = subprocess.Popen(
+                    launch_command,
+                    cwd=ROOT_DIR,
+                    env=decline_env,
+                    **hidden_subprocess_kwargs(),
+                )
+
+                decline_deadline = time.time() + 15.0
+                while time.time() < decline_deadline:
+                    runtime_logs = files_matching_sorted(scenario_root, "Runtime_")
+                    known_logs = {first_runtime_log, *[path for path in incoming_runtime_logs[:index] if path]}
+                    new_logs = [path for path in runtime_logs if path not in known_logs]
+                    if new_logs and not incoming_runtime_logs[index]:
+                        incoming_runtime_logs[index] = new_logs[0]
+
+                    if first_runtime_log:
+                        first_runtime_lines = read_lines(first_runtime_log)
+                        if any("RENDERER_MAIN|RELAUNCH_REQUEST_RECEIVED" in line for line in first_runtime_lines):
+                            active_session_changed_before_manual_shutdown = True
+                        if any("RENDERER_MAIN|SHUTDOWN_REQUESTED" in line for line in first_runtime_lines):
+                            active_session_changed_before_manual_shutdown = True
+                        if any(SINGLE_INSTANCE_RELEASED_MARKER in line for line in first_runtime_lines):
+                            active_session_changed_before_manual_shutdown = True
+                        if any(
+                            RELAUNCH_REPLACEMENT_SESSION_ACTIVE_MARKER in line
+                            or RELAUNCH_REPLACEMENT_SESSION_SETTLED_MARKER in line
+                            for line in first_runtime_lines
+                        ):
+                            active_session_changed_before_manual_shutdown = True
+
+                    if incoming_runtime_logs[index]:
+                        incoming_runtime_lines[index] = read_lines(incoming_runtime_logs[index])
+                        if any(
+                            RELAUNCH_DECLINED_SESSION_PRESERVED_MARKER in line
+                            for line in incoming_runtime_lines[index]
+                        ):
+                            break
+                    if incoming_procs[index].poll() is not None and incoming_runtime_logs[index]:
+                        break
+                    time.sleep(0.2)
+
+            if first_settled_seen:
+                shutdown_hotkey_attempts += 1
+                shutdown_hotkey_sent, shutdown_hotkey_detail = send_shutdown_hotkey()
+
+            shutdown_deadline = time.time() + 20.0
+            while time.time() < shutdown_deadline:
+                first_runtime_lines = read_lines(first_runtime_log)
+                shutdown_seen = any(
+                    "RENDERER_MAIN|SHUTDOWN_REQUESTED" in line for line in first_runtime_lines
+                )
+                exit_seen = any(
+                    "RENDERER_MAIN|EVENT_LOOP_EXIT|code=0" in line for line in first_runtime_lines
+                )
+                release_seen = any(
+                    SINGLE_INSTANCE_RELEASED_MARKER in line for line in first_runtime_lines
+                )
+
+                if shutdown_hotkey_sent and not shutdown_seen and shutdown_hotkey_attempts < 2:
+                    shutdown_hotkey_attempts += 1
+                    shutdown_hotkey_sent, shutdown_hotkey_detail = send_shutdown_hotkey()
+
+                if shutdown_seen and exit_seen and release_seen:
+                    break
+                time.sleep(0.2)
+    finally:
+        all_procs = [first_proc, *incoming_procs]
+        for index, proc in enumerate(all_procs):
+            if proc is None:
+                continue
+            try:
+                if proc.poll() is None:
+                    terminate_process_tree(proc)
+                stdout_text, stderr_text = proc.communicate(timeout=5)
+            except Exception:
+                stdout_text = ""
+                stderr_text = ""
+
+            if index == 0:
+                first_stdout = (stdout_text or "").strip()
+                first_stderr = (stderr_text or "").strip()
+            else:
+                incoming_stdouts[index - 1] = (stdout_text or "").strip()
+                incoming_stderrs[index - 1] = (stderr_text or "").strip()
+
+    first_runtime_lines = read_lines(first_runtime_log)
+    incoming_runtime_lines = [read_lines(path) for path in incoming_runtime_logs]
+
+    residual_launch_chain_processes_before, residual_launch_chain_killed, residual_launch_chain_processes_after = (
+        cleanup_launch_chain_processes_for_log_root(BASE_LOG_ROOT)
+    )
+
+    first_settled_index = first_marker_index(first_runtime_lines, AUTHORITATIVE_DESKTOP_SETTLED_MARKER)
+    first_relaunch_request_index = first_marker_index(first_runtime_lines, "RENDERER_MAIN|RELAUNCH_REQUEST_RECEIVED")
+    first_shutdown_index = first_marker_index(first_runtime_lines, "RENDERER_MAIN|SHUTDOWN_REQUESTED")
+    first_exit_index = first_marker_index(first_runtime_lines, "RENDERER_MAIN|EVENT_LOOP_EXIT|code=0")
+    first_recoverable_complete_index = first_marker_index(
+        first_runtime_lines,
+        POST_SETTLED_RECOVERABLE_COMPLETE_MARKER,
+    )
+    first_release_index = first_marker_index(first_runtime_lines, SINGLE_INSTANCE_RELEASED_MARKER)
+    first_replacement_active_index = first_marker_index(
+        first_runtime_lines,
+        RELAUNCH_REPLACEMENT_SESSION_ACTIVE_MARKER,
+    )
+    first_replacement_settled_index = first_marker_index(
+        first_runtime_lines,
+        RELAUNCH_REPLACEMENT_SESSION_SETTLED_MARKER,
+    )
+
+    incoming_indexes = []
+    for lines in incoming_runtime_lines:
+        incoming_indexes.append(
+            {
+                "conflict": first_marker_index(lines, "SINGLE_INSTANCE_CONFLICT_DETECTED"),
+                "prompt_decline": max(
+                    first_marker_index(lines, "REPLACE_PROMPT_DECLINED"),
+                    first_marker_index(lines, "REPLACE_PROMPT_AUTO_DECLINED"),
+                ),
+                "decline_success": first_marker_index(lines, RELAUNCH_DECLINED_SESSION_PRESERVED_MARKER),
+                "already_running": first_marker_index(
+                    lines,
+                    "STATUS|SKIP|LAUNCHER_RUNTIME|ALREADY_RUNNING",
+                ),
+                "runtime_start": first_marker_index(lines, "STATUS|START|LAUNCHER_RUNTIME"),
+                "renderer_spawn": first_marker_index(
+                    lines,
+                    "STATUS|SUCCESS|RENDERER_PROCESS_SPAWN",
+                ),
+                "prompt_accept": max(
+                    first_marker_index(lines, "REPLACE_PROMPT_ACCEPTED"),
+                    first_marker_index(lines, "REPLACE_PROMPT_AUTO_ACCEPTED"),
+                ),
+                "signal_sent": first_marker_index(lines, "RELAUNCH_SIGNAL_SENT"),
+                "reacquire": first_marker_index(lines, "RELAUNCH_ACQUIRED_AFTER_WAIT"),
+                "replacement_confirmed": first_marker_index(
+                    lines,
+                    "RELAUNCH_REPLACEMENT_SESSION_CONFIRMED",
+                ),
+                "replacement_active": first_marker_index(
+                    lines,
+                    RELAUNCH_REPLACEMENT_SESSION_ACTIVE_MARKER,
+                ),
+                "settled": first_marker_index(lines, AUTHORITATIVE_DESKTOP_SETTLED_MARKER),
+                "replacement_settled": first_marker_index(
+                    lines,
+                    RELAUNCH_REPLACEMENT_SESSION_SETTLED_MARKER,
+                ),
+                "release": first_marker_index(lines, SINGLE_INSTANCE_RELEASED_MARKER),
+            }
+        )
+
+    ordering_detail = (
+        f"first_settled={first_settled_index}, first_relaunch_request={first_relaunch_request_index}, "
+        f"first_shutdown={first_shutdown_index}, first_exit={first_exit_index}, "
+        f"first_recoverable_complete={first_recoverable_complete_index}, first_release={first_release_index}, "
+        f"first_replacement_active={first_replacement_active_index}, "
+        f"first_replacement_settled={first_replacement_settled_index}, "
+        f"incoming1={incoming_indexes[0]}, incoming2={incoming_indexes[1]}"
+    )
+
+    checks = {
+        "cscript_available": line_status(
+            bool(cscript_command),
+            cscript_command[0] if cscript_command else "missing Windows Script Host entrypoint",
+        ),
+        "scenario_log_root_cleared_before_launch": line_status(
+            not scenario_root_entries_after_reset,
+            "empty" if not scenario_root_entries_after_reset else ", ".join(scenario_root_entries_after_reset[:5]),
+        ),
+        "three_runtime_logs_created": line_status(
+            bool(first_runtime_log)
+            and all(incoming_runtime_logs)
+            and len({first_runtime_log, *incoming_runtime_logs}) == 3,
+            ", ".join(path or "missing" for path in [first_runtime_log, *incoming_runtime_logs]),
+        ),
+        "active_session_reached_settled_before_declines": line_status(
+            first_settled_index >= 0,
+            AUTHORITATIVE_DESKTOP_SETTLED_MARKER if first_settled_index >= 0 else "missing authoritative settled marker",
+        ),
+        "active_session_unchanged_during_declines": line_status(
+            not active_session_changed_before_manual_shutdown and first_relaunch_request_index < 0,
+            ordering_detail,
+        ),
+        "active_session_replacement_markers_absent": line_status(
+            first_replacement_active_index < 0 and first_replacement_settled_index < 0,
+            ordering_detail,
+        ),
+        "active_session_lifecycle_completed_after_declines": line_status(
+            (
+                first_shutdown_index > first_settled_index >= 0
+                and first_exit_index > first_shutdown_index
+                and first_release_index > first_exit_index
+            )
+            or (
+                first_recoverable_complete_index > first_settled_index >= 0
+                and first_release_index > first_recoverable_complete_index
+            ),
+            ordering_detail,
+        ),
+        "active_session_shutdown_hotkey_optional": line_status(
+            True,
+            shutdown_hotkey_detail if shutdown_hotkey_sent else "not sent",
+        ),
+        "incoming_launches_conflict_and_decline": line_status(
+            all(
+                info["conflict"] >= 0 and info["prompt_decline"] > info["conflict"] >= 0
+                for info in incoming_indexes
+            ),
+            ordering_detail,
+        ),
+        "incoming_launches_record_preserved_session_success": line_status(
+            all(
+                info["decline_success"] > info["prompt_decline"] >= 0
+                for info in incoming_indexes
+            ),
+            ordering_detail,
+        ),
+        "incoming_launches_never_start_runtime_ownership": line_status(
+            all(
+                info["runtime_start"] < 0 and info["renderer_spawn"] < 0 and info["settled"] < 0
+                for info in incoming_indexes
+            ),
+            ordering_detail,
+        ),
+        "incoming_launches_emit_no_replacement_markers": line_status(
+            all(
+                info["prompt_accept"] < 0
+                and info["signal_sent"] < 0
+                and info["reacquire"] < 0
+                and info["replacement_confirmed"] < 0
+                and info["replacement_active"] < 0
+                and info["replacement_settled"] < 0
+                and info["release"] < 0
+                for info in incoming_indexes
+            ),
+            ordering_detail,
+        ),
+        "incoming_launches_generic_already_running_marker_absent": line_status(
+            all(info["already_running"] < 0 for info in incoming_indexes),
+            ordering_detail,
+        ),
+        "incoming_launches_no_failure_flow": line_status(
+            all(
+                not any("STATUS|SUCCESS|LAUNCHER_RUNTIME|FAILURE_FLOW_COMPLETE" in line for line in lines)
+                for lines in incoming_runtime_lines
+            ),
+            "STATUS|SUCCESS|LAUNCHER_RUNTIME|FAILURE_FLOW_COMPLETE absent",
+        ),
+        "no_relaunch_wait_timeout_in_incoming_launches": line_status(
+            all(
+                not any("RELAUNCH_WAIT_TIMEOUT" in line for line in lines)
+                for lines in incoming_runtime_lines
+            ),
+            "RELAUNCH_WAIT_TIMEOUT absent",
+        ),
+        "single_instance_guard_remained_with_active_session": line_status(
+            first_relaunch_request_index < 0
+            and all(info["reacquire"] < 0 for info in incoming_indexes)
+            and (
+                first_release_index > first_exit_index >= 0
+                or first_release_index > first_recoverable_complete_index >= 0
+            ),
+            ordering_detail,
+        ),
+        "traceback_absent": line_status(
+            "Traceback" not in first_stderr
+            and all("Traceback" not in stderr for stderr in incoming_stderrs),
+            "\n".join(
+                part for part in [first_stderr, *incoming_stderrs, first_stdout, *incoming_stdouts] if part
+            ) or "no traceback in launcher output",
+        ),
+        "scenario_preflight_cleanup_optional": line_status(
+            not preexisting_processes_after,
+            "no prior validation-owned launcher/runtime processes detected"
+            if not preexisting_processes_before
+            else (
+                f"detected {len(preexisting_processes_before)} prior process(es); "
+                f"killed={','.join(str(pid) for pid in preexisting_processes_killed) or 'none'}"
+            ),
+        ),
+        "launch_chain_cleanup_optional": line_status(
+            not residual_launch_chain_processes_after,
+            "no residual validation-owned launcher/runtime processes detected"
+            if not residual_launch_chain_processes_before
+            else (
+                f"detected {len(residual_launch_chain_processes_before)} residual process(es); "
+                f"killed={','.join(str(pid) for pid in residual_launch_chain_killed) or 'none'}"
+            ),
+        ),
+    }
+
+    return {
+        "scenario_name": scenario_name,
+        "log_root": scenario_root,
+        "runtime_log": first_runtime_log,
+        "stdout": "\n".join(part for part in [first_stdout, *incoming_stdouts] if part),
+        "stderr": "\n".join(part for part in [first_stderr, *incoming_stderrs] if part),
         "checks": checks,
     }
 
@@ -2845,6 +3213,7 @@ def run_validation():
         "vbs_accepted_relaunch_cycle_slow_shutdown",
         {"JARVIS_HARNESS_RELAUNCH_SHUTDOWN_DELAY_SECONDS": "1.6"},
     )
+    declined_relaunch_result = run_declined_relaunch_cycle_scenario()
     relaunch_after_recoverable_result = run_relaunch_after_recoverable_exit_scenario()
     consecutive_relaunch_cycles_result = run_rapid_consecutive_accepted_relaunch_cycles_scenario()
     main_invalid_argument_result = run_main_invalid_argument_scenario()
@@ -2879,6 +3248,8 @@ def run_validation():
         checks[f"{accepted_relaunch_result['scenario_name']}::{check_name}"] = check_result
     for check_name, check_result in accepted_relaunch_slow_shutdown_result["checks"].items():
         checks[f"{accepted_relaunch_slow_shutdown_result['scenario_name']}::{check_name}"] = check_result
+    for check_name, check_result in declined_relaunch_result["checks"].items():
+        checks[f"{declined_relaunch_result['scenario_name']}::{check_name}"] = check_result
     for check_name, check_result in relaunch_after_recoverable_result["checks"].items():
         checks[f"{relaunch_after_recoverable_result['scenario_name']}::{check_name}"] = check_result
     for check_name, check_result in consecutive_relaunch_cycles_result["checks"].items():


### PR DESCRIPTION
## Summary

Deliver the bounded FB-047 runtime/user-facing relaunch-decline preservation slice by proving declined incoming launches preserve the settled active session, keep single-instance ownership with that session, and exit truthfully without false replacement-session markers; preserve real desktop shortcut and explicit dev boot proof; align merge-target canon for `v1.6.11-prebeta`; and select FB-048 as the next relaunch signal-failure and wait-timeout truth lane.

## What Changed

No detailed branch evidence was preserved in the original PR body.

Historical metadata preserved for traceability:
- Base: `main`
- Head: `feature/fb-047-active-session-relaunch-decline-preservation`
- Head commit: `b410357f877bc679416396cad273c422900c3f3d`

Historical metadata preserved for traceability:
- Base: `main`
- Head: `feature/fb-047-active-session-relaunch-decline-preservation`
- Head commit: `b410357f877bc679416396cad273c422900c3f3d`
