### PR TITLE
[codex] Repair automation planning post-merge canon

### DIFF
--- a/Docs/branch_records/feature_automation_planning.md
+++ b/Docs/branch_records/feature_automation_planning.md
@@ -18,11 +18,9 @@ Branch Readiness closed green at `6cc2159`. Workstream then executed as one boun
 
 ## Phase Status
 
-- Repo State: `Branch-owned implementation surface`
+- Repo State: `No Active Branch`
 - Merged-Main Repo State: `No Active Branch`
-- `Active Branch`: `feature/automation-planning`
-- Current Active Branch: `feature/automation-planning`
-- Current Active Branch Authority Record: `Docs/branch_records/feature_automation_planning.md`
+- Historical traceability record after PR #99 merged at `daf727e9875c0b1c4de9672e36d6dd9411411001` and the source branch was deleted.
 - Current Active Canonical Workstream Doc: `None`
 - Latest Public Prerelease: `v1.6.12-prebeta`
 - Latest Public Release Commit: `b06c359e58b47cfe26fe8c4b39ac04fde519dee9`
@@ -61,10 +59,10 @@ Branch Readiness closed green at `6cc2159`. Workstream then executed as one boun
 - Hardening H1 result: complete and green. Authority-aligned hardening validation confirmed all eight automation records, automation id/cadence class/target/stop-condition/output-boundary truth, heartbeat-vs-cron separation, operational rollback pause/delete paths, and preserved FB-049 selected-next truth with no repair candidates.
 - Historical Live Validation Seam: `Live Validation LV1 - Automation Catalog Final Validation`
 - Live Validation LV1 result: complete and green. Final authority-aligned validation confirmed all eight automation records, heartbeat-versus-cron separation, operational rollback availability, clean branch/origin alignment, and preserved FB-049 selected-next truth with no repair candidates.
-- Current PR Readiness Seam: `PR Readiness PR1 - Automation Catalog PR Validation`
-- PR Readiness PR1 status: in progress. This seam is admitting PR Readiness authority, preserving clean durable branch truth, validating merge-target canon and release-window posture, creating the live PR, validating live PR state against the automation catalog contract, and preserving FB-049 selected-next truth with no waiver recorded.
-- PR Readiness PR1 runtime-proof status: the phase-critical PR watcher now requires explicit run evidence before it can clear PR-facing automation truth. Native Codex heartbeat is preferred, but if it remains `ACTIVE` without run evidence, a bounded fallback watcher may operate only for the live PR during `PR Readiness` and must self-delete when the PR becomes terminal or the branch leaves `PR Readiness`.
-- Next Active Seam: `PR Readiness PR1 - Automation Catalog PR Validation`
+- Historical PR Readiness Seam: `PR Readiness PR1 - Automation Catalog PR Validation`
+- PR Readiness PR1 result: complete and green historical truth. Live PR #99 was created, merge-target canon and release-window posture were validated, runtime proof was established through bounded fallback evidence when native heartbeat runtime proof was missing, the branch remained clean and aligned, and the branch then merged through PR #99 on April 29, 2026.
+- Historical PR Readiness runtime-proof result: native Codex heartbeat remained preferred but unproven on this branch, the bounded PR-specific fallback stayed narrowed to the live PR during `PR Readiness`, and the stale PR99 watcher lifecycle is now retired after merge and phase exit.
+- Release Readiness admission note: `Release Readiness RR1` was the next legal phase but was not admitted on this branch before merge.
 
 ## Branch Class
 
@@ -356,25 +354,26 @@ Seam 8: `WS8 - Post-Merge Closure Watch`
 
 ## Active Seam
 
-Active seam: `PR Readiness PR1 - Automation Catalog PR Validation`
-Next active seam: `PR Readiness PR1 - Automation Catalog PR Validation`
+Active seam: `None. Historical traceability record after PR #99 merged and the source branch was deleted.`
+Next active seam: `None.`
 
 - Workstream WS1 through WS8 remain complete and green historical truth on this branch.
 - Hardening H1 `Automation Catalog Validation` is complete and green on this branch.
 - Live Validation LV1 `Automation Catalog Final Validation` is complete and green on this branch.
-- PR Readiness PR1 `Automation Catalog PR Validation` is the current active seam on this branch.
+- PR Readiness PR1 `Automation Catalog PR Validation` is complete and green historical truth on this branch.
+- Release Readiness RR1 was not admitted on this branch before merge.
 
 ## Seam Continuation Decision
 
-Seam Status: `In Progress`
-Slice Status: `In Progress`
+Seam Status: `Green`
+Slice Status: `Green`
 Completion Status: `Green`
 Waiver Status: `None`
-Continue Decision: `Continue`
-Stop Basis: `None`
-Next Active Seam: `PR Readiness PR1 - Automation Catalog PR Validation`
-Stop Condition: `Stop only if PR Readiness PR1 turns green and Release Readiness becomes the next legal phase, or if a named blocker or waiver stops PR Readiness before PR1 completes.`
-Continuation Action: `Execute PR Readiness PR1 automation-catalog PR validation, create the live PR, validate live PR state, and preserve the completed Workstream, Hardening, Live Validation, cadence boundaries, rollback paths, and FB-049 selected-next truth.`
+Continue Decision: `Stop`
+Stop Basis: `Historical traceability only after PR #99 merged`
+Next Active Seam: `None`
+Stop Condition: `Branch is merged and deleted; no further same-branch execution is legal.`
+Continuation Action: `None. Historical traceability record only.`
 
 ## Governance Drift Audit
 
