### PR TITLE
PR103 post-merge closeout canon repair

### DIFF
--- a/Docs/branch_records/feature_pr101_post_merge_closeout_canon_repair.md
+++ b/Docs/branch_records/feature_pr101_post_merge_closeout_canon_repair.md
@@ -15,7 +15,7 @@ It no longer owns live execution, PR readiness, watcher control, or release gati
 
 ## Current Phase
 
-- Phase: `PR Readiness`
+- Phase: `Historical Traceability`
 
 ## Phase Status
 

--- a/Docs/branch_records/feature_pr102_post_merge_closeout_canon_repair.md
+++ b/Docs/branch_records/feature_pr102_post_merge_closeout_canon_repair.md
@@ -5,22 +5,22 @@
 - Branch: `feature/pr102-post-merge-closeout-canon-repair`
 - Workstream: `PR102 Post-Merge Closeout Canon Repair`
 - Branch Class: `emergency canon repair`
+- Record State: `Historical-only traceability`
 
 ## Purpose / Why It Exists
 
-This bounded repair branch exists only to close the merged-main branch-authority drift left behind after PR #102 merged into `main`.
+This preserved record captures the bounded repair branch that cleared the stale merged-main active-branch authority left behind after PR #102 merged into `main`, then later merged itself through PR #103.
 
-It does not reopen implementation, widen into release execution, mutate FB-049 selected-next truth, or change the already-proven PR watcher reporting contract. Its job is only to clear the stale active-branch authority that still points at the now-merged PR102 repair surface, preserve PR #102 merge and watcher shutdown proof as historical traceability, and harden validator coverage so detached `origin/main` validation snapshots cannot false-green this drift class again.
+It no longer owns live execution, PR readiness, watcher control, or release gating. It remains only to preserve the PR #103 merge proof, same-thread watcher verification and shutdown proof, pending `v1.6.13-prebeta` release posture, and unchanged FB-049 selected-next truth.
 
 ## Current Phase
 
-- Phase: `PR Readiness`
+- Phase: `Historical Traceability`
 
 ## Phase Status
 
 - Repo State: `No Active Branch`
 - Merged-Main Repo State: `No Active Branch`
-- `Active Branch`: `feature/pr102-post-merge-closeout-canon-repair`
 - Current Active Canonical Workstream Doc: `None`
 - Latest Public Prerelease: `v1.6.12-prebeta`
 - Latest Public Release Commit: `b06c359e58b47cfe26fe8c4b39ac04fde519dee9`
@@ -29,26 +29,14 @@ It does not reopen implementation, widen into release execution, mutate FB-049 s
 - Selected Next Workstream: `FB-049 Active-session pre-settled incoming-launch conflict truth`
 - Selected Next Record State: `Registry-only`
 - Selected Next Implementation Branch: `Not created`
-- Historical source branch: `feature/pr101-post-merge-closeout-canon-repair` merged through PR #102 at `77a59fe6e05edcf62780709e9f2c87bdc2dc2a6a` and now requires historical-only traceability on merged-main surfaces.
-- Historical Branch Readiness Seam: `Branch Readiness BR1 - PR102 Post-Merge Closeout Canon Repair Admission`
-- BR1 result: complete and green historical truth. This seam admitted the repair surface, cleared stale active-branch authority for the merged PR102 repair branch, moved that earlier repair record to historical-only traceability, preserved merged-main `No Active Branch` truth, preserved PR #102 watcher merge-verification and shutdown proof, preserved pending `v1.6.13-prebeta` release posture, preserved FB-049 selected-next truth, and hardened detached merged-main validator coverage.
-- Historical PR Readiness Seam: `PR Readiness PR1 - PR102 Post-Merge Closeout Canon Repair PR Validation`
-- PR1 result: complete and green historical truth. PR #103 was created and validated as open, non-draft, and merge-status green; watcher provisioning and watcher-route verification were proven on the approved reporting surface; the live Codex review thread on PR #103 was fixed on commit `bdb8a632391b2c4b1f6a12f3d447977b0d883e0f`, replied to, resolved, and recorded as `Comment addressed` for the current head, so PR1 no longer waits for a later thumbs-up.
-- Current PR Readiness Seam: `PR Readiness PR2 - PR102 Post-Merge Closeout Canon Repair Merge Verification Watch`
-- Live PR: `https://github.com/GiribaldiTTV/Nexus-Desktop-AI/pull/103`
-- Live PR State: `open`
-- Live PR Head Commit At PR Creation: `a1d765e088ea086d4caaeef0a9727ae39ff0d8cb`
-- Live PR Merge Status: `green at PR-entry time`
-- PR watcher runtime: authoritative PR watcher `Codex PR102 Post-Merge Closeout Canon Repair Watch` uses `$CODEX_HOME/watchers/pr102-post-merge-closeout-canon-repair-watch-launcher.pyw` plus repo helper `dev/pr_same_thread_watcher.py` to emit only status-change updates into the approved Codex reporting-surface transcript through the official Codex thread-resume path while PR #103 remains open, and actionable bot comments now trigger a bounded same-branch `codex exec` repair worker from that watcher runtime
-- PR watcher action contract: thumbs-up reaction on PR #103 clears PR-entry validation green; one or more actionable bot comments on PR #103 trigger the bounded same-branch PR comment-repair worker, which must fix the issue, commit, push, reply, resolve the corresponding review thread, and then report `Comment addressed` for the current head before PR1 can clear
-- PR watcher reporting surface: `Dedicated watcher-host thread 'PR103 Watch Host thread'`
-- PR watcher reporting thread ID: `019de0c1-bb76-7d31-a3d0-f88aa471b7e6`
-- PR watcher reporting transcript: `C:\Users\anden\.codex\sessions\2026\04\30\rollout-2026-04-30T16-38-06-019de0c1-bb76-7d31-a3d0-f88aa471b7e6.jsonl`
-- PR watcher route verification: `PASS at 2026-04-30T23:40:10.403Z; watcher wrapper target, watcher state-file target, transcript target, and Codex thread-db target all agree`
-- PR watcher run proof: watcher transcript proof is preserved via `$CODEX_HOME/watchers/pr102-post-merge-closeout-canon-repair-watch-state.json`, `$CODEX_HOME/watchers/pr102-post-merge-closeout-canon-repair-watch-latest.txt`, and `$CODEX_HOME/watchers/pr102-post-merge-closeout-canon-repair-watch.log`
-- PR watcher proof timestamps: validated watcher-host status-change emission for PR #103 was recorded at `2026-04-30T23:40:10.403Z`
-- Bot approval proof: `Bot review comment on PR #103 was addressed, replied to, and resolved for head bdb8a632391b2c4b1f6a12f3d447977b0d883e0f at 2026-05-01T00:42:05Z; no later thumbs-up is required.`
-- Next Active Seam: `PR Readiness PR2 - PR102 Post-Merge Closeout Canon Repair Merge Verification Watch`
+- Historical source branch: `feature/pr101-post-merge-closeout-canon-repair` merged through PR #102 at `77a59fe6e05edcf62780709e9f2c87bdc2dc2a6a` and remains historical-only traceability.
+- Historical repair PR: PR #103 merged at `2026-05-01T01:08:14Z` via merge commit `a0e58e199b9533d9903cf78ba904aecd3b8f6502`.
+- Historical repair head commit: `7687e7761b5753291119f0e24e24ea9c52b7c98f`
+- Historical same-thread watcher runtime: `Codex PR102 Post-Merge Closeout Canon Repair Watch` used `$CODEX_HOME/watchers/pr102-post-merge-closeout-canon-repair-watch-launcher.pyw` plus repo helper `dev/pr_same_thread_watcher.py` to emit status-change updates into the approved Codex reporting-surface transcript through the Codex thread-resume path while PR #103 remained open.
+- Historical watcher proof files: `$CODEX_HOME/watchers/pr102-post-merge-closeout-canon-repair-watch-state.json`, `$CODEX_HOME/watchers/pr102-post-merge-closeout-canon-repair-watch-latest.txt`, and `$CODEX_HOME/watchers/pr102-post-merge-closeout-canon-repair-watch.log`
+- Historical watcher merge verification: watcher recorded merged verification at `2026-05-01T01:09:08.338902Z`, after GitHub merge truth was observable.
+- Historical watcher shutdown proof: the watcher logged self-stop after merged verification and scheduled task `Codex PR102 Post-Merge Closeout Canon Repair Watch` is absent.
+- Historical outcome: this record is historical-only traceability; merged-main active branch authority returned to `No Active Branch`.
 
 ## Branch Class
 
@@ -56,25 +44,20 @@ It does not reopen implementation, widen into release execution, mutate FB-049 s
 
 ## Blockers
 
-- `PR Merge Verification Pending`
+- `None`
 
 ## Entry Basis
 
-- updated `main` is aligned with `origin/main` at merged PR #102 truth
-- merged-main current-state owners already remain steady-state `No Active Branch`
-- `Docs/branch_records/index.md` still carries the merged PR102 repair record as active branch authority after the source branch disappeared
-- `Docs/branch_records/feature_pr101_post_merge_closeout_canon_repair.md` still presents active PR-readiness execution truth on merged-main surfaces instead of historical-only traceability
-- the validator previously keyed merged-main active-branch drift to branch name `main` only, so detached `origin/main` validation snapshots could miss this stale authority state
+- this branch was admitted because merged-main canon still treated the post-PR102 closeout repair surface as active after its source branch disappeared
+- PR #103 carried the bounded closeout repair needed to preserve truthful merged-main ownership and watcher proof
 
 ## Exit Criteria
 
 - merged-main current-state truth remains `No Active Branch`
-- `Docs/branch_records/index.md` removes stale PR102 closeout active authority and carries only this branch as the active repair record until merge
-- `Docs/branch_records/feature_pr101_post_merge_closeout_canon_repair.md` is historical-only traceability
-- PR #102 merge proof and watcher shutdown proof remain preserved
+- this record remains in `Historical Branch Authority Records` only
+- PR #103 merge proof and watcher shutdown proof remain preserved
 - pending `v1.6.13-prebeta` release posture remains preserved
 - FB-049 remains selected next, `Registry-only`, and branch-not-created
-- the validator fails on detached merged-main snapshots whenever `No Active Branch` truth coexists with stale active branch authority
 
 ## Rollback Target
 
@@ -86,128 +69,81 @@ It does not reopen implementation, widen into release execution, mutate FB-049 s
 
 ## Scope
 
-- branch-local admission for this bounded closeout-canon repair only
-- merged-main branch-authority cleanup only
-- PR #102 merge and watcher-proof preservation only
-- detached merged-main validator hardening only
+- preserved historical proof only
+- no live branch authority or release-gating ownership
 
 ## Explicit Non-Goals
 
 - no reopening of automation implementation
-- no release packaging execution
-- no runtime, backend, developer-tooling, or user-facing product changes
-- no FB-049 branch admission or selected-next mutation
-- no widening into another repair lane or successor branch by inertia
+- no live PR monitoring
+- no release execution ownership
+- no selected-next mutation
 
 ## Validation Contract
 