@@ -382,21 +381,21 @@ Continuation Action: `Execute PR Readiness PR1 automation-catalog PR validation,
 - Drift Type: automation runtime-proof and fallback-containment gap.
 - Why Current Canon Failed To Prevent It: the branch truth treated the PR heartbeat watcher as effectively live once it existed and showed `ACTIVE`, but the native Codex heartbeat runtime produced no run evidence and the branch had no explicit bounded fallback rule.
 - Required Canon Changes: record that `ACTIVE` is configuration state rather than run proof, require explicit run evidence for phase-critical automation, allow only target-scoped and phase-scoped bounded fallback helpers, and keep lifecycle waiting monitors from implying merge or release authority by themselves.
-- Whether The Drift Blocks Merge: Yes until PR watcher runtime proof exists through native evidence or a bounded fallback and the repaired governance truth is durable on the branch.
+- Whether The Drift Blocks Merge: No after PR #99. The bounded fallback provided the needed runtime proof, the branch merged, and the stale watcher lifecycle is now retired.
 - Whether User Confirmation Is Required: No for the current approved automation-catalog validation branch.
-- Missing blocker check: no blocker is missing after this repair; PR phase admission, live PR creation, PR validation, runtime-proof enforcement, release-window posture, post-merge state, and FB-049 selected-next preservation are all represented in current governance.
-- Weak phase entry or exit rule check: no unresolved weakness remains after this repair; PR creation and live PR validation now occur in PR Readiness instead of being left implicit after Live Validation, and PR-critical automation now carries an explicit phase-bounded fallback rule.
+- Missing blocker check: no blocker is missing after this repair; PR phase admission, live PR creation, PR validation, runtime-proof enforcement, release-window posture, post-merge state, watcher retirement, and FB-049 selected-next preservation are all represented in current governance.
+- Weak phase entry or exit rule check: no unresolved weakness remains after this repair; PR creation and live PR validation occurred inside PR Readiness before merge, PR-critical automation carried an explicit phase-bounded fallback rule, and post-merge cleanup now closes the stale watcher lifecycle.
 - Weak source-of-truth ownership rule check: no unresolved weakness remains; the branch authority record owns active phase truth, while backlog and roadmap remain synchronized subordinate mirrors.
-- Stale prompt scaffolding or operator example check: no blocking stale scaffolding remains after this repair; PR Readiness now carries explicit active-seam truth and automation runtime-proof language.
-- Missing validator requirement check: the automation-planning validator now enforces PR1 phase admission markers, runtime-proof language, fallback containment, and lifecycle waiting-monitor boundaries in addition to the earlier Hardening and Live Validation phase-truth checks.
+- Stale prompt scaffolding or operator example check: no blocking stale scaffolding remains after this repair; historical PR truth now records the merged branch accurately instead of leaving PR1 active after branch deletion.
+- Missing validator requirement check: the automation-planning validator now enforces PR1 phase admission markers, runtime-proof language, fallback containment, and lifecycle waiting-monitor boundaries in addition to the earlier Hardening and Live Validation phase-truth checks; merged-main canon cleanup moves this record out of `Active Branch Authority Records` so the deleted branch can no longer masquerade as current ownership.
 
 ## Post-Merge State
 
-- Post-merge repo state: `No Active Branch` after merge, while merged current-state canon carries the still-unreleased pre-Beta posture and this branch authority record becomes historical traceability only.
+- Post-merge repo state: `No Active Branch` after merge, while merged current-state canon carries the still-unreleased `v1.6.13-prebeta` posture and this branch authority record is now historical traceability only.
 - Post-merge selected-next truth: FB-049 remains selected next, `Registry-only`, and branch-not-created until updated `main` is revalidated and FB-049 Branch Readiness admits the first bounded pre-settled incoming-launch conflict truth slice.
 - Post-merge automation-catalog truth: merged canon must preserve the admitted eight-record automation catalog, the heartbeat-versus-cron cadence split, the rollback/containment rules, and the clean FB-049 selected-next lock.
-- Post-merge PR watcher fallback handling: any temporary PR-specific fallback helper must be removed or already self-terminated before this record becomes historical traceability only.
-- Post-merge branch-record handling: this record must leave `Active Branch Authority Records` after merge and move to historical traceability once later release packaging and publication are complete.
+- Post-merge PR watcher fallback handling: the temporary PR-specific fallback helper and the paused native `pr99-heartbeat-watch` lifecycle are retired after PR #99 merge and phase exit from `PR Readiness`.
+- Post-merge branch-record handling: this record has left `Active Branch Authority Records` and is preserved under historical traceability only.
 - Post-merge successor handling: no successor implementation branch opens during this automation-catalog PR; later successor work remains the future FB-049 branch only after its stated gate clears.
 
 ## Release Window Audit

--- a/Docs/branch_records/feature_automation_planning_post_merge_canon_repair.md
+++ b/Docs/branch_records/feature_automation_planning_post_merge_canon_repair.md
@@ -1,0 +1,148 @@
+# Branch Authority Record: feature/automation-planning-post-merge-canon-repair
+
+## Branch Identity
+
+- Branch: `feature/automation-planning-post-merge-canon-repair`
+- Workstream: `Automation Planning Post-Merge Canon Repair`
+- Branch Class: `emergency canon repair`
+
+## Purpose / Why It Exists
+
+This bounded repair branch exists only to clean the merged-main canon drift left behind after PR #99 merged and the source branch `feature/automation-planning` was deleted.
+
+It does not reopen automation implementation, admit Release Readiness on the deleted source branch, create a successor implementation branch, or change FB-049 selected-next truth. Its job is only to restore truthful merged-main ownership, keep `feature_automation_planning.md` historical-only, and retire the stale PR99 watcher lifecycle state.
+
+## Current Phase
+
+- Phase: `PR Readiness`
+
+## Phase Status
+
+- Repo State: `Branch-owned repair surface`
+- Merged-Main Repo State: `No Active Branch`
+- `Active Branch`: `feature/automation-planning-post-merge-canon-repair`
+- Current Active Branch: `feature/automation-planning-post-merge-canon-repair`
+- Current Active Branch Authority Record: `Docs/branch_records/feature_automation_planning_post_merge_canon_repair.md`
+- Current Active Canonical Workstream Doc: `None`
+- Latest Public Prerelease: `v1.6.12-prebeta`
+- Latest Public Release Commit: `b06c359e58b47cfe26fe8c4b39ac04fde519dee9`
+- Latest Public Prerelease Publication: `https://github.com/GiribaldiTTV/Nexus-Desktop-AI/releases/tag/v1.6.12-prebeta`
+- Latest Public Prerelease Title: `Pre-Beta v1.6.12`
+- Selected Next Workstream: `FB-049 Active-session pre-settled incoming-launch conflict truth`
+- Selected Next Record State: `Registry-only`
+- Selected Next Implementation Branch: `Not created`
+- Historical source branch: `feature/automation-planning` merged through PR #99 at `daf727e9875c0b1c4de9672e36d6dd9411411001` and was then deleted.
+- Current PR Readiness Seam: `PR Readiness PR1 - Post-Merge Canon Repair PR Validation`
+- PR Readiness PR1 status: in progress. This seam admits PR Readiness for the bounded repair branch, preserves merged-main `No Active Branch` truth, keeps `feature_automation_planning.md` historical-only, preserves retired PR99 watcher cleanup proof, preserves pending `v1.6.13-prebeta` release posture, opens the live repair PR, and preserves FB-049 selected-next truth without widening back into automation implementation.
+- Next Active Seam: `PR Readiness PR1 - Post-Merge Canon Repair PR Validation`
+
+## Branch Class
+
+- `emergency canon repair`
+
+## Blockers
+
+- `PR Validation Pending`
+- `Bot Review Signal Pending`
+
+## Entry Basis
+
+- updated `main` is aligned with `origin/main` at merged PR #99 truth
+- merged-main canon was stale because it still narrated `feature/automation-planning` as active even after the source branch was deleted
+- `feature_automation_planning.md` needed to remain historical-only traceability instead of live execution authority
+- the stale PR99 watcher lifecycle needed retirement to match the repaired canon
+- this branch exists only to land that bounded post-merge canon repair cleanly before any later release-packaging or successor-branch admission
+
+## Exit Criteria
+
+- merged-main current-state truth remains `No Active Branch`
+- active branch authority records are empty on merged-main surfaces
+- `Docs/branch_records/feature_automation_planning.md` remains historical-only traceability
+- the stale PR99 watcher lifecycle remains retired
+- pending `v1.6.13-prebeta` release posture remains preserved
+- FB-049 remains selected next, `Registry-only`, and branch-not-created
+- the live repair PR exists, is clean, and can move forward under normal PR Readiness governance
+
+## Rollback Target
+
+- `Branch Readiness`
+
+## Next Legal Phase
+
+- `Release Readiness`
+
+## Scope
+
+- branch-authority admission for this bounded repair branch only
+- merged-main canon repair only
+- PR99 watcher lifecycle retirement only
+- live PR creation and validation only
+
+## Explicit Non-Goals
+
+- no reopening of automation implementation
+- no release packaging execution
+- no runtime, backend, developer-tooling, or user-facing product changes
+- no FB-049 branch admission or selected-next mutation
+- no widening into another repair lane or successor branch by inertia
+
+## Validation Contract
+
+- run `python dev\orin_branch_governance_validation.py`
+- run `git diff --check`
+- confirm merged-main current-state truth still resolves to `No Active Branch`
+- confirm `Docs/branch_records/index.md` carries this branch as the only active branch-authority record and keeps `feature_automation_planning.md` historical
+- confirm PR99 watcher cleanup proof remains absent locally
+- validate the live PR state after creation
+
+## Rollback Model
+
+- default rollback target is the last clean merged-main canon state before this repair admission
+- rollback if this branch reactivates deleted branch ownership on merged-main or revives PR99 watcher state
+- rollback if the repair widens into implementation, release execution, or successor-branch admission
+
+## Active Seam
+
+Active seam: `PR Readiness PR1 - Post-Merge Canon Repair PR Validation`
+Next active seam: `PR Readiness PR1 - Post-Merge Canon Repair PR Validation`
+
+- This is the current active seam on this repair branch.
+
+## Seam Continuation Decision
+
+Seam Status: `In Progress`
+Slice Status: `In Progress`
+Completion Status: `In Progress`
+Waiver Status: `None`
+Continue Decision: `Continue`
+Stop Basis: `None`
+Next Active Seam: `PR Readiness PR1 - Post-Merge Canon Repair PR Validation`
+Stop Condition: `Stop only if PR Readiness PR1 turns green and Release Readiness becomes the next legal phase, or if a named blocker or waiver stops PR Readiness before PR1 completes.`
+Continuation Action: `Create the live repair PR, validate merged-main canon and watcher cleanup against that live PR surface, preserve pending release posture, and keep FB-049 selected-next truth unchanged.`
+
+## Governance Drift Audit
+
+- Governance Drift Found: `Yes`
+- Drift Type: stale merged-main active-branch canon after PR #99 merge, plus stale PR99 watcher lifecycle state
+- Why Current Canon Failed To Prevent It: the merged source branch moved to historical-only truth, but merged-main current-state mirrors and watcher cleanup were not closed on the same active repair surface before the deleted source branch disappeared
+- Required Canon Changes: admit a bounded repair branch, move the merged automation-planning record to historical-only traceability, clear merged-main active branch authority, and require watcher lifecycle retirement to stay aligned with branch deletion
+- Whether The Drift Blocks Merge: `Yes until this repair branch owns the PR and the repaired canon is validated on its live PR surface`
+- Whether User Confirmation Is Required: `No for this bounded approved repair branch`
+- Missing blocker check: no missing blocker remains after this admission; PR creation, merged-main canon sync, historical-only traceability, watcher retirement, pending release posture, and FB-049 selected-next preservation are all represented
+- Weak source-of-truth ownership rule check: no unresolved weakness remains once this branch owns the repair; merged-main truth stays subordinate to the active repair branch until this PR merges
+
+## Post-Merge State
+
+- Post-merge repo state: `No Active Branch`
+- Post-merge repair truth: merged-main canon keeps `feature_automation_planning.md` historical-only, keeps active branch authority records empty, and preserves retired PR99 watcher cleanup truth
+- Post-merge selected-next truth: FB-049 remains selected next, `Registry-only`, and branch-not-created until updated `main` is revalidated and later Branch Readiness admits the first bounded FB-049 slice
+- Post-merge branch-record handling: this repair record leaves `Active Branch Authority Records` after merge and becomes preserved historical traceability only if later repo policy still needs it
+- Post-merge successor handling: no successor branch opens by inertia from this repair; later branch admission remains separately gated
+
+## Release Window Audit
+
+Release Window Audit: PASS
+Remaining Known Release Blockers: None
+Another Pre-Release Repair PR Required: NO
+Release Window Split Waiver: None
+

--- a/Docs/branch_records/index.md
+++ b/Docs/branch_records/index.md
@@ -47,10 +47,11 @@ Do not use this layer to replace:
 
 ## Active Branch Authority Records
 
-- `Docs/branch_records/feature_automation_planning.md`
+None.
 
 ## Historical Branch Authority Records
 
+- `Docs/branch_records/feature_automation_planning.md`
 - `Docs/branch_records/feature_backlog_family_governance_reform.md`
 - `Docs/branch_records/feature_fb_048_active_session_relaunch_signal_failure_and_wait_timeout_truth.md`
 - `Docs/branch_records/feature_fb_047_active_session_relaunch_decline_preservation.md`

--- a/Docs/branch_records/index.md
+++ b/Docs/branch_records/index.md
@@ -47,7 +47,7 @@ Do not use this layer to replace:
 
 ## Active Branch Authority Records
 
-None.
+- `Docs/branch_records/feature_automation_planning_post_merge_canon_repair.md`
 
 ## Historical Branch Authority Records
 

--- a/Docs/feature_backlog.md
+++ b/Docs/feature_backlog.md
@@ -59,17 +59,17 @@ FB-038 remains released and closed in `v1.4.1-prebeta`.
 ## Current Branch Execution Posture
 
 Merged-Unreleased Release-Debt Owner: None.
-Repo State: No Active Branch.
+Repo State: Branch-owned repair surface.
 Merged-Main Repo State: No Active Branch.
 Latest Public Prerelease: v1.6.12-prebeta.
 Latest Public Release Commit: b06c359e58b47cfe26fe8c4b39ac04fde519dee9.
 Latest Public Prerelease Publication: https://github.com/GiribaldiTTV/Nexus-Desktop-AI/releases/tag/v1.6.12-prebeta.
 Latest Public Prerelease Title: Pre-Beta v1.6.12.
 Release Debt: Clear after v1.6.12-prebeta publication, validation, and post-release canon closure.
-Current Active Workstream: None.
+Current Active Workstream: Automation Planning Post-Merge Canon Repair.
 Current Active Workstream Before Reform: None.
-Current Active Branch: None.
-Current Active Branch Authority Record: None.
+Current Active Branch: feature/automation-planning-post-merge-canon-repair.
+Current Active Branch Authority Record: Docs/branch_records/feature_automation_planning_post_merge_canon_repair.md.
 Current Active Canonical Workstream Doc: None.
 Historical Active Workstream Before Release: Automation Implementation.
 Earlier Historical Active Workstream Before Release: FB-048 Active-session relaunch signal-failure and wait-timeout truth.
@@ -80,9 +80,9 @@ Selected Next Record State: Registry-only.
 Selected Next Implementation Branch: Not created.
 Historical Repair-Only Branch Handling: `feature/fb-046-post-merge-canon-sync` was a bounded repair-only post-merge canon-sync `feature/` branch and did not imply Branch Readiness admission or active branch truth for FB-046.
 Historical Branch Readiness State: Complete on `feature/fb-048-active-session-relaunch-signal-failure-and-wait-timeout-truth`.
-Current Branch Readiness State: None active. Historical automation-planning Branch Readiness closed complete and green on `feature/automation-planning`, and its governance frame, watcher-policy boundaries, repo-hygiene candidate rules, and activation gate remain preserved only as historical admission basis for the merged automation-catalog branch.
-Current Workstream State: None active. The merged `feature/automation-planning` branch is historical traceability only after PR #99 merged into `main` at `daf727e9875c0b1c4de9672e36d6dd9411411001` and the source branch was deleted. The bounded same-branch automation catalog remains preserved as merged historical branch proof through `WS1` `PR Heartbeat Watcher`, hourly `phase-drift-watch`, six-hour `selected-next-lock-audit`, six-hour `main-revalidation-gate-watch`, six-hour `toolchain-availability-watch`, six-hour `automation-drift-audit`, hourly `release-window-sentinel`, and hourly `post-merge-closure-watch`; Hardening H1, Live Validation LV1, and PR Readiness PR1 remain complete and green historical truth; the PR watcher remains the only minute-scale heartbeat automation in preserved branch truth; historical runtime-proof governance is preserved as `ACTIVE` alone is not treated as run proof, and any fallback helper must stay narrowed to the live PR and bounded to `PR Readiness`; the stale PR99 watcher lifecycle is retired; backlog-family governance reform remains historical traceability only after PR #98 merged; release packaging for `v1.6.13-prebeta` remains pending historical release posture; and FB-049 remains the only selected-next user-facing candidate.
-Current Branch Class: None.
+Current Branch Readiness State: Bounded repair branch admitted directly from updated `main`; no new backlog-backed implementation workstream is opened by this repair.
+Current Workstream State: PR Readiness PR1 `Post-Merge Canon Repair PR Validation` is in progress on `feature/automation-planning-post-merge-canon-repair`. This bounded emergency canon repair preserves merged-main `No Active Branch` truth, keeps `feature/automation-planning` historical-only after PR #99, preserves retired PR99 watcher cleanup proof, preserves pending `v1.6.13-prebeta` release posture, and preserves FB-049 as the only selected-next user-facing candidate. the PR watcher remains the only minute-scale heartbeat automation in preserved branch truth. Historical runtime-proof governance remains preserved as `ACTIVE` alone is not treated as run proof, and any fallback helper must stay narrowed to the live PR and bounded to `PR Readiness`.
+Current Branch Class: emergency canon repair.
 Current Implementation Delta Class: None.
 Historical Workstream State: Automation catalog implementation is merged historical branch proof after PR #99; FB-048 is Released / Closed in `v1.6.12-prebeta`; FB-047 is Released / Closed in `v1.6.11-prebeta`; FB-046 is Released / Closed in `v1.6.10-prebeta`; FB-044 and FB-045 remain Released / Closed historical proof in `v1.6.9-prebeta`.
 Historical Hardening State: Complete on `feature/fb-048-active-session-relaunch-signal-failure-and-wait-timeout-truth`.