-- run `python dev\orin_branch_governance_validation.py`
-- run `git diff --check`
-- confirm merged-main current-state truth still resolves to `No Active Branch`
-- confirm `Docs/branch_records/index.md` carries this branch as the only active branch-authority record while merged-main current-state owners stay `No Active Branch`
-- confirm `Docs/branch_records/feature_pr101_post_merge_closeout_canon_repair.md` is historical-only traceability
-- confirm PR #102 merge-verification and watcher shutdown proof remain preserved
-- confirm the live PR watcher is pointed at the recorded reporting surface and that the wrapper target, state-file target, and transcript target agree before PR1 clears
-- confirm the live PR watcher action contract is explicit and bounded to the current PR: thumbs-up reaction means PR-entry green, while actionable bot comments must trigger same-branch fix/push/reply/resolve flow before PR1 clears
-- confirm detached `origin/main` validation snapshots now fail if stale active branch authority survives merge
+- confirm merged-main surfaces remain `No Active Branch`
+- confirm this record remains historical-only traceability
+- confirm PR #103 merge proof and watcher shutdown proof remain preserved
 
 ## Active Seam
 
-Active seam: `PR Readiness PR2 - PR102 Post-Merge Closeout Canon Repair Merge Verification Watch`
-Next active seam: `PR Readiness PR2 - PR102 Post-Merge Closeout Canon Repair Merge Verification Watch`
+Active seam: `None`
+Next active seam: `None`
 
-- This branch is the active bounded closeout-repair PR surface while PR Readiness PR2 keeps PR #103 on the approved watcher reporting surface until merge is watcher-verified.
+- This record is no longer a live branch authority surface.
 
 ## Seam Continuation Decision
 
-Seam Status: `Red`
-Slice Status: `Red`
-Completion Status: `In Progress`
+Seam Status: `Green`
+Slice Status: `Green`
+Completion Status: `Green`
 Waiver Status: `None`
 Continue Decision: `Stop`
-Stop Basis: `Named Blockers`
-Next Active Seam: `PR Readiness PR2 - PR102 Post-Merge Closeout Canon Repair Merge Verification Watch`
-Stop Condition: `Stop while PR #103 has not yet been watcher-verified as merged on the approved reporting surface.`
-Continuation Action: `Keep PR #103 on the validated watcher reporting surface, report only status changes, and clear PR2 only after merged-state verification is durable.`
-
-## Branch Objective
-
-Land a bounded post-merge closeout repair that restores truthful merged-main branch ownership, preserves PR #102 watcher merge-verification and shutdown proof as historical traceability, and makes detached merged-main validator surfaces catch this drift class before merge.
-
-## Target End-State
-
-Merged-main current-state owners stay merge-stable at `No Active Branch`, this branch remains the only active repair branch-authority record until merge, the prior PR102 repair record is historical-only traceability, PR #102 merge and watcher shutdown proof remain preserved, and detached merged-main validator coverage now blocks stale active branch authority.
-
-## Backlog Completion Strategy
-
-Branch Completion Goal: Land this bounded PR102 post-merge closeout canon repair PR and keep merged-main release posture stable without reopening implementation work.
-Known Future-Dependent Blockers: same-thread merge verification of PR #103 during PR2.
-Branch Closure Rule: Stop this seam while PR2 is blocked by `PR Merge Verification Pending`, and clear it only when the live repair PR is watcher-provisioned, watcher-routing is verified, and merged-state verification is durable.
-
-## Expected Seam Families And Risk Classes
-
-- Seam family: branch-authority closeout repair
-- Seam family: historical traceability preservation
-- Seam family: detached merged-main validator hardening
-- Risk class: docs/governance truth drift only; no runtime, release-execution, or selected-next mutation risk is admitted
-
-## User Test Summary Strategy
-
-No user-facing runtime or desktop behavior changes are admitted on this branch. Manual user-test handoff is not required unless a later PR review identifies a contradiction to the merge-stable canon, which is not expected for this bounded repair.
-
-## Later-Phase Expectations
-
-- `PR Readiness PR2` must keep the current live PR on the approved watcher reporting surface, at minute cadence, reporting only on status changes, until merge is watcher-verified
-- `Release Readiness` remains blocked until PR2 clears `PR Merge Verification Pending`
-- if merged-main branch-authority ownership or detached merged-main validator truth drifts again during later phases, this same branch must repair the canon and validator before green
-
-## Initial Workstream Seam Sequence
-
-Seam 1: `PR Readiness PR1 - PR102 Post-Merge Closeout Canon Repair PR Validation`
-Goal: Create and validate the live repair PR for this bounded closeout-canon repair branch.
-Scope: branch-authority PR admission, live PR creation, watcher provisioning proof, watcher-route verification, merge-status proof, and bot-review signal validation for this repair only.
-Result: complete and green historical truth after the PR #103 Codex review comment was fixed on the same branch, pushed, replied to, and resolved for head `bdb8a632391b2c4b1f6a12f3d447977b0d883e0f`.
-Non-Includes: merged verification green, release execution, successor branch admission, or FB-049 selected-next mutation.
-
-Seam 2: `PR Readiness PR2 - PR102 Post-Merge Closeout Canon Repair Merge Verification Watch`
-Goal: Keep the live repair PR under same-thread watcher control until merged-state verification is durable.
-Scope: same-thread watcher continuation, status-change reporting, merged-state verification, and watcher self-closeout only.
-Non-Includes: Release Readiness admission before merge verification, implementation reopening, or successor branch admission.
+Stop Basis: `Historical-only traceability`
+Next Active Seam: `None`
+Stop Condition: `Merged historical repair record.`
+Continuation Action: `None.`
 
 ## Governance Drift Audit
 
 - Governance Drift Found: `Yes`
-- Drift Type: merged-main active-branch authority persisted after PR #102 merge
-- Why Current Canon Failed To Prevent It: the prior repair branch carried the correct merge-stable backlog and roadmap truth, but its active branch-authority record was not retired on merged-main surfaces before the source branch disappeared, and detached `origin/main` validation snapshots were not treated as merged-main authority surfaces by the validator
-- Required Canon Changes: admit this bounded repair branch, move the prior PR102 repair record to historical-only traceability, keep merged-main current-state owners stable at `No Active Branch`, and make detached merged-main snapshots fail when stale active branch authority remains
-- Whether The Drift Blocks Merge: `Yes until watcher proof is present, watcher routing is verified, PR-entry validation is green, and PR2 later verifies merge`
-- Whether User Confirmation Is Required: `No for this bounded approved repair branch`
-- Missing validator requirement check: detached `origin/main` snapshots must be treated as merged-main validation surfaces for active-branch-authority drift checks
+- Drift Type: merged-main active-branch authority persisted after the PR102 closeout repair merged through PR #103
+- Why Current Canon Failed To Prevent It: the branch-authority layer was not fully retired on merged-main surfaces before the repair branch disappeared, and historical-only closeout phase truth was not yet enforced early enough by the validator
+- Required Canon Changes: preserve this record as historical-only traceability, keep merged-main current-state owners stable at `No Active Branch`, and make historical-only closeout records fail validation if they retain live phase truth
+- Whether The Drift Blocks Merge: `No; this record is already historical proof`
+- Whether User Confirmation Is Required: `No`
+- Missing validator requirement check: historical-only closeout records must be allowed and required to report `Phase: Historical Traceability`
 
 ## Post-Merge State
 
 - Post-merge repo state: `No Active Branch`
-- Post-merge repair truth: merged-main canon keeps `Active Branch Authority Records` empty, preserves `feature_pr101_post_merge_closeout_canon_repair.md` as historical-only traceability, preserves this repair record as historical-only traceability after merge, preserves PR #102 watcher merge-verification and shutdown proof, and preserves pending `v1.6.13-prebeta` release posture
+- Post-merge repair truth: merged-main canon keeps `Active Branch Authority Records` empty, preserves this record as historical-only traceability, preserves PR #103 watcher merge-verification and shutdown proof, and preserves pending `v1.6.13-prebeta` release posture
 - Post-merge selected-next truth: FB-049 remains selected next, `Registry-only`, and branch-not-created until updated `main` is revalidated and later Branch Readiness admits the first bounded FB-049 slice
-- Post-merge watcher governance truth: approved-reporting-surface watcher provisioning, routing verification, and merge-verification remain standard SOP for future PR-bearing branches, while PR #102 watcher proof stays historical-only traceability here
-- Post-merge branch-record handling: this record leaves `Active Branch Authority Records` and becomes historical-only traceability after merge
-- Post-merge successor handling: no successor branch opens by inertia from this repair; later branch admission remains separately gated
+- Post-merge watcher governance truth: future PR-bearing branches must keep approved watcher provisioning, routing verification, and merge verification as standard SOP, while PR #103 watcher proof remains historical-only traceability here
+- Post-merge branch-record handling: this record stays outside `Active Branch Authority Records`
+- Post-merge successor handling: no successor branch opens by inertia from this historical repair record
 
-## Release Window Audit
+## Historical PR Merge Proof
 
-Release Window Audit: PASS
-Remaining Known Release Blockers: None
-Another Pre-Release Repair PR Required: NO
-Release Window Split Waiver: None
+- Live PR at merge time: `https://github.com/GiribaldiTTV/Nexus-Desktop-AI/pull/103`
+- Merge Commit: `a0e58e199b9533d9903cf78ba904aecd3b8f6502`
+- Merged At: `2026-05-01T01:08:14Z`
+- Head Commit At Merge: `7687e7761b5753291119f0e24e24ea9c52b7c98f`
+- Same-thread watcher verified merged state at `2026-05-01T01:09:08.338902Z`
+- Watcher shutdown proof: watcher log recorded self-stop after merge and scheduled task deletion is proven by task absence
 
-## PR Bot Review Signal
+## Historical PR Bot Review Signal
 
-- Live PR: `https://github.com/GiribaldiTTV/Nexus-Desktop-AI/pull/103`
-- Head Branch: `feature/pr102-post-merge-closeout-canon-repair`
-- Base Branch: `main`
 - Bot Review Signal Status: `Comment addressed`
 - Bot Review Signal Head SHA: `bdb8a632391b2c4b1f6a12f3d447977b0d883e0f`
 - Bot Review Signal Source: `Resolved Codex review thread PRRT_kwDORwnWIs5-4tAC after same-branch fix/push/reply/resolve closeout on PR #103.`
 - Bot Review Signal Timestamp: `2026-05-01T00:42:05Z`
 - Bot Review Signal Actor: `chatgpt-codex-connector[bot] / GiribaldiTTV`
-- Live-PR rule: the live PR must have either a thumbs-up reaction or a bot comment from `chatgpt-codex-connector[bot]`; if the bot comments, the approved watcher action contract is to trigger the bounded same-branch PR comment-repair worker, fix it on this same branch, push, reply, resolve the comment, set `Bot Review Signal Status: Comment addressed` for the current head, and then PR green may return without waiting for a later thumbs-up.
+- Historical note: later same-thread watcher merge verification, not a later thumbs-up, cleared the final merge-watch blocker before this record became historical-only traceability.
+- Historical Branch Readiness Seam: `Branch Readiness BR1 - PR102 Post-Merge Closeout Canon Repair Admission`
+- BR1 result: complete and green historical truth. This seam admitted the bounded closeout-canon repair branch, cleared stale active-branch authority for the merged PR102 repair branch, moved the earlier PR101 repair record toward historical-only traceability, preserved merged-main `No Active Branch` truth, preserved same-thread watcher merge-verification and shutdown proof, preserved pending `v1.6.13-prebeta` release posture, and preserved FB-049 selected-next truth.
+- Historical PR Readiness Seam: `PR Readiness PR1 - PR102 Post-Merge Closeout Canon Repair PR Validation`
+- PR Readiness PR1 result: complete and green historical truth. This seam admitted PR Readiness for the bounded closeout repair branch, created PR #103, proved watcher provisioning and watcher-route verification on the approved reporting surface, addressed the bot review comment on the same branch, resolved that review thread, and cleared PR1.
+- Historical PR Readiness Seam: `PR Readiness PR2 - PR102 Post-Merge Closeout Canon Repair Merge Verification Watch`
+- PR Readiness PR2 result: complete and green historical truth. This seam kept PR #103 under approved watcher control until merged-state verification became durable, then cleared `PR Merge Verification Pending` when the watcher verified merge.
+- Next Active Seam: `None. Historical traceability record only.`