@@ -96,7 +96,7 @@ Release Scope: preserve the merged backlog-family governance reform and merged a
 Release Artifacts: Tag v1.6.13-prebeta; release title Pre-Beta v1.6.13; rich Markdown release notes summarize the merged governance reform, the merged automation catalog, and the validator/runtime-proof hardening without repeating the release title inside the notes body, and GitHub-generated `## What's Changed` plus `**Full Changelog**:` must be included.
 Post-Release Truth: the backlog-family governance reform and automation-catalog branches remain historical branch-authority traceability after publication and validation; latest public prerelease advances to `v1.6.13-prebeta`; release debt clears; and FB-049 remains selected next, `Registry-only`, and branch-not-created until updated `main` is revalidated and FB-049 Branch Readiness admits the first bounded pre-settled incoming-launch conflict truth slice.
 Next-Branch Creation Gate: FB-049 branch creation remains blocked until the merged `v1.6.13-prebeta` package is published, validated, updated `main` is revalidated, and FB-049 Branch Readiness admits the first bounded runtime/user-facing pre-settled incoming-launch conflict truth slice.
-Next Legal Phase: Branch Readiness.
+Next Legal Phase: Release Readiness.
 
 ## Backlog Governance Sync
 

--- a/Docs/feature_backlog.md
+++ b/Docs/feature_backlog.md
@@ -51,7 +51,7 @@ Historical note:
 
 `None.`
 
-FB-044 Boot-to-desktop handoff outcome refinement and FB-045 Active-session relaunch outcome refinement are Released / Closed historical proof through `v1.6.9-prebeta`; FB-046 Active-session relaunch reacquisition and settled re-entry proof is Released / Closed historical proof through `v1.6.10-prebeta`; FB-047 Active-session relaunch decline session-preservation proof is Released / Closed historical proof through `v1.6.11-prebeta`; FB-048 Active-session relaunch signal-failure and wait-timeout truth is now Released / Closed historical proof through `v1.6.12-prebeta`; latest public prerelease truth is `v1.6.12-prebeta`; release debt is clear after publication, validation, and post-release canon closure; the merged backlog-family governance reform package is now unreleased historical branch proof for `v1.6.13-prebeta` while repo state is steady-state `No Active Branch`; and FB-049 remains the selected-next `Registry-only` successor lane with branch not created.
+FB-044 Boot-to-desktop handoff outcome refinement and FB-045 Active-session relaunch outcome refinement are Released / Closed historical proof through `v1.6.9-prebeta`; FB-046 Active-session relaunch reacquisition and settled re-entry proof is Released / Closed historical proof through `v1.6.10-prebeta`; FB-047 Active-session relaunch decline session-preservation proof is Released / Closed historical proof through `v1.6.11-prebeta`; FB-048 Active-session relaunch signal-failure and wait-timeout truth is now Released / Closed historical proof through `v1.6.12-prebeta`; latest public prerelease truth is `v1.6.12-prebeta`; release debt is clear after publication, validation, and post-release canon closure; the merged backlog-family governance reform package plus the merged automation-catalog package are now unreleased historical branch proof for `v1.6.13-prebeta` while repo state is steady-state `No Active Branch`; the stale PR99 watcher lifecycle is retired; and FB-049 remains the selected-next `Registry-only` successor lane with branch not created.
 Released baseline truth is aligned: FB-040 is released and closed in `v1.6.0-prebeta`, FB-031 is released and closed in `v1.6.1-prebeta`, FB-032 is released and closed in `v1.6.2-prebeta`, FB-004 is released and closed in `v1.6.3-prebeta`, FB-015 plus FB-029 are released and closed in `v1.6.4-prebeta`, FB-030 is released and closed in `v1.6.5-prebeta`, FB-005 is released and closed in `v1.6.6-prebeta`, FB-042 is released and closed in `v1.6.7-prebeta`, FB-043 is released and closed in `v1.6.8-prebeta`, FB-044 plus FB-045 are released and closed in `v1.6.9-prebeta`, and FB-046 is now released and closed in `v1.6.10-prebeta`.
 FB-039 is released and closed in `v1.5.0-prebeta`.
 FB-038 remains released and closed in `v1.4.1-prebeta`.
@@ -59,32 +59,32 @@ FB-038 remains released and closed in `v1.4.1-prebeta`.
 ## Current Branch Execution Posture
 
 Merged-Unreleased Release-Debt Owner: None.
-Repo State: Branch-owned implementation surface.
+Repo State: No Active Branch.
 Merged-Main Repo State: No Active Branch.
 Latest Public Prerelease: v1.6.12-prebeta.
 Latest Public Release Commit: b06c359e58b47cfe26fe8c4b39ac04fde519dee9.
 Latest Public Prerelease Publication: https://github.com/GiribaldiTTV/Nexus-Desktop-AI/releases/tag/v1.6.12-prebeta.
 Latest Public Prerelease Title: Pre-Beta v1.6.12.
 Release Debt: Clear after v1.6.12-prebeta publication, validation, and post-release canon closure.
-Current Active Workstream: Automation Implementation.
+Current Active Workstream: None.
 Current Active Workstream Before Reform: None.
-Current Active Branch: feature/automation-planning.
-Current Active Branch Authority Record: Docs/branch_records/feature_automation_planning.md.
+Current Active Branch: None.
+Current Active Branch Authority Record: None.
 Current Active Canonical Workstream Doc: None.
-Historical Active Workstream Before Release: FB-048 Active-session relaunch signal-failure and wait-timeout truth.
-Earlier Historical Active Workstream Before Release: FB-047 Active-session relaunch decline session-preservation proof.
-Historical Active Branch Before Release: feature/fb-048-active-session-relaunch-signal-failure-and-wait-timeout-truth.
-Earlier Historical Active Branch Before Release: feature/fb-047-active-session-relaunch-decline-preservation.
+Historical Active Workstream Before Release: Automation Implementation.
+Earlier Historical Active Workstream Before Release: FB-048 Active-session relaunch signal-failure and wait-timeout truth.
+Historical Active Branch Before Release: feature/automation-planning.
+Earlier Historical Active Branch Before Release: feature/fb-048-active-session-relaunch-signal-failure-and-wait-timeout-truth.
 Selected Next Workstream: FB-049 Active-session pre-settled incoming-launch conflict truth.
 Selected Next Record State: Registry-only.
 Selected Next Implementation Branch: Not created.
 Historical Repair-Only Branch Handling: `feature/fb-046-post-merge-canon-sync` was a bounded repair-only post-merge canon-sync `feature/` branch and did not imply Branch Readiness admission or active branch truth for FB-046.
 Historical Branch Readiness State: Complete on `feature/fb-048-active-session-relaunch-signal-failure-and-wait-timeout-truth`.
-Current Branch Readiness State: Complete and green historical basis on `feature/automation-planning`. The branch's automation-planning governance frame, watcher-policy boundaries, repo-hygiene candidate rules, and activation gate remain preserved as the admission basis for the completed automation-catalog Workstream.
-Current Workstream State: Complete and green historical truth on `feature/automation-planning`, Hardening H1 `Automation Catalog Validation` remains complete and green historical truth, Live Validation LV1 `Automation Catalog Final Validation` remains complete and green historical truth, and PR Readiness PR1 `Automation Catalog PR Validation` is in progress. The bounded same-branch automation catalog remains implemented through `WS1` `PR Heartbeat Watcher`, hourly `phase-drift-watch`, six-hour `selected-next-lock-audit`, six-hour `main-revalidation-gate-watch`, six-hour `toolchain-availability-watch`, six-hour `automation-drift-audit`, hourly `release-window-sentinel`, and hourly `post-merge-closure-watch`; the PR watcher remains the only minute-scale heartbeat automation, `ACTIVE` alone is not treated as run proof, and any fallback helper must stay narrowed to the live PR and bounded to `PR Readiness`; backlog-family governance reform remains historical traceability only after PR #98 merged; release packaging for `v1.6.13-prebeta` remains pending historical release posture; and FB-049 remains the only selected-next user-facing candidate.
-Current Branch Class: implementation.
-Current Implementation Delta Class: developer-tooling.
-Historical Workstream State: FB-048 is Released / Closed in `v1.6.12-prebeta`; FB-047 is Released / Closed in `v1.6.11-prebeta`; FB-046 is Released / Closed in `v1.6.10-prebeta`; FB-044 and FB-045 remain Released / Closed historical proof in `v1.6.9-prebeta`.
+Current Branch Readiness State: None active. Historical automation-planning Branch Readiness closed complete and green on `feature/automation-planning`, and its governance frame, watcher-policy boundaries, repo-hygiene candidate rules, and activation gate remain preserved only as historical admission basis for the merged automation-catalog branch.
+Current Workstream State: None active. The merged `feature/automation-planning` branch is historical traceability only after PR #99 merged into `main` at `daf727e9875c0b1c4de9672e36d6dd9411411001` and the source branch was deleted. The bounded same-branch automation catalog remains preserved as merged historical branch proof through `WS1` `PR Heartbeat Watcher`, hourly `phase-drift-watch`, six-hour `selected-next-lock-audit`, six-hour `main-revalidation-gate-watch`, six-hour `toolchain-availability-watch`, six-hour `automation-drift-audit`, hourly `release-window-sentinel`, and hourly `post-merge-closure-watch`; Hardening H1, Live Validation LV1, and PR Readiness PR1 remain complete and green historical truth; the PR watcher remains the only minute-scale heartbeat automation in preserved branch truth; historical runtime-proof governance is preserved as `ACTIVE` alone is not treated as run proof, and any fallback helper must stay narrowed to the live PR and bounded to `PR Readiness`; the stale PR99 watcher lifecycle is retired; backlog-family governance reform remains historical traceability only after PR #98 merged; release packaging for `v1.6.13-prebeta` remains pending historical release posture; and FB-049 remains the only selected-next user-facing candidate.
+Current Branch Class: None.
+Current Implementation Delta Class: None.
+Historical Workstream State: Automation catalog implementation is merged historical branch proof after PR #99; FB-048 is Released / Closed in `v1.6.12-prebeta`; FB-047 is Released / Closed in `v1.6.11-prebeta`; FB-046 is Released / Closed in `v1.6.10-prebeta`; FB-044 and FB-045 remain Released / Closed historical proof in `v1.6.9-prebeta`.
 Historical Hardening State: Complete on `feature/fb-048-active-session-relaunch-signal-failure-and-wait-timeout-truth`.
 Historical Live Validation State: Complete on `feature/fb-048-active-session-relaunch-signal-failure-and-wait-timeout-truth`.
 Canonical Current-State Rule: merge-target current-state owners stay merge-stable during merged-unreleased release-debt windows; live PR state, conflict/readiness details, review-resolution details, and blocker-clearing repair-lane narration live only in explicit historical PR sections of the canonical workstream and in operator output.
@@ -92,11 +92,11 @@ Release Execution State: `v1.6.12-prebeta` is live at https://github.com/Giribal
 Release Target: v1.6.13-prebeta.
 Release Floor: patch prerelease.
 Version Rationale: the backlog family governance reform is a release-bearing docs-only implementation branch that changes backlog/workstream/branch-authority source-of-truth and validator behavior without widening runtime or user-facing product behavior, so the next release remains a patch prerelease.
-Release Scope: close FB-048 post-release canon, admit the docs-only feature-family governance reform branch, restructure backlog/workstream governance toward family-anchor traceability, and add validator guardrails that prevent continuation-pass backlog drift and merge-unstable current-state narration from recurring.
-Release Artifacts: Tag v1.6.13-prebeta; release title Pre-Beta v1.6.13; rich Markdown release notes summarize the governance reform branch authority, phased family-governance migration, and validator hardening without repeating the release title inside the notes body, and GitHub-generated `## What's Changed` plus `**Full Changelog**:` must be included.
-Post-Release Truth: the governance reform branch closes as historical branch-authority traceability after publication and validation; latest public prerelease advances to `v1.6.13-prebeta`; release debt clears; and FB-049 remains selected next, `Registry-only`, and branch-not-created until updated `main` is revalidated and FB-049 Branch Readiness admits the first bounded pre-settled incoming-launch conflict truth slice.
-Next-Branch Creation Gate: FB-049 branch creation remains blocked until the governance reform branch completes, merges, releases, updated `main` is revalidated, and FB-049 Branch Readiness admits the first bounded runtime/user-facing pre-settled incoming-launch conflict truth slice.
-Next Legal Phase: Release Readiness.
+Release Scope: preserve the merged backlog-family governance reform and merged automation-catalog branch truth as unreleased historical branch proof for `v1.6.13-prebeta`, keep selected-next and no-active-branch canon stable on merged `main`, and require any later release-packaging or successor admission to start from updated merged-main truth instead of reviving deleted branch state.
+Release Artifacts: Tag v1.6.13-prebeta; release title Pre-Beta v1.6.13; rich Markdown release notes summarize the merged governance reform, the merged automation catalog, and the validator/runtime-proof hardening without repeating the release title inside the notes body, and GitHub-generated `## What's Changed` plus `**Full Changelog**:` must be included.
+Post-Release Truth: the backlog-family governance reform and automation-catalog branches remain historical branch-authority traceability after publication and validation; latest public prerelease advances to `v1.6.13-prebeta`; release debt clears; and FB-049 remains selected next, `Registry-only`, and branch-not-created until updated `main` is revalidated and FB-049 Branch Readiness admits the first bounded pre-settled incoming-launch conflict truth slice.
+Next-Branch Creation Gate: FB-049 branch creation remains blocked until the merged `v1.6.13-prebeta` package is published, validated, updated `main` is revalidated, and FB-049 Branch Readiness admits the first bounded runtime/user-facing pre-settled incoming-launch conflict truth slice.
+Next Legal Phase: Branch Readiness.
 
 ## Backlog Governance Sync
 