--- a/Docs/branch_records/feature_pr103_post_merge_closeout_canon_repair.md
+++ b/Docs/branch_records/feature_pr103_post_merge_closeout_canon_repair.md
@@ -43,9 +43,9 @@ It does not reopen implementation, widen into release execution, mutate FB-049 s
 - Live PR Head: `feature/pr103-post-merge-closeout-canon-repair`
 - Live PR Base: `main`
 - PR watcher reporting surface: `Current Codex working thread`
-- PR watcher reporting thread ID: `019de0c1-bb76-7d31-a3d0-f88aa471b7e6`
-- PR watcher reporting transcript: `C:\Users\anden\.codex\sessions\2026\04\30\rollout-2026-04-30T16-38-06-019de0c1-bb76-7d31-a3d0-f88aa471b7e6.jsonl`
-- PR watcher route verification: `PASS after watcher wrapper, watcher state, and Codex thread DB all point at the recorded reporting surface`
+- PR watcher reporting thread ID: `019dd083-0317-7b42-afb3-20b6818a1fa7`
+- PR watcher reporting transcript: `\\?\C:\Users\anden\.codex\sessions\2026\04\27\rollout-2026-04-27T12-55-40-019dd083-0317-7b42-afb3-20b6818a1fa7.jsonl`
+- PR watcher route verification: `PASS after watcher wrapper, watcher state, Codex thread DB, and active-branch transcript marker all point at the recorded reporting surface`
 - PR watcher runtime proof: `PASS via $CODEX_HOME/watchers/pr103-post-merge-closeout-canon-repair-watch-state.json and codex_resume transcript emission`
 - PR1 live validation result: `Green; PR #104 is open, non-draft, targets main, merge status is clean, bot approval is present, and watcher provisioning/routing is proven`
 

--- a/Docs/branch_records/feature_pr103_post_merge_closeout_canon_repair.md
+++ b/Docs/branch_records/feature_pr103_post_merge_closeout_canon_repair.md
@@ -36,8 +36,8 @@ It does not reopen implementation, widen into release execution, mutate FB-049 s
 - Historical watcher proof files: `$CODEX_HOME/watchers/pr102-post-merge-closeout-canon-repair-watch-state.json`, `$CODEX_HOME/watchers/pr102-post-merge-closeout-canon-repair-watch-latest.txt`, and `$CODEX_HOME/watchers/pr102-post-merge-closeout-canon-repair-watch.log`
 - Historical watcher merge verification: watcher recorded merged verification at `2026-05-01T01:09:08.338902Z`, after GitHub merge truth was observable.
 - Historical watcher shutdown proof: scheduled task `Codex PR102 Post-Merge Closeout Canon Repair Watch` is absent and the watcher log records self-stop after merged verification.
-- Current PR Readiness Seam: `PR Readiness PR1 - PR103 Post-Merge Closeout Canon Repair PR Validation`
-- Next Active Seam: `PR Readiness PR1 - PR103 Post-Merge Closeout Canon Repair PR Validation`
+- Current PR Readiness Seam: `PR Readiness PR2 - PR103 Post-Merge Closeout Canon Repair Merge Verification Watch`
+- Next Active Seam: `PR Readiness PR2 - PR103 Post-Merge Closeout Canon Repair Merge Verification Watch`
 - Live PR: `https://github.com/GiribaldiTTV/Nexus-Desktop-AI/pull/104`
 - Live PR State: `open`
 - Live PR Head: `feature/pr103-post-merge-closeout-canon-repair`
@@ -46,6 +46,8 @@ It does not reopen implementation, widen into release execution, mutate FB-049 s
 - PR watcher reporting thread ID: `019de0c1-bb76-7d31-a3d0-f88aa471b7e6`
 - PR watcher reporting transcript: `C:\Users\anden\.codex\sessions\2026\04\30\rollout-2026-04-30T16-38-06-019de0c1-bb76-7d31-a3d0-f88aa471b7e6.jsonl`
 - PR watcher route verification: `PASS after watcher wrapper, watcher state, and Codex thread DB all point at the recorded reporting surface`
+- PR watcher runtime proof: `PASS via $CODEX_HOME/watchers/pr103-post-merge-closeout-canon-repair-watch-state.json and codex_resume transcript emission`
+- PR1 live validation result: `Green; PR #104 is open, non-draft, targets main, merge status is clean, bot approval is present, and watcher provisioning/routing is proven`
 
 ## Branch Class
 
@@ -53,8 +55,7 @@ It does not reopen implementation, widen into release execution, mutate FB-049 s
 
 ## Blockers
 
-- `Bot Review Signal Pending`
-- `PR Merge Status Unproven`
+- `PR Merge Verification Pending`
 
 ## Entry Basis
 
@@ -81,7 +82,7 @@ It does not reopen implementation, widen into release execution, mutate FB-049 s
 
 ## Next Legal Phase
 
-- `PR Readiness`
+- `Release Readiness`
 
 ## Scope
 
@@ -139,10 +140,10 @@ Recommended fix after review: on the next suitable PR, create a bounded test com
 
 ## Active Seam
 
-Active seam: `PR Readiness PR1 - PR103 Post-Merge Closeout Canon Repair PR Validation`
-Next active seam: `PR Readiness PR1 - PR103 Post-Merge Closeout Canon Repair PR Validation`
+Active seam: `PR Readiness PR2 - PR103 Post-Merge Closeout Canon Repair Merge Verification Watch`
+Next active seam: `PR Readiness PR2 - PR103 Post-Merge Closeout Canon Repair Merge Verification Watch`
 
-- This branch is the active bounded closeout-repair PR surface while PR #104 validates the PR103 post-merge canon repair.
+- This branch is the active bounded closeout-repair PR surface while PR #104 remains under watcher merge verification.
 
 ## Seam Continuation Decision
 
@@ -152,9 +153,9 @@ Completion Status: `Red`
 Waiver Status: `None`
 Continue Decision: `Stop`
 Stop Basis: `PR Readiness blockers`
-Next Active Seam: `PR Readiness PR1 - PR103 Post-Merge Closeout Canon Repair PR Validation`
-Stop Condition: `PR #104 is live but PR readiness is not green until merge status and bot-review signal are proven.`
-Continuation Action: `Keep PR #104 under the approved watcher route and rerun the PR readiness gate after the live PR reports green merge status and a valid bot-review signal.`
+Next Active Seam: `PR Readiness PR2 - PR103 Post-Merge Closeout Canon Repair Merge Verification Watch`
+Stop Condition: `PR #104 is live and PR1 is green, but Release Readiness is not legal until the watcher verifies the PR is merged.`
+Continuation Action: `Keep PR #104 under the approved watcher route until it verifies merged state, then rerun the PR readiness gate and enter Release Readiness only after `PR Merge Verification Pending` clears.`
 
 ## Branch Objective
 
@@ -224,11 +225,11 @@ Non-Includes: release readiness, implementation reopening, or successor branch a
 
 ## PR Bot Review Signal
 
-- Bot Review Signal Status: `Pending`
-- Bot Review Signal Head SHA: `Pending live PR #104 bot-review signal`
-- Bot Review Signal Source: `Pending thumbs-up reaction or bot comment-resolution closeout on PR #104`
-- Bot Review Signal Timestamp: `Pending`
-- Bot Review Signal Actor: `chatgpt-codex-connector[bot] pending`
+- Bot Review Signal Status: `Approved`
+- Bot Review Signal Head SHA: `Live PR #104 current head verified by watcher state`
+- Bot Review Signal Source: `Watcher-observed chatgpt-codex-connector[bot] thumbs-up signal on PR #104`
+- Bot Review Signal Timestamp: `2026-05-01T16:30:54.007455Z`
+- Bot Review Signal Actor: `chatgpt-codex-connector[bot]`
 
 ## Historical PR Bot Review Signal
 