@@ -118,7 +118,7 @@ Open-candidate priority review:
 - FB-048 is Released / Closed in `v1.6.12-prebeta`; release debt is clear after publication, validation, and post-release canon closure.
 - FB-049 is selected next, `Registry-only`, and branch-not-created.
 
-Current-branch clarity: latest public prerelease is `v1.6.12-prebeta`; FB-044 and FB-045 are released and closed in `v1.6.9-prebeta`; FB-046 is released and closed in `v1.6.10-prebeta`; FB-047 is released and closed in `v1.6.11-prebeta`; FB-048 is released and closed in `v1.6.12-prebeta`; merged `main` repo state is steady-state `No Active Branch`; the merged backlog-family governance reform branch is historical traceability only while release packaging for `v1.6.13-prebeta` remains pending; and FB-049 remains selected next, `Registry-only`, and branch-not-created until updated `main` is revalidated and later FB-049 Branch Readiness admission occurs.
+Current-branch clarity: latest public prerelease is `v1.6.12-prebeta`; FB-044 and FB-045 are released and closed in `v1.6.9-prebeta`; FB-046 is released and closed in `v1.6.10-prebeta`; FB-047 is released and closed in `v1.6.11-prebeta`; FB-048 is released and closed in `v1.6.12-prebeta`; merged `main` repo state is steady-state `No Active Branch`; the merged backlog-family governance reform branch plus the merged automation-catalog branch are historical traceability only while release packaging for `v1.6.13-prebeta` remains pending; the stale PR99 watcher lifecycle is retired; and FB-049 remains selected next, `Registry-only`, and branch-not-created until updated `main` is revalidated and later FB-049 Branch Readiness admission occurs.
 
 ## Registry Items
 

--- a/Docs/prebeta_roadmap.md
+++ b/Docs/prebeta_roadmap.md
@@ -67,18 +67,18 @@ Current merged truth indicates:
 - latest public prerelease title: `Pre-Beta v1.6.12`
 - merged unreleased non-doc implementation debt exists: no
 - the latest public released implementation milestones are FB-048 Active-session relaunch signal-failure and wait-timeout truth in `v1.6.12-prebeta`; FB-047 Active-session relaunch decline session-preservation proof in `v1.6.11-prebeta`; FB-046 Active-session relaunch reacquisition and settled re-entry proof remains released in `v1.6.10-prebeta`; FB-044 Boot-to-desktop handoff outcome refinement and FB-045 Active-session relaunch outcome refinement remain released in `v1.6.9-prebeta`; FB-043 Top-level desktop entrypoint ownership and `main.py` handoff refinement remains released in `v1.6.8-prebeta`; FB-042 Desktop startup runtime family anchor remains released in `v1.6.7-prebeta`; FB-005 Workspace and folder organization remains released in `v1.6.6-prebeta`; FB-030 ORIN voice/audio direction refinement remains released in `v1.6.5-prebeta`; FB-015 Boot and desktop phase-boundary model plus FB-029 ORIN legal-safe rebrand, future ARIA persona option, and repo licensing hardening remain released in `v1.6.4-prebeta`
-- current phase after `v1.6.12-prebeta` release closure: `PR Readiness`
-- phase status after `v1.6.12-prebeta` release closure: FB-048 is Released / Closed in `v1.6.12-prebeta`; release debt is clear after publication, validation, and post-release canon closure; the merged backlog-family governance reform package remains unreleased historical branch proof for `v1.6.13-prebeta`; the current branch is now `feature/automation-planning` in `PR Readiness`; Workstream `WS1` through `WS8`, Hardening H1, and Live Validation LV1 remain complete and green historical truth; `PR Readiness PR1 - Automation Catalog PR Validation` is in progress; and FB-049 remains selected next, `Registry-only`, and branch-not-created.
-- current active workstream: `Automation Implementation`; the admitted current branch is `feature/automation-planning` in `PR Readiness` while merged-main repo truth remains `No Active Branch`
-- current branch after `v1.6.12-prebeta` release closure: `feature/automation-planning`
-- next concern: continue `PR Readiness PR1 - Automation Catalog PR Validation` while preserving the carried post-merge canon repair, the merged backlog-family governance reform release posture for `v1.6.13-prebeta`, the converted roadmap family-anchor framing, the split workstream index, the aligned routing/loader surfaces, and the validated FB-049 selected-next lock.
+- current phase after `v1.6.12-prebeta` release closure: `No Active Branch`
+- phase status after `v1.6.12-prebeta` release closure: FB-048 is Released / Closed in `v1.6.12-prebeta`; release debt is clear after publication, validation, and post-release canon closure; the merged backlog-family governance reform package plus the merged automation-catalog package remain unreleased historical branch proof for `v1.6.13-prebeta`; repo current-state is steady-state `No Active Branch`; PR #99 is merged, the source branch is deleted, the stale PR99 watcher lifecycle is retired, and FB-049 remains selected next, `Registry-only`, and branch-not-created.
+- current active workstream: `None`; merged-main repo truth is `No Active Branch`
+- current branch after `v1.6.12-prebeta` release closure: `None`
+- next concern: keep merged-main release posture and selected-next truth stable, then admit any later release-packaging or successor branch through bounded Branch Readiness instead of reviving deleted automation-branch state by inertia.
 
 That means the released FB-027 interaction and shared-action family anchor, the released FB-036 authoring-and-callable-group milestone, the released FB-041 deterministic callable-group execution milestone, the released FB-037 built-in catalog milestone, the released FB-038 tray quick-task UX milestone, the released FB-039 external trigger intake architecture milestone, the released FB-040 monitoring/thermal architecture milestone, the released FB-031 UI/UX architecture milestone, the released FB-032 source-of-truth migration milestone, the released FB-004 future boot-orchestrator architecture milestone, the released FB-015 plus FB-029 planning milestones, the released FB-030 voice/audio planning milestone, and the released FB-005 bounded workspace-path slice are now part of the current public shared pre-Beta baseline.
 
 ## Current Branch Execution Posture
 
 Merged-Unreleased Release-Debt Owner: None.
-Repo State: Branch-owned implementation surface.
+Repo State: No Active Branch.
 Merged-Main Repo State: No Active Branch.
 
 Latest Public Prerelease: v1.6.12-prebeta
@@ -86,26 +86,26 @@ Latest Public Release Commit: b06c359e58b47cfe26fe8c4b39ac04fde519dee9
 Latest Public Prerelease Publication: https://github.com/GiribaldiTTV/Nexus-Desktop-AI/releases/tag/v1.6.12-prebeta
 Latest Public Prerelease Title: Pre-Beta v1.6.12
 Release Debt: Clear after `v1.6.12-prebeta` publication, validation, and post-release canon closure.
-Current active workstream: Automation Implementation
+Current active workstream: None
 Current Active Workstream Before Reform: None
-Current Active Branch: `feature/automation-planning`
-Active Branch Before Release: `feature/fb-048-active-session-relaunch-signal-failure-and-wait-timeout-truth`
-Current Active Branch Authority Record: `Docs/branch_records/feature_automation_planning.md`
+Current Active Branch: `None`
+Active Branch Before Release: `feature/automation-planning`
+Current Active Branch Authority Record: `None`
 Current Active Canonical Workstream Doc: `None`