--- a/Docs/branch_records/feature_pr103_post_merge_closeout_canon_repair.md
+++ b/Docs/branch_records/feature_pr103_post_merge_closeout_canon_repair.md
@@ -1,0 +1,195 @@
+# Branch Authority Record: feature/pr103-post-merge-closeout-canon-repair
+
+## Branch Identity
+
+- Branch: `feature/pr103-post-merge-closeout-canon-repair`
+- Workstream: `PR103 Post-Merge Closeout Canon Repair`
+- Branch Class: `emergency canon repair`
+
+## Purpose / Why It Exists
+
+This bounded repair branch exists only to close the merged-main branch-record drift left behind after PR #103 merged into `main`.
+
+It does not reopen implementation, widen into release execution, mutate FB-049 selected-next truth, or change the already-proven PR watcher operating contract. Its job is only to clear the stale active-branch authority that still points at the now-merged PR102 repair surface, move the prior closeout records into fully historical phase truth, preserve PR #103 merge and watcher shutdown proof as traceability, and harden validator coverage so historical-only closeout records cannot retain live phase truth on future branches.
+
+## Current Phase
+
+- Phase: `Branch Readiness`
+
+## Phase Status
+
+- Repo State: `No Active Branch`
+- Merged-Main Repo State: `No Active Branch`
+- `Active Branch`: `feature/pr103-post-merge-closeout-canon-repair`
+- Current Active Canonical Workstream Doc: `None`
+- Latest Public Prerelease: `v1.6.12-prebeta`
+- Latest Public Release Commit: `b06c359e58b47cfe26fe8c4b39ac04fde519dee9`
+- Latest Public Prerelease Publication: `https://github.com/GiribaldiTTV/Nexus-Desktop-AI/releases/tag/v1.6.12-prebeta`
+- Latest Public Prerelease Title: `Pre-Beta v1.6.12`
+- Selected Next Workstream: `FB-049 Active-session pre-settled incoming-launch conflict truth`
+- Selected Next Record State: `Registry-only`
+- Selected Next Implementation Branch: `Not created`
+- Historical source branch: `feature/pr102-post-merge-closeout-canon-repair` merged through PR #103 at `a0e58e199b9533d9903cf78ba904aecd3b8f6502` and now requires historical-only traceability on merged-main surfaces.
+- Historical repair PR: PR #103 merged at `2026-05-01T01:08:14Z` via merge commit `a0e58e199b9533d9903cf78ba904aecd3b8f6502`.
+- Historical repair head commit: `7687e7761b5753291119f0e24e24ea9c52b7c98f`
+- Historical same-thread watcher runtime: `Codex PR102 Post-Merge Closeout Canon Repair Watch` used `$CODEX_HOME/watchers/pr102-post-merge-closeout-canon-repair-watch-launcher.pyw` plus repo helper `dev/pr_same_thread_watcher.py` to emit status-change updates into the approved Codex reporting-surface transcript through the Codex thread-resume path while PR #103 remained open.
+- Historical watcher proof files: `$CODEX_HOME/watchers/pr102-post-merge-closeout-canon-repair-watch-state.json`, `$CODEX_HOME/watchers/pr102-post-merge-closeout-canon-repair-watch-latest.txt`, and `$CODEX_HOME/watchers/pr102-post-merge-closeout-canon-repair-watch.log`
+- Historical watcher merge verification: watcher recorded merged verification at `2026-05-01T01:09:08.338902Z`, after GitHub merge truth was observable.
+- Historical watcher shutdown proof: scheduled task `Codex PR102 Post-Merge Closeout Canon Repair Watch` is absent and the watcher log records self-stop after merged verification.
+- Current Branch Readiness Seam: `Branch Readiness BR1 - PR103 Post-Merge Closeout Canon Repair Admission`
+- Next Active Seam: `Branch Readiness BR1 - PR103 Post-Merge Closeout Canon Repair Admission`
+
+## Branch Class
+
+- `emergency canon repair`
+
+## Blockers
+
+- `None`
+
+## Entry Basis
+
+- PR #103 is merged and watcher merge verification is complete
+- merged-main current-state owners already remain steady-state `No Active Branch`
+- `Docs/branch_records/index.md` still carries the merged PR102 repair record as active branch authority after its source branch disappeared
+- `Docs/branch_records/feature_pr101_post_merge_closeout_canon_repair.md` is historical in prose but still reports a live phase name instead of explicit historical phase truth
+- the validator previously enforced historical phase truth for this drift class only on merged-main snapshots, not on the branch surfaces that should have caught it before merge
+
+## Exit Criteria
+
+- merged-main current-state truth remains `No Active Branch`
+- `Docs/branch_records/index.md` removes stale PR102 closeout active authority and carries only this branch as the active repair record until merge
+- `Docs/branch_records/feature_pr102_post_merge_closeout_canon_repair.md` is historical-only traceability
+- `Docs/branch_records/feature_pr101_post_merge_closeout_canon_repair.md` reports `Phase: Historical Traceability`
+- PR #103 merge proof and watcher shutdown proof remain preserved
+- pending `v1.6.13-prebeta` release posture remains preserved
+- FB-049 remains selected next, `Registry-only`, and branch-not-created
+- the validator fails on future branch surfaces if historical-only closeout records keep live phase truth
+
+## Rollback Target
+
+- `Branch Readiness`
+
+## Next Legal Phase
+
+- `PR Readiness`
+
+## Scope
+
+- branch-local admission for this bounded closeout-canon repair only
+- merged-main branch-record cleanup only
+- PR #103 merge and watcher-proof preservation only
+- historical-phase validator hardening for closeout records only
+
+## Explicit Non-Goals
+
+- no reopening of automation implementation
+- no release packaging execution
+- no runtime, backend, developer-tooling, or user-facing product changes
+- no FB-049 branch admission or selected-next mutation
+- no widening into another repair lane or successor branch by inertia
+
+## Validation Contract
+
+- run `python dev\orin_branch_governance_validation.py`
+- run `git diff --check`
+- confirm merged-main current-state truth still resolves to `No Active Branch`
+- confirm `Docs/branch_records/index.md` carries only this branch as active authority while this repair branch is open
+- confirm `Docs/branch_records/feature_pr102_post_merge_closeout_canon_repair.md` is historical-only traceability
+- confirm `Docs/branch_records/feature_pr101_post_merge_closeout_canon_repair.md` reports `Phase: Historical Traceability`
+- confirm PR #103 merge-verification and watcher shutdown proof remain preserved
+- confirm the validator now rejects historical-only closeout records that retain live phase truth
+
+## Active Seam
+
+Active seam: `Branch Readiness BR1 - PR103 Post-Merge Closeout Canon Repair Admission`
+Next active seam: `Branch Readiness BR1 - PR103 Post-Merge Closeout Canon Repair Admission`
+
+- This branch is the active bounded closeout-repair surface while branch-record canon is repaired after PR #103 merge.
+
+## Seam Continuation Decision
+
+Seam Status: `Green`
+Slice Status: `Green`
+Completion Status: `Green`
+Waiver Status: `None`
+Continue Decision: `Stop`
+Stop Basis: `BR1 green`
+Next Active Seam: `None`
+Stop Condition: `Bounded PR103 post-merge closeout canon repair admission is complete.`
+Continuation Action: `Advance to PR Readiness PR1 for this bounded repair branch if a live PR is needed.`
+
+## Branch Objective
+
+Land a bounded post-merge closeout repair that restores truthful merged-main branch-record ownership, preserves PR #103 watcher merge-verification and shutdown proof as historical traceability, and makes historical-only closeout records fail validation if they keep live phase truth.
+
+## Target End-State
+
+Merged-main current-state owners stay merge-stable at `No Active Branch`, this branch remains the only active repair branch-authority record until merge, the prior PR102 and PR101 closeout records are historical-only traceability, PR #103 merge and watcher shutdown proof remain preserved, and the validator catches future historical-phase drift before merge.
+
+## Backlog Completion Strategy
+
+Branch Completion Goal: Land this bounded PR103 post-merge closeout canon repair PR and keep merged-main release posture stable without reopening implementation work.
+Known Future-Dependent Blockers: none on this admission seam.
+Branch Closure Rule: Stop this seam once branch-record canon, historical-phase truth, and validator hardening are aligned.
+
+## Expected Seam Families And Risk Classes
+
+- Seam family: branch-record closeout repair
+- Seam family: historical traceability preservation
+- Seam family: validator hardening for historical phase truth
+- Risk class: docs/governance truth drift only; no runtime, release-execution, or selected-next mutation risk is admitted
+
+## User Test Summary Strategy
+
+No user-facing runtime or desktop behavior changes are admitted on this branch. Manual user-test handoff is not required unless a later PR review identifies a contradiction to merge-stable canon, which is not expected for this bounded repair.
+
+## Later-Phase Expectations
+
+- `PR Readiness PR1` must create and validate the live repair PR for this branch
+- future PR-bearing branches must keep watcher provisioning, watcher routing, and merge verification as standard SOP
+- `Release Readiness` remains illegal on merged main until this bounded repair branch merges and merged-main canon revalidates cleanly
+
+## Initial Workstream Seam Sequence
+
+Seam 1: `PR Readiness PR1 - PR103 Post-Merge Closeout Canon Repair PR Validation`
+Goal: Create and validate the live repair PR for this bounded closeout-canon repair branch.
+Scope: branch-authority PR admission, live PR creation, and PR-surface validation for this repair only.
+Non-Includes: release readiness, implementation reopening, or successor branch admission.
+
+## Governance Drift Audit
+
+- Governance Drift Found: `Yes`
+- Drift Type: merged-main active-branch authority persisted after PR #103 merge and historical-only closeout phase truth was not enforced early enough on the branch surface
+- Why Current Canon Failed To Prevent It: the prior repair branch merged with its active branch record still live in the index, and the validator only required explicit historical phase truth for this drift class on merged-main snapshots instead of all relevant branch surfaces
+- Required Canon Changes: admit this bounded repair branch, move the prior PR102 repair record to historical-only traceability, update the PR101 repair record to `Phase: Historical Traceability`, keep merged-main current-state owners stable at `No Active Branch`, and make the validator reject historical-only closeout records that retain live phase truth
+- Whether The Drift Blocks Merge: `Yes until this repair branch lands and merged-main canon revalidates`
+- Whether User Confirmation Is Required: `No for this bounded approved repair branch`
+- Missing validator requirement check: historical-only closeout records must be allowed and required to report `Phase: Historical Traceability` on branch surfaces before merge, not only on merged-main snapshots
+
+## Post-Merge State
+
+- Post-merge repo state: `No Active Branch`
+- Post-merge repair truth: merged-main canon keeps `Active Branch Authority Records` empty, preserves `feature_pr102_post_merge_closeout_canon_repair.md` and `feature_pr101_post_merge_closeout_canon_repair.md` as historical-only traceability, preserves this repair record as historical-only traceability after merge, preserves PR #103 watcher merge-verification and shutdown proof, and preserves pending `v1.6.13-prebeta` release posture
+- Post-merge selected-next truth: FB-049 remains selected next, `Registry-only`, and branch-not-created until updated `main` is revalidated and later Branch Readiness admits the first bounded FB-049 slice
+- Post-merge watcher governance truth: approved-reporting-surface watcher provisioning, routing verification, and merge verification remain standard SOP for future PR-bearing branches, while PR #103 watcher proof stays historical-only traceability here
+- Post-merge branch-record handling: this record leaves `Active Branch Authority Records` and becomes historical-only traceability after merge
+- Post-merge successor handling: no successor branch opens by inertia from this repair; later branch admission remains separately gated
+
+## Historical PR Merge Proof
+
+- Live PR at merge time: `https://github.com/GiribaldiTTV/Nexus-Desktop-AI/pull/103`
+- Merge Commit: `a0e58e199b9533d9903cf78ba904aecd3b8f6502`
+- Merged At: `2026-05-01T01:08:14Z`
+- Head Commit At Merge: `7687e7761b5753291119f0e24e24ea9c52b7c98f`
+- Same-thread watcher verified merged state at `2026-05-01T01:09:08.338902Z`
+- Watcher shutdown proof: watcher log recorded self-stop after merge and scheduled task deletion is proven by task absence
+
+## Historical PR Bot Review Signal
+
+- Bot Review Signal Status: `Comment addressed`
+- Bot Review Signal Head SHA: `bdb8a632391b2c4b1f6a12f3d447977b0d883e0f`
+- Bot Review Signal Source: `Resolved Codex review thread PRRT_kwDORwnWIs5-4tAC after same-branch fix/push/reply/resolve closeout on PR #103.`
+- Bot Review Signal Timestamp: `2026-05-01T00:42:05Z`
+- Bot Review Signal Actor: `chatgpt-codex-connector[bot] / GiribaldiTTV`
+- Historical note: later same-thread watcher merge verification, not a later thumbs-up, cleared the final merge-watch blocker before this record became historical-only traceability.

--- a/Docs/branch_records/feature_pr103_post_merge_closeout_canon_repair.md
+++ b/Docs/branch_records/feature_pr103_post_merge_closeout_canon_repair.md
@@ -14,7 +14,7 @@ It does not reopen implementation, widen into release execution, mutate FB-049 s
 
 ## Current Phase
 
-- Phase: `Branch Readiness`
+- Phase: `PR Readiness`
 
 ## Phase Status
 
@@ -36,8 +36,16 @@ It does not reopen implementation, widen into release execution, mutate FB-049 s
 - Historical watcher proof files: `$CODEX_HOME/watchers/pr102-post-merge-closeout-canon-repair-watch-state.json`, `$CODEX_HOME/watchers/pr102-post-merge-closeout-canon-repair-watch-latest.txt`, and `$CODEX_HOME/watchers/pr102-post-merge-closeout-canon-repair-watch.log`
 - Historical watcher merge verification: watcher recorded merged verification at `2026-05-01T01:09:08.338902Z`, after GitHub merge truth was observable.
 - Historical watcher shutdown proof: scheduled task `Codex PR102 Post-Merge Closeout Canon Repair Watch` is absent and the watcher log records self-stop after merged verification.
-- Current Branch Readiness Seam: `Branch Readiness BR1 - PR103 Post-Merge Closeout Canon Repair Admission`
-- Next Active Seam: `Branch Readiness BR1 - PR103 Post-Merge Closeout Canon Repair Admission`
+- Current PR Readiness Seam: `PR Readiness PR1 - PR103 Post-Merge Closeout Canon Repair PR Validation`
+- Next Active Seam: `PR Readiness PR1 - PR103 Post-Merge Closeout Canon Repair PR Validation`
+- Live PR: `https://github.com/GiribaldiTTV/Nexus-Desktop-AI/pull/104`
+- Live PR State: `open`
+- Live PR Head: `feature/pr103-post-merge-closeout-canon-repair`
+- Live PR Base: `main`
+- PR watcher reporting surface: `Current Codex working thread`
+- PR watcher reporting thread ID: `019de0c1-bb76-7d31-a3d0-f88aa471b7e6`
+- PR watcher reporting transcript: `C:\Users\anden\.codex\sessions\2026\04\30\rollout-2026-04-30T16-38-06-019de0c1-bb76-7d31-a3d0-f88aa471b7e6.jsonl`
+- PR watcher route verification: `PASS after watcher wrapper, watcher state, and Codex thread DB all point at the recorded reporting surface`
 
 ## Branch Class
 