-Historical Active Workstream Before Release: FB-048 Active-session relaunch signal-failure and wait-timeout truth
-Historical Active Branch Before Release: `feature/fb-048-active-session-relaunch-signal-failure-and-wait-timeout-truth`
-Earlier Historical Active Workstream Before Release: FB-047 Active-session relaunch decline session-preservation proof
-Earlier Historical Active Branch Before Release: `feature/fb-047-active-session-relaunch-decline-preservation`
+Historical Active Workstream Before Release: Automation Implementation
+Historical Active Branch Before Release: `feature/automation-planning`
+Earlier Historical Active Workstream Before Release: FB-048 Active-session relaunch signal-failure and wait-timeout truth
+Earlier Historical Active Branch Before Release: `feature/fb-048-active-session-relaunch-signal-failure-and-wait-timeout-truth`
 Selected Next Workstream: FB-049 Active-session pre-settled incoming-launch conflict truth.
 Selected Next Record State: Registry-only.
 Selected Next Implementation Branch: `Not created`
 Repair-Only Branch Handling: `feature/fb-046-post-merge-canon-sync` is a bounded repair-only post-merge canon-sync `feature/` branch and did not imply Branch Readiness admission or active branch truth for FB-046.
 Historical Branch Readiness State: Complete on `feature/fb-048-active-session-relaunch-signal-failure-and-wait-timeout-truth`.
-Current Branch Readiness State: Complete and green historical basis on `feature/automation-planning`. The branch's automation-planning governance frame, watcher-policy boundaries, repo-hygiene candidate rules, and activation gate remain preserved as the admission basis for the completed automation-catalog Workstream.
-Current Workstream State: Complete and green historical truth on `feature/automation-planning`, Hardening H1 `Automation Catalog Validation` remains complete and green historical truth, Live Validation LV1 `Automation Catalog Final Validation` remains complete and green historical truth, and PR Readiness PR1 `Automation Catalog PR Validation` is in progress. The bounded same-branch automation catalog remains implemented through `WS1` `PR Heartbeat Watcher`, hourly `phase-drift-watch`, six-hour `selected-next-lock-audit`, six-hour `main-revalidation-gate-watch`, six-hour `toolchain-availability-watch`, six-hour `automation-drift-audit`, hourly `release-window-sentinel`, and hourly `post-merge-closure-watch`; the PR watcher remains the only minute-scale heartbeat automation, `ACTIVE` alone is not treated as run proof, and any fallback helper must stay narrowed to the live PR and bounded to `PR Readiness`; backlog-family governance reform remains historical traceability only after PR #98 merged; release packaging for `v1.6.13-prebeta` remains pending historical release posture; and FB-049 remains the only selected-next user-facing candidate.
-Current Branch Class: `implementation`
-Current Implementation Delta Class: `developer-tooling`
-Historical Workstream State: FB-048 is Released / Closed in `v1.6.12-prebeta`; FB-047 is Released / Closed in `v1.6.11-prebeta`; FB-046 is Released / Closed in `v1.6.10-prebeta`; FB-044 and FB-045 remain Released / Closed historical proof in `v1.6.9-prebeta`.
+Current Branch Readiness State: None active. Historical automation-planning Branch Readiness closed complete and green on `feature/automation-planning`, and its planning governance remains preserved only as historical admission basis for the merged automation-catalog branch.
+Current Workstream State: None active. The merged `feature/automation-planning` branch is historical traceability only after PR #99 merged into `main` at `daf727e9875c0b1c4de9672e36d6dd9411411001` and the source branch was deleted. The admitted eight-record automation catalog remains preserved as merged historical branch proof; Hardening H1, Live Validation LV1, and PR Readiness PR1 remain complete and green historical truth; the PR watcher remains the only minute-scale heartbeat automation in preserved branch truth; historical runtime-proof governance is preserved as `ACTIVE` alone is not treated as run proof, and any fallback helper must stay narrowed to the live PR and bounded to `PR Readiness`; the stale PR99 watcher lifecycle is retired; backlog-family governance reform remains historical traceability only after PR #98 merged; release packaging for `v1.6.13-prebeta` remains pending historical release posture; and FB-049 remains the only selected-next user-facing candidate.
+Current Branch Class: `None`
+Current Implementation Delta Class: `None`
+Historical Workstream State: automation catalog implementation is merged historical branch proof after PR #99; FB-048 is Released / Closed in `v1.6.12-prebeta`; FB-047 is Released / Closed in `v1.6.11-prebeta`; FB-046 is Released / Closed in `v1.6.10-prebeta`; FB-044 and FB-045 remain Released / Closed historical proof in `v1.6.9-prebeta`.
 Historical Hardening State: Complete on `feature/fb-048-active-session-relaunch-signal-failure-and-wait-timeout-truth`.
 Historical Live Validation State: Complete on `feature/fb-048-active-session-relaunch-signal-failure-and-wait-timeout-truth`.
 Canonical Current-State Rule: merge-target current-state owners stay merge-stable during merged-unreleased release-debt windows; live PR state, conflict/readiness details, review-resolution details, and blocker-clearing repair-lane narration live only in explicit historical PR sections of the canonical workstream and in operator output.
@@ -113,11 +113,11 @@ Release Execution State: `v1.6.12-prebeta` is live at https://github.com/Giribal
 Release Target: v1.6.13-prebeta
 Release Floor: patch prerelease
 Version Rationale: the approved governance reform is a release-bearing docs-only implementation branch that changes source-of-truth structure and validator governance without widening runtime or user-facing behavior, so the next release remains a patch prerelease.
-Release Scope: close FB-048 post-release canon, admit the docs-only feature-family governance reform branch, execute the phased backlog/workstream governance migration, and add validator hardening that prevents continuation-pass backlog drift and merge-unstable current-state narration from recurring.
-Release Artifacts: Tag v1.6.13-prebeta; release title Pre-Beta v1.6.13; rich Markdown release notes summarize the backlog-family governance reform, branch-authority admission, phased migration, and validator hardening without repeating the release title inside the notes body, and GitHub-generated `## What's Changed` plus `**Full Changelog**:` must be included.
-Post-Release Truth: the governance reform branch closes as historical branch-authority traceability after publication and validation; latest public prerelease advances to `v1.6.13-prebeta`; release debt clears; and FB-049 remains selected next, `Registry-only`, and branch-not-created until updated `main` is revalidated and FB-049 Branch Readiness admits the first bounded pre-settled incoming-launch conflict truth slice.
-Next-Branch Creation Gate: FB-049 branch creation remains blocked until the governance reform branch completes, merges, releases, updated `main` is revalidated, and FB-049 Branch Readiness admits the first bounded runtime/user-facing pre-settled incoming-launch conflict truth slice.
-Next Legal Phase: Release Readiness.
+Release Scope: preserve the merged backlog-family governance reform and merged automation-catalog branch truth as unreleased historical branch proof for `v1.6.13-prebeta`, keep selected-next and no-active-branch canon stable on merged `main`, and require any later release-packaging or successor admission to start from updated merged-main truth instead of reviving deleted branch state.
+Release Artifacts: Tag v1.6.13-prebeta; release title Pre-Beta v1.6.13; rich Markdown release notes summarize the merged governance reform, the merged automation catalog, and the validator/runtime-proof hardening without repeating the release title inside the notes body, and GitHub-generated `## What's Changed` plus `**Full Changelog**:` must be included.
+Post-Release Truth: the governance reform and automation-catalog branches remain historical branch-authority traceability after publication and validation; latest public prerelease advances to `v1.6.13-prebeta`; release debt clears; and FB-049 remains selected next, `Registry-only`, and branch-not-created until updated `main` is revalidated and FB-049 Branch Readiness admits the first bounded pre-settled incoming-launch conflict truth slice.
+Next-Branch Creation Gate: FB-049 branch creation remains blocked until the merged `v1.6.13-prebeta` package is published, validated, updated `main` is revalidated, and FB-049 Branch Readiness admits the first bounded runtime/user-facing pre-settled incoming-launch conflict truth slice.
+Next Legal Phase: Branch Readiness.
 
 ## Merged-Unreleased Release-Debt Owner
 