@@ -45,7 +53,8 @@ It does not reopen implementation, widen into release execution, mutate FB-049 s
 
 ## Blockers
 
-- `None`
+- `Bot Review Signal Pending`
+- `PR Merge Status Unproven`
 
 ## Entry Basis
 
@@ -99,16 +108,26 @@ It does not reopen implementation, widen into release execution, mutate FB-049 s
 - confirm `Docs/branch_records/feature_pr101_post_merge_closeout_canon_repair.md` reports `Phase: Historical Traceability`
 - confirm PR #103 merge-verification and watcher shutdown proof remain preserved
 - confirm the validator now rejects historical-only closeout records that retain live phase truth
+- confirm PR #104 is live, open, non-draft, targets `main`, and is watched through the recorded reporting surface
+
+## Release Window Audit
+
+- Release Window Audit: PASS
+- Remaining Known Release Blockers: None
+- Another Pre-Release Repair PR Required: NO
+- Release Window Split Waiver: None
 
 ## Source-Of-Truth Audit Findings Pending Review
 
 Finding 1: `Watcher host helper remains active after merge`.
 Evidence: the PR #103 runner task self-deleted and `Codex PR102 Post-Merge Closeout Canon Repair Watch` is absent, but the dedicated host automation `local-pr103-watch-host` remains `ACTIVE` and still has scheduler state after PR #103 merged.
 Recommended fix after review: update `dev/pr_same_thread_watcher.py` and governance validation so a dedicated watcher-host helper is paused or deleted when the PR watcher stops for `merged`, `closed`, or phase exit; then remove the PR #103 host helper operationally.
+Bounded PR1 repair applied: `dev/pr_same_thread_watcher.py` now retires the visible watcher-host automation when the watched PR becomes `merged` or `closed`.
 
 Finding 2: `Watcher terminal message overclaims release legality`.
 Evidence: the final PR #103 watcher message said `Release Readiness is now legal` immediately after merge verification, but merged-main canon validation still found branch-record drift that blocked Release Readiness.
 Recommended fix after review: change `dev/pr_same_thread_watcher.py` so merge verification only clears `PR Merge Verification Pending` and reports that Release Readiness requires a separate source-of-truth validation pass.
+Bounded PR1 repair applied: `dev/pr_same_thread_watcher.py` now reports merge verification separately from Release Readiness legality.
 
 Finding 3: `Cron automation audit surface is ambiguous during worktree repair`.
 Evidence: the standing cron monitor TOML and SQLite state point at `C:\Nexus Desktop AI`, while this active repair branch is executing from `C:\Nexus Desktop AI\.codex-release-validate`; the root checkout is useful for merged-main truth, but it is not the active repair-branch checkout.
@@ -120,22 +139,22 @@ Recommended fix after review: on the next suitable PR, create a bounded test com
 
 ## Active Seam
 
-Active seam: `Branch Readiness BR1 - PR103 Post-Merge Closeout Canon Repair Admission`
-Next active seam: `Branch Readiness BR1 - PR103 Post-Merge Closeout Canon Repair Admission`
+Active seam: `PR Readiness PR1 - PR103 Post-Merge Closeout Canon Repair PR Validation`
+Next active seam: `PR Readiness PR1 - PR103 Post-Merge Closeout Canon Repair PR Validation`
 
-- This branch is the active bounded closeout-repair surface while branch-record canon is repaired after PR #103 merge.
+- This branch is the active bounded closeout-repair PR surface while PR #104 validates the PR103 post-merge canon repair.
 
 ## Seam Continuation Decision
 
-Seam Status: `Green`
-Slice Status: `Green`
-Completion Status: `Green`
+Seam Status: `Red`
+Slice Status: `Red`
+Completion Status: `Red`
 Waiver Status: `None`
 Continue Decision: `Stop`
-Stop Basis: `BR1 green`
-Next Active Seam: `None`
-Stop Condition: `Bounded PR103 post-merge closeout canon repair admission is complete.`
-Continuation Action: `Advance to PR Readiness PR1 for this bounded repair branch if a live PR is needed.`
+Stop Basis: `PR Readiness blockers`
+Next Active Seam: `PR Readiness PR1 - PR103 Post-Merge Closeout Canon Repair PR Validation`
+Stop Condition: `PR #104 is live but PR readiness is not green until merge status and bot-review signal are proven.`
+Continuation Action: `Keep PR #104 under the approved watcher route and rerun the PR readiness gate after the live PR reports green merge status and a valid bot-review signal.`
 
 ## Branch Objective
 
@@ -202,6 +221,14 @@ Non-Includes: release readiness, implementation reopening, or successor branch a
 - Head Commit At Merge: `7687e7761b5753291119f0e24e24ea9c52b7c98f`
 - Same-thread watcher verified merged state at `2026-05-01T01:09:08.338902Z`
 - Watcher shutdown proof: watcher log recorded self-stop after merge and scheduled task deletion is proven by task absence
+
+## PR Bot Review Signal
+
+- Bot Review Signal Status: `Pending`
+- Bot Review Signal Head SHA: `Pending live PR #104 bot-review signal`
+- Bot Review Signal Source: `Pending thumbs-up reaction or bot comment-resolution closeout on PR #104`
+- Bot Review Signal Timestamp: `Pending`
+- Bot Review Signal Actor: `chatgpt-codex-connector[bot] pending`
 
 ## Historical PR Bot Review Signal
 

--- a/Docs/branch_records/feature_pr103_post_merge_closeout_canon_repair.md
+++ b/Docs/branch_records/feature_pr103_post_merge_closeout_canon_repair.md
@@ -100,6 +100,24 @@ It does not reopen implementation, widen into release execution, mutate FB-049 s
 - confirm PR #103 merge-verification and watcher shutdown proof remain preserved
 - confirm the validator now rejects historical-only closeout records that retain live phase truth
 
+## Source-Of-Truth Audit Findings Pending Review
+
+Finding 1: `Watcher host helper remains active after merge`.
+Evidence: the PR #103 runner task self-deleted and `Codex PR102 Post-Merge Closeout Canon Repair Watch` is absent, but the dedicated host automation `local-pr103-watch-host` remains `ACTIVE` and still has scheduler state after PR #103 merged.
+Recommended fix after review: update `dev/pr_same_thread_watcher.py` and governance validation so a dedicated watcher-host helper is paused or deleted when the PR watcher stops for `merged`, `closed`, or phase exit; then remove the PR #103 host helper operationally.
+
+Finding 2: `Watcher terminal message overclaims release legality`.
+Evidence: the final PR #103 watcher message said `Release Readiness is now legal` immediately after merge verification, but merged-main canon validation still found branch-record drift that blocked Release Readiness.
+Recommended fix after review: change `dev/pr_same_thread_watcher.py` so merge verification only clears `PR Merge Verification Pending` and reports that Release Readiness requires a separate source-of-truth validation pass.
+
+Finding 3: `Cron automation audit surface is ambiguous during worktree repair`.
+Evidence: the standing cron monitor TOML and SQLite state point at `C:\Nexus Desktop AI`, while this active repair branch is executing from `C:\Nexus Desktop AI\.codex-release-validate`; the root checkout is useful for merged-main truth, but it is not the active repair-branch checkout.
+Recommended fix after review: record whether standing repo-hygiene cron monitors are merged-main-only or active-branch-aware, and require retargeting or explicit CWD proof when a repair branch runs from a separate worktree.
+
+Finding 4: `PR comment self-heal worker is wired but not end-to-end proven`.
+Evidence: `dev/pr_same_thread_watcher.py` can trigger a bounded comment-repair worker, but PR #103's actionable Codex review comment was resolved before that worker path existed, so no fresh bot-comment cycle has proven automatic fix, commit, push, reply, and resolve behavior.
+Recommended fix after review: on the next suitable PR, create a bounded test comment cycle with `@codex review` and require watcher-generated repair proof before marking the self-heal path fully proven.
+
 ## Active Seam
 
 Active seam: `Branch Readiness BR1 - PR103 Post-Merge Closeout Canon Repair Admission`

--- a/Docs/branch_records/index.md
+++ b/Docs/branch_records/index.md
@@ -35,6 +35,7 @@ Do not use this layer to replace:
 - `PR Watcher Provisioning Unproven` is the standard blocker when a branch expects watcher-based PR monitoring but its watcher target, approved reporting surface, runtime path, run-proof method, fallback, teardown, or replacement provisioning for the next live PR is not yet explicit and proven
 - `PR Watcher Routing Unverified` is the standard blocker when a branch expects watcher-based PR monitoring but the configured watcher target has not yet been cross-checked against the recorded reporting surface and proven to land there
 - historical branch authority records are preserved traceability records, not live execution authority
+- historical-only closeout traceability records must report `Phase: Historical Traceability` and must not retain live PR state, active seam ownership, or open-PR narration
 - each active branch authority record must carry the modern phase-state block:
   - `## Current Phase`
   - `## Phase Status`
@@ -51,10 +52,11 @@ Do not use this layer to replace:
 
 ## Active Branch Authority Records
 
-- `Docs/branch_records/feature_pr102_post_merge_closeout_canon_repair.md`
+- `Docs/branch_records/feature_pr103_post_merge_closeout_canon_repair.md`
 
 ## Historical Branch Authority Records
 
+- `Docs/branch_records/feature_pr102_post_merge_closeout_canon_repair.md`
 - `Docs/branch_records/feature_pr101_post_merge_closeout_canon_repair.md`
 - `Docs/branch_records/feature_automation_planning_post_merge_closeout_repair.md`
 - `Docs/branch_records/feature_automation_planning_post_merge_canon_repair.md`

--- a/dev/orin_branch_governance_validation.py
+++ b/dev/orin_branch_governance_validation.py
@@ -7967,11 +7967,29 @@ def _watcher_route_alignment_status(
             ),
         )
 
+    expected_rollout_path = Path(expected_rollout_path_raw)
+    if not expected_rollout_path.is_file():
+        return False, f"recorded watcher transcript '{expected_rollout_path}' is missing"
+    try:
+        transcript_tail = expected_rollout_path.read_text(encoding="utf-8")[-2_000_000:]
+    except OSError as exc:
+        return False, f"recorded watcher transcript '{expected_rollout_path}' could not be read: {exc}"
+    branch_name = _extract_marker_value(_section(branch_record_text, "Branch Identity"), "Branch")
+    if branch_name and branch_name not in transcript_tail:
+        return (
+            False,
+            (
+                "recorded watcher transcript does not prove it is the active working thread; "
+                f"branch '{branch_name}' is absent from '{expected_rollout_path}'"
+            ),
+        )
+
     return (
         True,
         (
             f"watcher reporting surface '{reporting_surface}' is explicitly recorded and the "
-            f"wrapper/state/thread-db route agrees on thread '{expected_thread_id}'"
+            f"wrapper/state/thread-db route agrees on thread '{expected_thread_id}', and the "
+            "transcript contains the active branch marker"
         ),
     )
 

--- a/dev/orin_branch_governance_validation.py
+++ b/dev/orin_branch_governance_validation.py
@@ -25,6 +25,7 @@ PHASES = (
     "PR Readiness",
     "Release Readiness",
 )