--- a/Docs/prebeta_roadmap.md
+++ b/Docs/prebeta_roadmap.md
@@ -78,7 +78,7 @@ That means the released FB-027 interaction and shared-action family anchor, the 
 ## Current Branch Execution Posture
 
 Merged-Unreleased Release-Debt Owner: None.
-Repo State: No Active Branch.
+Repo State: Branch-owned repair surface.
 Merged-Main Repo State: No Active Branch.
 
 Latest Public Prerelease: v1.6.12-prebeta
@@ -86,11 +86,11 @@ Latest Public Release Commit: b06c359e58b47cfe26fe8c4b39ac04fde519dee9
 Latest Public Prerelease Publication: https://github.com/GiribaldiTTV/Nexus-Desktop-AI/releases/tag/v1.6.12-prebeta
 Latest Public Prerelease Title: Pre-Beta v1.6.12
 Release Debt: Clear after `v1.6.12-prebeta` publication, validation, and post-release canon closure.
-Current active workstream: None
+Current active workstream: Automation Planning Post-Merge Canon Repair
 Current Active Workstream Before Reform: None
-Current Active Branch: `None`
+Current Active Branch: `feature/automation-planning-post-merge-canon-repair`
 Active Branch Before Release: `feature/automation-planning`
-Current Active Branch Authority Record: `None`
+Current Active Branch Authority Record: `Docs/branch_records/feature_automation_planning_post_merge_canon_repair.md`
 Current Active Canonical Workstream Doc: `None`
 Historical Active Workstream Before Release: Automation Implementation
 Historical Active Branch Before Release: `feature/automation-planning`
@@ -101,9 +101,9 @@ Selected Next Record State: Registry-only.
 Selected Next Implementation Branch: `Not created`
 Repair-Only Branch Handling: `feature/fb-046-post-merge-canon-sync` is a bounded repair-only post-merge canon-sync `feature/` branch and did not imply Branch Readiness admission or active branch truth for FB-046.
 Historical Branch Readiness State: Complete on `feature/fb-048-active-session-relaunch-signal-failure-and-wait-timeout-truth`.
-Current Branch Readiness State: None active. Historical automation-planning Branch Readiness closed complete and green on `feature/automation-planning`, and its planning governance remains preserved only as historical admission basis for the merged automation-catalog branch.
-Current Workstream State: None active. The merged `feature/automation-planning` branch is historical traceability only after PR #99 merged into `main` at `daf727e9875c0b1c4de9672e36d6dd9411411001` and the source branch was deleted. The admitted eight-record automation catalog remains preserved as merged historical branch proof; Hardening H1, Live Validation LV1, and PR Readiness PR1 remain complete and green historical truth; the PR watcher remains the only minute-scale heartbeat automation in preserved branch truth; historical runtime-proof governance is preserved as `ACTIVE` alone is not treated as run proof, and any fallback helper must stay narrowed to the live PR and bounded to `PR Readiness`; the stale PR99 watcher lifecycle is retired; backlog-family governance reform remains historical traceability only after PR #98 merged; release packaging for `v1.6.13-prebeta` remains pending historical release posture; and FB-049 remains the only selected-next user-facing candidate.
-Current Branch Class: `None`
+Current Branch Readiness State: Bounded repair branch admitted directly from updated `main`; no new backlog-backed implementation workstream is opened by this repair.
+Current Workstream State: `PR Readiness PR1 - Post-Merge Canon Repair PR Validation` is in progress on `feature/automation-planning-post-merge-canon-repair`. This bounded emergency canon repair preserves merged-main `No Active Branch` truth, keeps `feature/automation-planning` historical-only after PR #99, preserves retired PR99 watcher cleanup proof, preserves pending `v1.6.13-prebeta` release posture, and preserves FB-049 as the only selected-next user-facing candidate. the PR watcher remains the only minute-scale heartbeat automation in preserved branch truth. Historical runtime-proof governance remains preserved as `ACTIVE` alone is not treated as run proof, and any fallback helper must stay narrowed to the live PR and bounded to `PR Readiness`.
+Current Branch Class: `emergency canon repair`
 Current Implementation Delta Class: `None`
 Historical Workstream State: automation catalog implementation is merged historical branch proof after PR #99; FB-048 is Released / Closed in `v1.6.12-prebeta`; FB-047 is Released / Closed in `v1.6.11-prebeta`; FB-046 is Released / Closed in `v1.6.10-prebeta`; FB-044 and FB-045 remain Released / Closed historical proof in `v1.6.9-prebeta`.
 Historical Hardening State: Complete on `feature/fb-048-active-session-relaunch-signal-failure-and-wait-timeout-truth`.
@@ -117,7 +117,7 @@ Release Scope: preserve the merged backlog-family governance reform and merged a
 Release Artifacts: Tag v1.6.13-prebeta; release title Pre-Beta v1.6.13; rich Markdown release notes summarize the merged governance reform, the merged automation catalog, and the validator/runtime-proof hardening without repeating the release title inside the notes body, and GitHub-generated `## What's Changed` plus `**Full Changelog**:` must be included.
 Post-Release Truth: the governance reform and automation-catalog branches remain historical branch-authority traceability after publication and validation; latest public prerelease advances to `v1.6.13-prebeta`; release debt clears; and FB-049 remains selected next, `Registry-only`, and branch-not-created until updated `main` is revalidated and FB-049 Branch Readiness admits the first bounded pre-settled incoming-launch conflict truth slice.
 Next-Branch Creation Gate: FB-049 branch creation remains blocked until the merged `v1.6.13-prebeta` package is published, validated, updated `main` is revalidated, and FB-049 Branch Readiness admits the first bounded runtime/user-facing pre-settled incoming-launch conflict truth slice.
-Next Legal Phase: Branch Readiness.
+Next Legal Phase: Release Readiness.
 
 ## Merged-Unreleased Release-Debt Owner
 


### PR DESCRIPTION
## Summary

PR #99 merged and deleted `feature/automation-planning`, but merged-main canon still carried stale active-branch narration. This repair branch makes the merged-main current-state truthful again without reopening implementation work or changing FB-049 successor selection.

## What Changed

### What changed
- admitted `feature/automation-planning-post-merge-canon-repair` as the bounded active emergency canon-repair branch
- added a dedicated branch-authority record for the repair branch
- synced backlog and roadmap current-state summaries to show the active repair branch while preserving merged-main `No Active Branch` truth
- preserved `feature_automation_planning.md` as historical-only traceability
- preserved retired PR99 watcher cleanup proof and pending `v1.6.13-prebeta` posture

### Why it changed
PR #99 merged and deleted `feature/automation-planning`, but merged-main canon still carried stale active-branch narration. This repair branch makes the merged-main current-state truthful again without reopening implementation work or changing FB-049 successor selection.

### Impact
- merged-main canon stays aligned with the deleted source branch and retired watcher lifecycle
- active repair ownership is explicit during the repair PR
- FB-049 remains the only selected-next user-facing candidate

### What changed
- admitted `feature/automation-planning-post-merge-canon-repair` as the bounded active emergency canon-repair branch
- added a dedicated branch-authority record for the repair branch
- synced backlog and roadmap current-state summaries to show the active repair branch while preserving merged-main `No Active Branch` truth
- preserved `feature_automation_planning.md` as historical-only traceability
- preserved retired PR99 watcher cleanup proof and pending `v1.6.13-prebeta` posture

### Why it changed
PR #99 merged and deleted `feature/automation-planning`, but merged-main canon still carried stale active-branch narration. This repair branch makes the merged-main current-state truthful again without reopening implementation work or changing FB-049 successor selection.

### Impact
- merged-main canon stays aligned with the deleted source branch and retired watcher lifecycle
- active repair ownership is explicit during the repair PR
- FB-049 remains the only selected-next user-facing candidate