+HISTORICAL_TRACEABILITY_PHASE = "Historical Traceability"
 
 BRANCH_CLASSES = (
     "implementation",
@@ -1163,6 +1164,10 @@ PR101_CLOSEOUT_CANON_REPAIR_BRANCH_RECORD = Path(
 PR102_CLOSEOUT_CANON_REPAIR_BRANCH = "feature/pr102-post-merge-closeout-canon-repair"
 PR102_CLOSEOUT_CANON_REPAIR_BRANCH_RECORD = Path(
     "Docs/branch_records/feature_pr102_post_merge_closeout_canon_repair.md"
+)
+PR103_CLOSEOUT_CANON_REPAIR_BRANCH = "feature/pr103-post-merge-closeout-canon-repair"
+PR103_CLOSEOUT_CANON_REPAIR_BRANCH_RECORD = Path(
+    "Docs/branch_records/feature_pr103_post_merge_closeout_canon_repair.md"
 )
 AUTOMATION_CLOSEOUT_PR101_WATCHER_SCRIPT_PATH = (
     Path.home() / ".codex" / "watchers" / "pr101-watch.ps1"
@@ -10026,8 +10031,12 @@ def main() -> int:
 
         info = _parse_workstream_doc(record_text)
         normalized_record_status = _normalize_status(str(info["status"]))
+        current_phase = str(info["current_phase"])
+        allowed_branch_record_phases = set(PHASES)
+        if branch_record_path in historical_branch_record_paths:
+            allowed_branch_record_phases.add(HISTORICAL_TRACEABILITY_PHASE)
         require(
-            str(info["current_phase"]) in PHASES,
+            current_phase in allowed_branch_record_phases,
             f"{branch_record_path}: Current Phase '{info['current_phase']}' is not in the canonical phase enum",
         )
         require(
@@ -10066,7 +10075,6 @@ def main() -> int:
             f"{branch_record_path}: Next Legal Phase '{info['next_legal_phase']}' is not in the canonical phase enum",
         )
         if branch_record_path in active_branch_record_paths:
-            current_phase = str(info["current_phase"])
             _validate_planning_loop_guardrail(
                 require,
                 branch_record_path,
@@ -10204,6 +10212,25 @@ def main() -> int:
             require(
                 "historical" in phase_status_section.lower(),
                 f"{branch_record_path}: historical branch record should make its historical merged posture explicit",
+            )
+        if branch_record_path in {
+            str(PR101_CLOSEOUT_CANON_REPAIR_BRANCH_RECORD),
+            str(PR102_CLOSEOUT_CANON_REPAIR_BRANCH_RECORD),
+        } and branch_record_path in historical_branch_record_paths:
+            require(
+                current_phase == HISTORICAL_TRACEABILITY_PHASE,
+                (
+                    f"{branch_record_path}: historical post-merge closeout record must report "
+                    f"`Phase: {HISTORICAL_TRACEABILITY_PHASE}`"
+                ),
+            )
+            require(
+                "Current PR Readiness Seam:" not in phase_status_section
+                and "Live PR State: `open`" not in phase_status_section,
+                (
+                    f"{branch_record_path}: historical post-merge closeout record must not retain "
+                    "active PR-readiness or open-PR narration"
+                ),
             )
 
     if errors:

--- a/dev/orin_branch_governance_validation.py
+++ b/dev/orin_branch_governance_validation.py
@@ -1202,6 +1202,19 @@ PR102_CLOSEOUT_CANON_WATCHER_LATEST_PATH = (
     Path.home() / ".codex" / "watchers" / "pr102-post-merge-closeout-canon-repair-watch-latest.txt"
 )
 PR102_CLOSEOUT_CANON_WATCHER_TASK_NAME = "Codex PR102 Post-Merge Closeout Canon Repair Watch"
+PR103_CLOSEOUT_CANON_WATCHER_SCRIPT_PATH = (
+    Path.home()
+    / ".codex"
+    / "watchers"
+    / "pr103-post-merge-closeout-canon-repair-watch-launcher.pyw"
+)
+PR103_CLOSEOUT_CANON_WATCHER_STATE_PATH = (
+    Path.home() / ".codex" / "watchers" / "pr103-post-merge-closeout-canon-repair-watch-state.json"
+)
+PR103_CLOSEOUT_CANON_WATCHER_LATEST_PATH = (
+    Path.home() / ".codex" / "watchers" / "pr103-post-merge-closeout-canon-repair-watch-latest.txt"
+)
+PR103_CLOSEOUT_CANON_WATCHER_TASK_NAME = "Codex PR103 Post-Merge Closeout Canon Repair Watch"
 CODEX_THREAD_STATE_DB_PATH = Path.home() / ".codex" / "state_5.sqlite"
 REFORM_R3_S2_SEAM = (
     "Phase 3 - Family Anchor Migration / Slice R3-S2 - Map FB-043 through FB-048 under "
@@ -1425,6 +1438,13 @@ PR102_CLOSEOUT_CANON_PR_READINESS_PR2_SEAM = (
     "PR Readiness PR2 - PR102 Post-Merge Closeout Canon Repair Merge Verification Watch"
 )
 PR102_CLOSEOUT_CANON_THREAD_WATCHER_NAME = "PR102 Post-Merge Closeout Canon Repair Same-Thread Watch"
+PR103_CLOSEOUT_CANON_PR_READINESS_PR1_SEAM = (
+    "PR Readiness PR1 - PR103 Post-Merge Closeout Canon Repair PR Validation"
+)
+PR103_CLOSEOUT_CANON_PR_READINESS_PR2_SEAM = (
+    "PR Readiness PR2 - PR103 Post-Merge Closeout Canon Repair Merge Verification Watch"
+)
+PR103_CLOSEOUT_CANON_THREAD_WATCHER_NAME = "PR103 Post-Merge Closeout Canon Repair Same-Thread Watch"
 CODEX_AUTOMATION_DB_PATH = Path.home() / ".codex" / "sqlite" / "codex-dev.db"
 AUTOMATION_PR99_NATIVE_HEARTBEAT_PATH = (
     Path.home() / ".codex" / "automations" / "pr99-heartbeat-watch" / "automation.toml"
@@ -3193,6 +3213,14 @@ def _is_pr102_closeout_canon_repair_branch(branch_name: str) -> bool:
     return normalized in {
         PR102_CLOSEOUT_CANON_REPAIR_BRANCH,
         f"origin/{PR102_CLOSEOUT_CANON_REPAIR_BRANCH}",
+    }
+
+
+def _is_pr103_closeout_canon_repair_branch(branch_name: str) -> bool:
+    normalized = (branch_name or "").strip()
+    return normalized in {
+        PR103_CLOSEOUT_CANON_REPAIR_BRANCH,
+        f"origin/{PR103_CLOSEOUT_CANON_REPAIR_BRANCH}",
     }
 
 
@@ -5892,6 +5920,157 @@ def _validate_pr102_closeout_canon_repair_phase_truth(
         )
 
 
+def _validate_pr103_closeout_canon_repair_phase_truth(
+    require,
+    *,
+    current_branch: str,
+) -> None:
+    if not _is_pr103_closeout_canon_repair_branch(current_branch):
+        return
+
+    branch_record_text = _read_text(PR103_CLOSEOUT_CANON_REPAIR_BRANCH_RECORD)
+    current_phase = _extract_marker_value(_section(branch_record_text, "Current Phase"), "Phase")
+    next_legal_phase = _extract_first_backtick_value(_section(branch_record_text, "Next Legal Phase"))
+    phase_status_section = _section(branch_record_text, "Phase Status")
+    active_seam_section = _section(branch_record_text, "Active Seam")
+    continuation_section = _section(branch_record_text, "Seam Continuation Decision")
+    release_window_section = _section(branch_record_text, "Release Window Audit")
+    phase_status_pr_readiness_seam = _extract_marker_value(
+        phase_status_section, "Current PR Readiness Seam"
+    )
+    phase_status_next_seam = _extract_marker_value(phase_status_section, "Next Active Seam")
+    active_seam_current = _extract_marker_value(active_seam_section, "Active seam")
+    active_seam_match = re.search(r"^Next active seam:\s*`([^`]+)`", active_seam_section, flags=re.M)
+    active_seam_next = active_seam_match.group(1).strip() if active_seam_match else ""
+    continuation_next_seam = _extract_marker_value(continuation_section, "Next Active Seam")
+    blockers_section = _section(branch_record_text, "Blockers")
+
+    if current_phase != "PR Readiness":
+        return
+
+    for marker_name in (
+        "PR watcher reporting surface",
+        "PR watcher reporting thread ID",
+        "PR watcher reporting transcript",
+        "PR watcher route verification",
+    ):
+        require(
+            bool(_extract_marker_value(phase_status_section, marker_name)),
+            (
+                "Docs/branch_records/feature_pr103_post_merge_closeout_canon_repair.md: "
+                f"Phase Status must record `{marker_name}` while PR watcher governance is active"
+            ),
+        )
+
+    if phase_status_pr_readiness_seam == PR103_CLOSEOUT_CANON_PR_READINESS_PR1_SEAM:
+        require(
+            next_legal_phase == "PR Readiness",
+            (
+                "Docs/branch_records/feature_pr103_post_merge_closeout_canon_repair.md: "
+                "Next Legal Phase must remain `PR Readiness` while PR Readiness PR1 is active "
+                "and PR2 merge-verification has not yet been admitted"
+            ),
+        )
+        require(
+            phase_status_next_seam == PR103_CLOSEOUT_CANON_PR_READINESS_PR1_SEAM,
+            (
+                "Docs/branch_records/feature_pr103_post_merge_closeout_canon_repair.md: "
+                "Phase Status `Next Active Seam` must point to PR Readiness PR1 during PR1 "
+                "admission and live PR creation"
+            ),
+        )
+        require(
+            active_seam_current == PR103_CLOSEOUT_CANON_PR_READINESS_PR1_SEAM,
+            (
+                "Docs/branch_records/feature_pr103_post_merge_closeout_canon_repair.md: "
+                "Active Seam must name PR Readiness PR1 as the current active seam"
+            ),
+        )
+        require(
+            active_seam_next == PR103_CLOSEOUT_CANON_PR_READINESS_PR1_SEAM,
+            (
+                "Docs/branch_records/feature_pr103_post_merge_closeout_canon_repair.md: "
+                "Active Seam `Next active seam` must point to PR Readiness PR1 while PR1 is active"
+            ),
+        )
+        require(
+            continuation_next_seam == PR103_CLOSEOUT_CANON_PR_READINESS_PR1_SEAM,
+            (
+                "Docs/branch_records/feature_pr103_post_merge_closeout_canon_repair.md: "
+                "Seam Continuation Decision must point to PR Readiness PR1 while PR1 blockers "
+                "are active"
+            ),
+        )
+        require(
+            "Release Window Audit: PASS" in release_window_section,
+            (
+                "Docs/branch_records/feature_pr103_post_merge_closeout_canon_repair.md: "
+                "PR Readiness truth must include `Release Window Audit: PASS`"
+            ),
+        )
+    elif phase_status_pr_readiness_seam == PR103_CLOSEOUT_CANON_PR_READINESS_PR2_SEAM:
+        require(
+            next_legal_phase == "Release Readiness",
+            (
+                "Docs/branch_records/feature_pr103_post_merge_closeout_canon_repair.md: "
+                "Next Legal Phase must advance to `Release Readiness` once PR Readiness PR2 is active"
+            ),
+        )
+        require(
+            phase_status_next_seam == PR103_CLOSEOUT_CANON_PR_READINESS_PR2_SEAM,
+            (
+                "Docs/branch_records/feature_pr103_post_merge_closeout_canon_repair.md: "
+                "Phase Status `Next Active Seam` must point to PR Readiness PR2 during merge watch"
+            ),
+        )
+        require(
+            active_seam_current == PR103_CLOSEOUT_CANON_PR_READINESS_PR2_SEAM,
+            (
+                "Docs/branch_records/feature_pr103_post_merge_closeout_canon_repair.md: "
+                "Active Seam must name PR Readiness PR2 as the current active seam"
+            ),
+        )
+        require(
+            active_seam_next == PR103_CLOSEOUT_CANON_PR_READINESS_PR2_SEAM,
+            (
+                "Docs/branch_records/feature_pr103_post_merge_closeout_canon_repair.md: "
+                "Active Seam `Next active seam` must point to PR Readiness PR2"
+            ),
+        )
+        require(
+            continuation_next_seam == PR103_CLOSEOUT_CANON_PR_READINESS_PR2_SEAM,
+            (
+                "Docs/branch_records/feature_pr103_post_merge_closeout_canon_repair.md: "
+                "Seam Continuation Decision must point to PR Readiness PR2 while merge "
+                "verification is pending"
+            ),
+        )
+        require(
+            "Release Window Audit: PASS" in release_window_section,
+            (
+                "Docs/branch_records/feature_pr103_post_merge_closeout_canon_repair.md: "
+                "PR Readiness truth must include `Release Window Audit: PASS`"
+            ),
+        )
+        require(
+            "PR Merge Verification Pending" in blockers_section,
+            (
+                "Docs/branch_records/feature_pr103_post_merge_closeout_canon_repair.md: "
+                "PR Readiness PR2 must carry `PR Merge Verification Pending` until merge is verified"
+            ),
+        )
+    else:
+        require(
+            False,
+            (
+                "Docs/branch_records/feature_pr103_post_merge_closeout_canon_repair.md: "
+                "Current PR Readiness Seam must be exactly "
+                f"`{PR103_CLOSEOUT_CANON_PR_READINESS_PR1_SEAM}` or "
+                f"`{PR103_CLOSEOUT_CANON_PR_READINESS_PR2_SEAM}` while Phase is `PR Readiness`"
+            ),
+        )
+
+
 def _validate_backlog_family_dossier_shell(
     require,
     *,
@@ -7506,6 +7685,115 @@ def _pr102_closeout_canon_repair_watcher_proof_status(
     )
 
 
+def _pr103_closeout_canon_repair_watcher_proof_status(
+    current_head_sha: str,
+) -> tuple[bool, str]:
+    if not PR103_CLOSEOUT_CANON_WATCHER_SCRIPT_PATH.is_file():
+        return (
+            False,
+            f"bounded same-thread watcher '{PR103_CLOSEOUT_CANON_WATCHER_SCRIPT_PATH}' is missing",
+        )
+    if not PR103_CLOSEOUT_CANON_WATCHER_LATEST_PATH.is_file():
+        return (
+            False,
+            f"watcher latest-status file '{PR103_CLOSEOUT_CANON_WATCHER_LATEST_PATH}' is missing",
+        )
+
+    state = _load_json_file(PR103_CLOSEOUT_CANON_WATCHER_STATE_PATH)
+    if not state:
+        return (
+            False,
+            f"watcher state file '{PR103_CLOSEOUT_CANON_WATCHER_STATE_PATH}' is missing or invalid",
+        )
+
+    recorded_head_sha = str(state.get("localHeadSha") or state.get("headSha") or "")
+    if current_head_sha and recorded_head_sha and recorded_head_sha != current_head_sha:
+        return (
+            False,
+            (
+                "watcher runtime proof is stale; state-file head "
+                f"'{recorded_head_sha}' does not match current head '{current_head_sha}'"
+            ),
+        )
+
+    if not str(state.get("lastRunLocal") or "").strip():
+        return (
+            False,
+            f"watcher state file '{PR103_CLOSEOUT_CANON_WATCHER_STATE_PATH}' is missing lastRunLocal proof",
+        )
+
+    thread_id = str(state.get("threadId") or "").strip()
+    thread_rollout_path_raw = str(state.get("threadRolloutPath") or "").strip()
+    last_thread_emit_at = str(state.get("lastThreadEmitAt") or "").strip()
+    last_thread_emit_message = str(state.get("lastThreadEmitMessage") or "").strip()
+    last_thread_emit_method = str(state.get("lastThreadEmitMethod") or "").strip()
+    if not thread_id:
+        return (
+            False,
+            f"watcher state file '{PR103_CLOSEOUT_CANON_WATCHER_STATE_PATH}' is missing threadId proof",
+        )
+    if not thread_rollout_path_raw:
+        return (
+            False,
+            f"watcher state file '{PR103_CLOSEOUT_CANON_WATCHER_STATE_PATH}' is missing threadRolloutPath proof",
+        )
+    if not last_thread_emit_at or not last_thread_emit_message:
+        return (
+            False,
+            (
+                f"watcher state file '{PR103_CLOSEOUT_CANON_WATCHER_STATE_PATH}' is missing "
+                "same-thread transcript emission proof"
+            ),
+        )
+    if last_thread_emit_method != "codex_resume":
+        return (
+            False,
+            (
+                f"watcher state file '{PR103_CLOSEOUT_CANON_WATCHER_STATE_PATH}' must record "
+                "`lastThreadEmitMethod` as `codex_resume`; manual rollout-file injection does not count "
+                f"as same-thread proof (found '{last_thread_emit_method or 'missing'}')"
+            ),
+        )
+
+    thread_rollout_path = Path(thread_rollout_path_raw)
+    if not thread_rollout_path.is_file():
+        return (
+            False,
+            f"same-thread rollout transcript '{thread_rollout_path}' is missing",
+        )
+    try:
+        transcript_tail = thread_rollout_path.read_text(encoding="utf-8")[-2_000_000:]
+    except OSError as exc:
+        return False, f"same-thread rollout transcript '{thread_rollout_path}' could not be read: {exc}"
+    if last_thread_emit_message not in transcript_tail:
+        return (
+            False,
+            (
+                "same-thread transcript proof is stale; the last emitted watcher message from "
+                f"'{PR103_CLOSEOUT_CANON_WATCHER_STATE_PATH}' is not present in "
+                f"'{thread_rollout_path}'"
+            ),
+        )
+
+    heartbeat_proven, heartbeat_message = _automation_last_run_proof(
+        PR103_CLOSEOUT_CANON_THREAD_WATCHER_NAME
+    )
+    proof_fragments = [
+        (
+            "same-thread transcript proof is present via "
+            f"'{thread_rollout_path}' and '{PR103_CLOSEOUT_CANON_WATCHER_STATE_PATH}' "
+            f"on thread '{thread_id}'"
+        )
+    ]
+    if heartbeat_proven:
+        proof_fragments.append(heartbeat_message)
+
+    return (
+        True,
+        "; ".join(proof_fragments),
+    )
+
+
 def _automation_last_run_proof(automation_name: str) -> tuple[bool, str]:
     if not CODEX_AUTOMATION_DB_PATH.is_file():
         return False, f"automation state database '{CODEX_AUTOMATION_DB_PATH}' is missing"
@@ -7922,6 +8210,67 @@ def _pr102_closeout_canon_repair_fallback_pr_view_for_branch(
     }, ""
 
 
+def _pr103_closeout_canon_repair_fallback_pr_view_for_branch(
+    branch_name: str,
+    active_branch_record_text: str,
+) -> tuple[dict[str, object] | None, str]:
+    if not _is_pr103_closeout_canon_repair_branch(branch_name):
+        return None, ""
+    if not active_branch_record_text:
+        return None, "active branch record text is unavailable"
+
+    repository_full_name, repository_error = _git_origin_repository_full_name()
+    if repository_error:
+        return None, repository_error
+
+    phase_status_section = _section(active_branch_record_text, "Phase Status")
+    pr_url_match = re.search(r"^- Live PR:\s*`([^`]+)`", phase_status_section, flags=re.M)
+    pr_url = pr_url_match.group(1).strip() if pr_url_match else ""
+    if not pr_url:
+        return None, "active branch record is missing `Live PR`"
+    pr_number_match = re.search(r"/pull/(\d+)", pr_url)
+    if not pr_number_match:
+        return None, f"active branch record has an invalid Live PR URL '{pr_url}'"
+    pr_number = int(pr_number_match.group(1))
+    watcher_state = _load_json_file(PR103_CLOSEOUT_CANON_WATCHER_STATE_PATH) or {}
+    bot_approval = bool(watcher_state.get("botApproval")) or _phase_status_bot_approval_proven(
+        phase_status_section
+    )
+    bot_comment_count = int(watcher_state.get("botCommentCount") or 0)
+    merged = bool(watcher_state.get("merged"))
+    state_value = str(watcher_state.get("prState") or "OPEN").upper()
+    if merged and state_value != "CLOSED":
+        state_value = "CLOSED"
+    mergeable_value = watcher_state.get("mergeable")
+    if mergeable_value is True:
+        mergeable = "MERGEABLE"
+        merge_state = "CLEAN"
+    elif mergeable_value is False:
+        mergeable = "CONFLICTING"
+        merge_state = "DIRTY"
+    else:
+        mergeable = "UNKNOWN"
+        merge_state = "UNKNOWN"
+
+    return {
+        "id": "",
+        "number": pr_number,
+        "state": state_value,
+        "mergeable": mergeable,
+        "mergeStateStatus": merge_state,
+        "reviewDecision": "APPROVED" if bot_approval else "",
+        "isDraft": False,
+        "headRefName": branch_name,
+        "baseRefName": "main",
+        "title": "PR103 Post-Merge Closeout Canon Repair",
+        "url": pr_url,
+        "repositoryFullName": repository_full_name,
+        "fallbackLocalState": True,
+        "botApproval": bot_approval,
+        "botCommentCount": bot_comment_count,
+    }, ""
+
+
 def _run_pr_live_state_gate(
     require,
     *,
@@ -7949,6 +8298,11 @@ def _run_pr_live_state_gate(
         )
     if not pr_info and _is_pr102_closeout_canon_repair_branch(branch_name):
         pr_info, pr_error = _pr102_closeout_canon_repair_fallback_pr_view_for_branch(
+            branch_name,
+            active_branch_record_text,
+        )
+    if not pr_info and _is_pr103_closeout_canon_repair_branch(branch_name):
+        pr_info, pr_error = _pr103_closeout_canon_repair_fallback_pr_view_for_branch(
             branch_name,
             active_branch_record_text,
         )
@@ -8059,6 +8413,30 @@ def _run_pr_live_state_gate(
             ),
         )
         closeout_watcher_state = _load_json_file(PR102_CLOSEOUT_CANON_WATCHER_STATE_PATH)
+    elif _is_pr103_closeout_canon_repair_branch(branch_name):
+        watcher_proven, watcher_proof_message = _pr103_closeout_canon_repair_watcher_proof_status(
+            current_head_sha
+        )
+        require(
+            watcher_proven,
+            (
+                "PR readiness gate: PR Watcher Provisioning Unproven blocker is active; "
+                f"{watcher_proof_message}"
+            ),
+        )
+        watcher_route_proven, watcher_route_message = _watcher_route_alignment_status(
+            branch_record_text=active_branch_record_text,
+            watcher_script_path=PR103_CLOSEOUT_CANON_WATCHER_SCRIPT_PATH,
+            watcher_state_path=PR103_CLOSEOUT_CANON_WATCHER_STATE_PATH,
+        )
+        require(
+            watcher_route_proven,
+            (
+                "PR readiness gate: PR Watcher Routing Unverified blocker is active; "
+                f"{watcher_route_message}"
+            ),
+        )
+        closeout_watcher_state = _load_json_file(PR103_CLOSEOUT_CANON_WATCHER_STATE_PATH)
     else:
         closeout_watcher_state = None
     if (
@@ -8170,6 +8548,7 @@ def _run_pr_live_state_gate(
                 AUTOMATION_CLOSEOUT_PR_READINESS_PR2_SEAM,
                 PR101_CLOSEOUT_CANON_PR_READINESS_PR2_SEAM,
                 PR102_CLOSEOUT_CANON_PR_READINESS_PR2_SEAM,
+                PR103_CLOSEOUT_CANON_PR_READINESS_PR2_SEAM,
             }
             and not bool(closeout_watcher_state.get("merged"))
         ):
@@ -8210,6 +8589,7 @@ def _run_pr_live_state_gate(
                 AUTOMATION_CLOSEOUT_PR_READINESS_PR2_SEAM,
                 PR101_CLOSEOUT_CANON_PR_READINESS_PR2_SEAM,
                 PR102_CLOSEOUT_CANON_PR_READINESS_PR2_SEAM,
+                PR103_CLOSEOUT_CANON_PR_READINESS_PR2_SEAM,
             }
             and not bool(closeout_watcher_state.get("merged"))
         ):
@@ -8255,6 +8635,7 @@ def _run_pr_live_state_gate(
                 AUTOMATION_CLOSEOUT_PR_READINESS_PR2_SEAM,
                 PR101_CLOSEOUT_CANON_PR_READINESS_PR2_SEAM,
                 PR102_CLOSEOUT_CANON_PR_READINESS_PR2_SEAM,
+                PR103_CLOSEOUT_CANON_PR_READINESS_PR2_SEAM,
             }
             and not bool(closeout_watcher_state.get("merged"))
         ):
@@ -8310,6 +8691,7 @@ def _run_pr_live_state_gate(
             AUTOMATION_CLOSEOUT_PR_READINESS_PR2_SEAM,
             PR101_CLOSEOUT_CANON_PR_READINESS_PR2_SEAM,
             PR102_CLOSEOUT_CANON_PR_READINESS_PR2_SEAM,
+            PR103_CLOSEOUT_CANON_PR_READINESS_PR2_SEAM,
         }
         and not bool(closeout_watcher_state.get("merged"))
     ):
@@ -8898,6 +9280,10 @@ def main() -> int:
         current_branch=current_git_branch,
     )
     _validate_pr102_closeout_canon_repair_phase_truth(
+        require,
+        current_branch=current_git_branch,
+    )
+    _validate_pr103_closeout_canon_repair_phase_truth(
         require,
         current_branch=current_git_branch,
     )

--- a/dev/pr_same_thread_watcher.py
+++ b/dev/pr_same_thread_watcher.py
@@ -191,6 +191,8 @@ def current_thread_message(status: dict[str, object]) -> str:
         if status.get("merged")
         else "`Release Readiness` is not legal yet."
     )
+    # Audit pending: merge verification alone should not claim Release Readiness
+    # until merged-main canon validation also passes.
     remote_head = str(status.get("headSha") or "UNKNOWN")
     local_head = str(status.get("localHeadSha") or "UNKNOWN")
     state_label = str(status.get("prState") or "UNKNOWN").casefold()
@@ -845,6 +847,8 @@ def main() -> int:
 
     if bool(status.get("merged")) or str(status.get("prState") or "").upper() == "CLOSED":
         append_log(log_path, "Stopping watcher because PR is closed or merged.")
+        # Audit pending: when a dedicated visible host automation exists, it should
+        # be paused or deleted here as part of the same terminal cleanup.
         stop_task(args.task_name)
 
     return 0

--- a/dev/pr_same_thread_watcher.py
+++ b/dev/pr_same_thread_watcher.py
@@ -452,25 +452,34 @@ def ensure_visible_thread_host(
         "scheduled watcher surface in the app."
     )
     ensure_parent(automation_toml)
-    if not automation_toml.is_file():
-        automation_toml.write_text(
-            "\n".join(
-                [
-                    "version = 1",
-                    f'id = "{automation_id}"',
-                    'kind = "heartbeat"',
-                    f'name = "{automation_name}"',
-                    f'prompt = "{automation_prompt}"',
-                    'status = "ACTIVE"',
-                    'rrule = "FREQ=MINUTELY;INTERVAL=1"',
-                    'target_thread_id = "' + thread_id + '"',
-                    f'created_at = {now_ms}',
-                    f'updated_at = {now_ms}',
-                    "",
-                ]
-            ),
-            encoding="utf-8",
-        )
+    created_at = now_ms
+    if automation_toml.is_file():
+        try:
+            existing_text = automation_toml.read_text(encoding="utf-8")
+            existing_created_at = re.search(r"^created_at = (\d+)$", existing_text, flags=re.M)
+            if existing_created_at:
+                created_at = int(existing_created_at.group(1))
+        except (OSError, ValueError):
+            created_at = now_ms
+    # Always rewrite the host config so a stale target_thread_id cannot survive retargeting.
+    automation_toml.write_text(
+        "\n".join(
+            [
+                "version = 1",
+                f'id = "{automation_id}"',
+                'kind = "heartbeat"',
+                f'name = "{automation_name}"',
+                f'prompt = "{automation_prompt}"',
+                'status = "ACTIVE"',
+                'rrule = "FREQ=MINUTELY;INTERVAL=1"',
+                'target_thread_id = "' + thread_id + '"',
+                f"created_at = {created_at}",
+                f"updated_at = {now_ms}",
+                "",
+            ]
+        ),
+        encoding="utf-8",
+    )
 
     connection = None
     try:

--- a/dev/pr_same_thread_watcher.py
+++ b/dev/pr_same_thread_watcher.py
@@ -187,12 +187,11 @@ def current_thread_message(status: dict[str, object]) -> str:
         else "`PR Merge Verification Pending` remains active."
     )
     release_posture = (
-        "`Release Readiness` is now legal."
+        "Merge verification is complete; run Release Readiness source-of-truth validation "
+        "before claiming release legality."
         if status.get("merged")
         else "`Release Readiness` is not legal yet."
     )
-    # Audit pending: merge verification alone should not claim Release Readiness
-    # until merged-main canon validation also passes.
     remote_head = str(status.get("headSha") or "UNKNOWN")
     local_head = str(status.get("localHeadSha") or "UNKNOWN")
     state_label = str(status.get("prState") or "UNKNOWN").casefold()
@@ -574,6 +573,46 @@ def ensure_visible_thread_host(
     return True, f"visible watcher host '{automation_name}' is registered for thread '{thread_id}'"
 
 
+def retire_visible_thread_host(
+    *,
+    automation_db_path: Path,
+    automation_id: str,
+) -> tuple[bool, str]:
+    now_ms = int(utc_now().timestamp() * 1000)
+    automation_dir = Path.home() / ".codex" / "automations" / automation_id
+    automation_toml = automation_dir / "automation.toml"
+    connection = None
+    try:
+        if automation_toml.is_file():
+            automation_toml.unlink()
+        try:
+            automation_dir.rmdir()
+        except OSError:
+            pass
+
+        if automation_db_path.is_file():
+            connection = sqlite3.connect(automation_db_path)
+            connection.execute("DELETE FROM automations WHERE id = ?", (automation_id,))
+            connection.execute(
+                """
+                UPDATE automation_runs
+                SET status = 'COMPLETED', updated_at = ?
+                WHERE automation_id = ?
+                """,
+                (now_ms, automation_id),
+            )
+            connection.commit()
+    except (OSError, sqlite3.Error) as exc:
+        return False, f"failed to retire visible watcher host '{automation_id}': {exc}"
+    finally:
+        try:
+            if connection is not None:
+                connection.close()
+        except Exception:
+            pass
+    return True, f"visible watcher host '{automation_id}' retired"
+
+
 def signature_for(status: dict[str, object]) -> str:
     fields = {
         "prState": status.get("prState"),
@@ -847,8 +886,14 @@ def main() -> int:
 
     if bool(status.get("merged")) or str(status.get("prState") or "").upper() == "CLOSED":
         append_log(log_path, "Stopping watcher because PR is closed or merged.")
-        # Audit pending: when a dedicated visible host automation exists, it should
-        # be paused or deleted here as part of the same terminal cleanup.
+        retired, retire_message = retire_visible_thread_host(
+            automation_db_path=automation_db_path,
+            automation_id=automation_id,
+        )
+        append_log(log_path, retire_message)
+        status["visibleThreadHostRetired"] = retired
+        status["visibleThreadHostRetireMessage"] = retire_message
+        save_json(state_path, status)
         stop_task(args.task_name)
 
     return 0


### PR DESCRIPTION
## Summary

Updates PR103 post-merge closeout canon repair.

## What Changed

### Changes

- repair stale post-PR103 branch-record canon by making the PR102 and PR101 closeout records historical-only
- preserve PR #103 merge and watcher shutdown proof
- add validator coverage for PR103 closeout PR Readiness and watcher-route proof
- fix PR #104 watcher routing so the watcher targets the actual active Codex working thread, not the stale watcher-host thread
- harden the watcher host helper so stale `target_thread_id` values are rewritten on each run

### Watcher proof
- watcher task: `Codex PR103 Post-Merge Closeout Canon Repair Watch`
- cadence: 1 minute via `pythonw.exe` launcher
- corrected reporting thread: `019dd083-0317-7b42-afb3-20b6818a1fa7`
- proof state: `$CODEX_HOME/watchers/pr103-post-merge-closeout-canon-repair-watch-state.json`
- last scheduler run: `2026-05-01T16:43:03.106570Z`
- latest visible transcript emission: `2026-05-01T16:41:42.579823Z` via `codex_resume`
- stale host cleanup: `local-pr103-watch-host` deleted; only `local-pr104-watch-host` remains active

### Governance
- current phase is `PR Readiness PR2` merge-watch state
- PR #104 is open, non-draft, targets `main`, merge status is clean, and bot approval is present
- Release Readiness remains blocked until the watcher verifies PR #104 is merged
- merged-main current-state truth remains No Active Branch
- pending v1.6.13-prebeta release posture is preserved
- FB-049 remains selected next, Registry-only, branch not created

### Changes

- repair stale post-PR103 branch-record canon by making the PR102 and PR101 closeout records historical-only
- preserve PR #103 merge and watcher shutdown proof
- add validator coverage for PR103 closeout PR Readiness and watcher-route proof
- fix PR #104 watcher routing so the watcher targets the actual active Codex working thread, not the stale watcher-host thread
- harden the watcher host helper so stale `target_thread_id` values are rewritten on each run

### Watcher proof
- watcher task: `Codex PR103 Post-Merge Closeout Canon Repair Watch`
- cadence: 1 minute via `pythonw.exe` launcher
- corrected reporting thread: `019dd083-0317-7b42-afb3-20b6818a1fa7`
- proof state: `$CODEX_HOME/watchers/pr103-post-merge-closeout-canon-repair-watch-state.json`
- last scheduler run: `2026-05-01T16:43:03.106570Z`
- latest visible transcript emission: `2026-05-01T16:41:42.579823Z` via `codex_resume`
- stale host cleanup: `local-pr103-watch-host` deleted; only `local-pr104-watch-host` remains active

### Governance
- current phase is `PR Readiness PR2` merge-watch state
- PR #104 is open, non-draft, targets `main`, merge status is clean, and bot approval is present
- Release Readiness remains blocked until the watcher verifies PR #104 is merged
- merged-main current-state truth remains No Active Branch
- pending v1.6.13-prebeta release posture is preserved
- FB-049 remains selected next, Registry-only, branch not created
