### PR TITLE
[codex] v1.6.13-prebeta release packaging

### DIFF
--- a/Docs/branch_records/codex_one_time_backlog_governance_repair.md
+++ b/Docs/branch_records/codex_one_time_backlog_governance_repair.md
@@ -15,23 +15,30 @@ This branch must not change runtime behavior. Its job is to harden governance, v
 
 ## Current Phase
 
-- Phase: `PR Readiness`
+- Phase: `Historical Traceability`
 
 ## Phase Status
 
+- Historical record state: `Merged historical traceability`
 - Repo State: `No Active Branch` in merge-stable current-state owners.
-- `Active Branch`: `codex/one-time-backlog-governance-repair`
-- Active Branch Authority Record: `Docs/branch_records/codex_one_time_backlog_governance_repair.md`
-- Active Branch: `codex/one-time-backlog-governance-repair`
+- Historical source branch: `codex/one-time-backlog-governance-repair`
+- Historical Branch Authority Record: `Docs/branch_records/codex_one_time_backlog_governance_repair.md`
 - Workstream: `One-time backlog governance repair`
 - USER Approval: explicit in the 2026-05-04 instruction to fix the governance drift in a one-time governance branch.
 - Drift Finding: legacy FB-027 / PR #109 was allowed to become active selected-next and release-facing truth even though it was a small single-seam runtime follow-through.
 - Repair Scope: backlog identity admission blocker, selected-next permission blocker, FAM-003 legacy FB-027 aggregation-hold correction, PR #109 standalone release-driver removal, historical backlog-item consolidation into family/source-of-truth trace, fresh broad `FAM-###` namespace introduction, FAM -> Package -> Slice -> Seam taxonomy correction, single-slice package blocker, package completion markers, PR Readiness Stage 1 / Stage 2 organization, and validator alignment.
 - Runtime Scope: none.
-- Current PR Readiness Stage: `PR Readiness Stage 2 - Execution Gate`
+- Historical PR Readiness Stage: `PR Readiness Stage 2 - Execution Gate`
 - PR Readiness Stage 2 Approval: `USER approval to enter Stage 2 recorded on 2026-05-04 for this one-time governance repair branch only`
-- Current PR Readiness Seam: `PR Readiness Stage 2 - One-Time Backlog Governance Repair Merge Watch`
-- Current Seam: `PR Readiness Stage 2 - One-Time Backlog Governance Repair Merge Watch`
+- Historical PR Readiness Seam: `PR Readiness Stage 2 - One-Time Backlog Governance Repair Merge Watch`
+- Historical final seam: `PR Readiness Stage 2 - One-Time Backlog Governance Repair Merge Watch`
+- Historical PR URL: `https://github.com/GiribaldiTTV/Nexus-Desktop-AI/pull/110`
+- Historical PR Merge Commit: `86f68942b37c0947a9655d146017cb53d1fdc774`
+- Historical PR Merged At: `2026-05-04T16:45:56Z`
+- Historical Final Head SHA: `c74de00f6b16723ecf03e6298f34bc2b55bcf2d7`
+- Historical Bot Review Closeout: Codex review threads `PRRT_kwDORwnWIs5_Z8yC` and `PRRT_kwDORwnWIs5_Z8yM` were fixed on the same branch and resolved before merge.
+- Historical Watcher Merge Verification: `pr-110-same-thread-merge-watcher` emitted same-thread `merged=true` handoff after PR #110 merged.
+- Historical Watcher Retirement: `pr-110-same-thread-merge-watcher` was deleted after the terminal merge condition.
 
 ## Branch Class
 
@@ -39,7 +46,7 @@ This branch must not change runtime behavior. Its job is to harden governance, v
 
 ## Blockers
 
-- `PR Merge Verification Pending` until the same-thread watcher verifies the live PR is merged.
+- None
 
 ## Entry Basis
 
@@ -75,24 +82,24 @@ Rollback Path: revert this branch to restore the pre-repair governance and curre
 
 - `Release Readiness`
 
-Next Legal Phase Gate: `Blocked by PR Merge Verification Pending until the same-thread watcher verifies PR #110 merged=true`
+Next Legal Phase Gate: `Cleared by PR #110 merged=true watcher handoff; later release packaging proceeds from the active v1.6.13-prebeta release-packaging carrier branch.`
 
 ## Active Seam
 
-Active seam: `PR Readiness Stage 2 - One-Time Backlog Governance Repair Merge Watch`
+Active seam: `None - historical traceability record after PR #110 merge`
 
 ## Seam Continuation Decision
 
 Seam Status: `In Progress`
 Slice Status: `In Progress`
-Completion Status: `In Progress`
+Completion Status: `Green`
 Waiver Status: `None`
 Continue Decision: `Stop`
-Stop Basis: `Merge watch waiting for external PR merge event`
-Stop Condition: `PR Merge Verification Pending`
-Continuation Action: `Keep pr-110-same-thread-merge-watcher active on the approved same-thread route until it verifies PR #110 merged=true, then hand off the next legal Release Readiness validation prompt without performing release work.`
-Decision Basis: `PR #110 is live, non-draft, base/head aligned, mergeable clean, bot-review comments are resolved, watcher provisioning/routing is recorded, and watcher runtime proof exists through same-thread heartbeat output; only merge verification remains.`
-Next Active Seam: `PR Readiness Stage 2 - One-Time Backlog Governance Repair Merge Watch`
+Stop Basis: `Historical merge closeout complete`
+Stop Condition: `None`
+Continuation Action: `No action for this historical record; PR #110 merge proof and watcher retirement are preserved, and release-packaging follow-through is carried by codex/v1.6.13-prebeta-release-packaging.`
+Decision Basis: `PR #110 merged at 2026-05-04T16:45:56Z, Codex bot review threads were resolved, the same-thread watcher emitted merged=true proof, and the watcher was retired.`
+Next Active Seam: `None`
 
 ## Post-Merge State
 
@@ -125,12 +132,13 @@ Bot Review Signal Notes: `P1` taxonomy lookup crash risk is guarded before `FRES
 
 - Phase Admission: `PASS`
 - Active Seam: `PR Readiness Stage 2-R1 - PR State and Watcher Runtime Proof Sync`
-- PR #110 Live State: `PASS`; PR #110 is open, non-draft, base `main`, head `codex/one-time-backlog-governance-repair`, head SHA `b3c21c83318d0622ce09f3d681fe47b4567972af` at R1 validation, mergeable `MERGEABLE`, merge state `CLEAN`, and `mergedAt` is null.
+- PR #110 Historical Final State: `MERGED`; PR #110 merged into `main` at `2026-05-04T16:45:56Z` via merge commit `86f68942b37c0947a9655d146017cb53d1fdc774` with final head SHA `c74de00f6b16723ecf03e6298f34bc2b55bcf2d7`.
 - Bot Review Resolution State: `PASS`; Codex review threads `PRRT_kwDORwnWIs5_Z8yC` and `PRRT_kwDORwnWIs5_Z8yM` are resolved in GitHub, with the first thread outdated and the second resolved on the current PR diff after same-branch fixes.
 - Cleared PR Blockers: `PR Creation Pending`, `Bot Review Signal Pending`, `PR Watcher Provisioning Unproven`, and `PR Watcher Routing Unverified`.
-- Watcher Provisioning Proof: `PASS`; `pr-110-same-thread-merge-watcher` exists at `C:\Users\anden\.codex\automations\pr-110-same-thread-merge-watcher\automation.toml`, status `ACTIVE`, kind `heartbeat`, cadence `FREQ=MINUTELY;INTERVAL=1`, target thread `019df2d2-6580-7b82-a49f-59f49da0911c`, and prompt scope is PR #110 same-thread merge watching only.
-- Watcher Runtime Proof: `PASS via thread-output evidence`; same-thread heartbeat runs at `2026-05-04T16:32:23.507Z` and `2026-05-04T16:33:53.538Z` reported PR #110 unchanged with PR-readiness gate passing. Automation database `last_run` visibility remains absent and is tracked as observability lag, not as `Automation Runtime Unproven`, because thread output is accepted run evidence.
-- Remaining PR Readiness Blocker: `PR Merge Verification Pending`; the watcher has not verified `merged=true`.
+- Watcher Provisioning Proof: `PASS`; `pr-110-same-thread-merge-watcher` existed as a same-thread heartbeat watcher for PR #110 during PR Readiness.
+- Watcher Runtime Proof: `PASS via thread-output evidence`; same-thread heartbeat runs reported PR #110 state during merge watch, then the watcher emitted the terminal `merged=true` handoff after GitHub reported the merge.
+- Watcher Retirement Proof: `PASS`; `pr-110-same-thread-merge-watcher` was deleted after the terminal merge condition.
+- Remaining PR Readiness Blocker: `None`; `PR Merge Verification Pending` is cleared by the watcher merged=true handoff.
 - Not Performed: no merge, Release Readiness entry, release work, branch creation, package admission, selected-next truth, FAM taxonomy change, package/slice/seam model change, Element Coverage model change, Branch Readiness gate change, or PR Readiness gate change.
 
 ## Hardening H1 Record

--- a/Docs/branch_records/codex_v1_6_13_prebeta_release_packaging.md
+++ b/Docs/branch_records/codex_v1_6_13_prebeta_release_packaging.md
@@ -37,14 +37,14 @@ This branch must not create runtime work, select FAM-006 or any other runtime FA
 - Single-Slice Package User Approval: `Not required - the admitted release-packaging package has five concrete admitted slices`
 - PR #110 Closeout State: `Cleared on this branch before release-readiness work`
 - PR URL: `https://github.com/GiribaldiTTV/Nexus-Desktop-AI/pull/111`
-- Live PR State: `OPEN / non-draft / mergeable CLEAN`
+- Live PR State: `OPEN / non-draft / mergeable BLOCKED pending Codex review closeout`
 - Live PR Base: `main`
 - Live PR Head: `codex/v1.6.13-prebeta-release-packaging`
 - PR Creation Head SHA: `182727d8f7ff3162760d969c9e6928e680272398`
 - PR Watcher State: `Provisioned`
 - PR Watcher ID: `pr-111-same-thread-merge-watcher`
 - PR Watcher Route: `same Codex thread 019df2d2-6580-7b82-a49f-59f49da0911c`
-- Bot Review Signal Status: `Pending live bot signal`
+- Bot Review Signal Status: `Comment received; same-branch repair recorded, GitHub closeout pending`
 - Runtime Package Admission: `Not approved`
 - Selected Next Runtime FAM: `None - not approved`
 - Selected Next Implementation Branch: `Not created`
@@ -63,7 +63,7 @@ This branch must not create runtime work, select FAM-006 or any other runtime FA
 
 ## Blockers
 
-- `Bot Review Signal Pending`
+- `PR Validation Pending`
 - `PR Merge Verification Pending`
 
 ## Entry Basis
@@ -228,6 +228,7 @@ Repair Scope: branch authority index and historical branch-authority closeout on
 Release Window Audit: PASS
 Audit Incomplete: `No`
 Remaining Known Release Blockers: None
+PR Readiness Gate Scope Note: `PR Readiness gates remain tracked separately in ## Blockers and do not count as release-window blockers unless they require another pre-release repair PR.`
 Another Pre-Release Repair PR Required: NO
 Release Window Split Waiver: None
 Release Execution Approval State: `NOT APPROVED`
@@ -244,7 +245,7 @@ Release Artifact Creation Approval State: `NOT APPROVED`
 - PR State: `OPEN`
 - PR Draft State: `false`
 - PR Mergeability: `MERGEABLE`
-- PR Merge State: `CLEAN`
+- PR Merge State: `BLOCKED pending Codex review closeout`
 - PR Review Decision: `Pending / empty`
 - PR Status Checks: `No status checks reported`
 - PR Summary: `Release-packaging source-truth sync for v1.6.13-prebeta; no release execution, tag creation, GitHub Release creation, release artifact creation, runtime branch, runtime package, or selected-next runtime truth.`
@@ -261,6 +262,15 @@ Release Artifact Creation Approval State: `NOT APPROVED`
 - Watcher Routing Proof: `PASS - automation config records target_thread_id 019df2d2-6580-7b82-a49f-59f49da0911c for this thread`
 - Watcher Runtime Proof: `Pending first heartbeat run`
 - Watcher Teardown Rule: `Delete after watcher verifies PR #111 merged=true or USER explicitly stops the watcher`
+
+## PR Bot Review Signal
+
+- Bot Review Signal Status: `Comment received; same-branch repair recorded`
+- Bot Review Signal Head SHA: `082938a521084c670cc36432633adf3a5e4b3109`
+- Bot Review Signal Source: `Codex review thread PRRT_kwDORwnWIs5_c5UG on PR #111 reported a P2 source-truth contradiction between ## Blockers and Release Window Audit; this same-branch repair keeps release-window blockers scoped separately from PR Readiness gates.`
+- Bot Review Signal Timestamp: `2026-05-04T19:32:11Z`
+- Bot Review Signal Actor: `chatgpt-codex-connector[bot]`
+- Bot Review Signal Closeout State: `Same-branch repair recorded; GitHub review-thread closeout pending`
 
 ## Branch Readiness Stage 2 Validation Record
 
@@ -300,7 +310,7 @@ Release Artifact Creation Approval State: `NOT APPROVED`
 - Selected-Next Runtime Truth Approval State: `NOT APPROVED`
 - FAM-006 Selection State: `Recommendation-only / not selected`
 - PR Creation State: `Complete - PR #111`
-- Live PR Validation State: `PASS for open, non-draft, base/head, mergeability, and clean merge state`
-- Bot Review Signal State: `Pending live bot signal`
+- Live PR Validation State: `PASS for open, non-draft, base/head, and mergeability; merge state is blocked pending Codex review closeout`
+- Bot Review Signal State: `Comment received; P2 source-truth blocker summary repair recorded, GitHub closeout pending`
 - PR Watcher State: `Provisioned and routed; runtime proof pending first heartbeat run`
 - Next PR Readiness Seam: `PR Readiness Stage 2 - v1.6.13-prebeta Release Packaging Live PR Validation And Merge Watch`

--- a/Docs/branch_records/codex_v1_6_13_prebeta_release_packaging.md
+++ b/Docs/branch_records/codex_v1_6_13_prebeta_release_packaging.md
@@ -16,22 +16,29 @@ This branch must not create runtime work, select FAM-006 or any other runtime FA
 
 ## Current Phase
 
-- Phase: `Branch Readiness`
+- Phase: `PR Readiness`
 
 ## Phase Status
 
 - `Active Branch`: `codex/v1.6.13-prebeta-release-packaging`
+- PR Readiness Stage: `PR Readiness Stage 2 - Execution Gate`
+- PR Readiness Stage 2 Approval: `Granted for this release-packaging branch on 2026-05-04`
+- Current PR Readiness Seam: `PR Readiness Stage 2 - v1.6.13-prebeta Release Packaging PR Execution Gate`
 - Branch Readiness Stage: `Branch Readiness Stage 2 - Execution Gate`
 - Stage 2 USER Approval: `Granted for this release-packaging carrier branch on 2026-05-04`
 - Branch Readiness Stage 2 Admission: `Green`
+- RR1 Release Readiness Validation: `Green`
 - Release Target: `v1.6.13-prebeta`
 - Release Floor: `patch prerelease`
 - Release Packaging Package: `REL-PKG-001 v1.6.13-prebeta release packaging`
 - Package Admission State: `Admitted`
 - Admitted Slice Count: `5`
-- Package Completion State: `In Progress`
+- Package Completion State: `Complete`
 - Single-Slice Package User Approval: `Not required - the admitted release-packaging package has five concrete admitted slices`
 - PR #110 Closeout State: `Cleared on this branch before release-readiness work`
+- Live PR State: `Pending PR creation`
+- PR Watcher State: `Pending PR creation`
+- Bot Review Signal Status: `Pending live PR`
 - Runtime Package Admission: `Not approved`
 - Selected Next Runtime FAM: `None - not approved`
 - Selected Next Implementation Branch: `Not created`
@@ -50,7 +57,10 @@ This branch must not create runtime work, select FAM-006 or any other runtime FA
 
 ## Blockers
 
-- None
+- `PR Creation Pending`
+- `PR Watcher Provisioning Unproven`
+- `Bot Review Signal Pending`
+- `PR Merge Verification Pending`
 
 ## Entry Basis
 
@@ -80,7 +90,7 @@ Rollback Path: abandon this branch before merge to restore merged `main` to PR #
 
 - `Release Readiness`
 
-Next Legal Phase Gate: `Allowed only after Branch Readiness Stage 2 validation is green and this branch is committed and pushed; release execution and artifact creation still require separate Release Readiness authorization.`
+Next Legal Phase Gate: `Blocked until the live PR exists, targets main, is mergeable, bot-review signal is closed out, the same-thread PR watcher is provisioned/routed, and the watcher verifies merged=true. Release execution and artifact creation still require separate Release Readiness authorization.`
 
 ## Branch Objective
 
@@ -115,6 +125,18 @@ No desktop User Test Summary is required for this Branch Readiness pass because 
 
 Release Readiness must validate the latest public prerelease, release target, release floor, release scope, release artifact plan, post-release canon plan, and no-selected-next posture before any release execution. Release execution, release artifact creation, tag publication, and GitHub Release publication remain not approved by this Branch Readiness record.
 
+## Post-Merge State
+
+Repo State: `No Active Branch`
+Merged-Main Repo State: `No Active Branch`
+Selected Next Workstream: `None - blocked by Backlog Addition User Approval Missing until explicit USER approval`
+Selected Next Implementation Branch: `Not created`
+Successor Branch Handling: `No runtime successor branch is selected, created, or authorized on this release-packaging branch`
+Backlog Addition User Approval Missing: `Active for any attempted runtime backlog identity, runtime package admission, backlog split, family promotion, selected-next successor selection, standalone release-driver classification, or single-slice package waiver without explicit USER approval`
+Release Debt Handling: `After this branch merges and a separately approved release execution publishes v1.6.13-prebeta, the release-debt package may clear; until then the target remains pending`
+Runtime Branch Handling: `No runtime branch may be created from this PR Readiness Stage 2 pass`
+Post-Merge Truth: `After merge, this branch contributes release-packaging source-truth only; merged-main current-state remains No Active Branch with no selected-next runtime truth, PR numbers evidence-only, and legacy global FB IDs historical-only until a later USER-approved Branch Readiness pass admits new work.`
+
 ## Initial Workstream Seam Sequence
 
 Seam 1: `BR-S2-S1 - PR #110 Branch-Authority Closeout`
@@ -144,7 +166,7 @@ Non-Includes: no PR creation, release execution, or release artifact creation.
 
 ## Active Seam
 
-Active seam: `Branch Readiness Stage 2 - v1.6.13-prebeta Release Packaging Carrier Admission`
+Active seam: `PR Readiness Stage 2 - v1.6.13-prebeta Release Packaging PR Execution Gate`
 
 ## Release Packaging Package / Slice Plan
 
@@ -152,16 +174,16 @@ Package ID: `REL-PKG-001`
 Package Name: `v1.6.13-prebeta release packaging`
 Package Type: `release-support`
 Package Admission State: `Admitted`
-Package Completion State: `In Progress`
+Package Completion State: `Complete`
 Single-Slice Drift Check: `PASS - five concrete admitted release-support slices are defined; Element Coverage rows do not count as slices.`
 
 | Slice ID | Package ID | Slice Name | Admission State | Slice Status | Completion State | Seam Trace |
 | --- | --- | --- | --- | --- | --- | --- |
 | `REL-SLC-001` | `REL-PKG-001` | PR #110 branch-authority closeout | Admitted | Green | Complete | `BR-S2-S1` |
-| `REL-SLC-002` | `REL-PKG-001` | v1.6.13-prebeta release target and floor validation | Admitted | Pending | Not Started | `BR-S2-S2` |
-| `REL-SLC-003` | `REL-PKG-001` | Release scope and artifact plan validation | Admitted | Pending | Not Started | `BR-S2-S3` |
-| `REL-SLC-004` | `REL-PKG-001` | Post-release canon closure plan | Admitted | Pending | Not Started | `BR-S2-S4` |
-| `REL-SLC-005` | `REL-PKG-001` | Validation and Release Readiness handoff | Admitted | Pending | Not Started | `BR-S2-S5` |
+| `REL-SLC-002` | `REL-PKG-001` | v1.6.13-prebeta release target and floor validation | Admitted | Green | Complete | `RR1` |
+| `REL-SLC-003` | `REL-PKG-001` | Release scope and artifact plan validation | Admitted | Green | Complete | `RR1` |
+| `REL-SLC-004` | `REL-PKG-001` | Post-release canon closure plan | Admitted | Green | Complete | `RR1` |
+| `REL-SLC-005` | `REL-PKG-001` | Validation and Release Readiness handoff | Admitted | Green | Complete | `RR1` |
 
 ## Element Coverage Review
 
@@ -197,6 +219,16 @@ Repair Surface: this USER-approved real release-packaging carrier branch.
 Standalone Governance Repair: `Blocked`
 Repair Scope: branch authority index and historical branch-authority closeout only; no runtime work and no release execution.
 
+## Release Window Audit
+
+Release Window Audit: PASS
+Audit Incomplete: `No`
+Remaining Known Release Blockers: None
+Another Pre-Release Repair PR Required: NO
+Release Window Split Waiver: None
+Release Execution Approval State: `NOT APPROVED`
+Release Artifact Creation Approval State: `NOT APPROVED`
+
 ## Branch Readiness Stage 2 Validation Record
 
 - Branch Governance Validation: `PASS`; `python dev/orin_branch_governance_validation.py` passed after active/historical branch-authority routing was corrected.
@@ -204,3 +236,36 @@ Repair Scope: branch authority index and historical branch-authority closeout on
 - Diff Validation: `PASS`; `git diff --check` completed successfully.
 - Automation Observability Validation: `REVIEW`; `dev/automation_observability_report.py` completed successfully and reported stale external automation-memory rows that remain review inputs, not repo-source blockers.
 - Release Readiness Handoff: `Ready`; next pass may validate release target, release floor, release scope, release artifact plan, and post-release canon plan without performing release execution unless separately approved.
+
+## Release Readiness RR1 Validation Record
+
+- Phase Admission: `PASS`
+- Active Seam: `Release Readiness RR1 - v1.6.13-prebeta Release Package Validation`
+- File-Frozen Compliance: `PASS`; RR1 edited no repository files, staged nothing, committed nothing, pushed nothing, created no PR, created no tag, created no GitHub Release, created no release artifacts, and performed no release execution.
+- REL-PKG-001 Package State: `PASS`; release-packaging package has five admitted release-support slices and is not a single-slice cleanup package.
+- Release Target / Floor Validation: `PASS`; latest public prerelease is `v1.6.12-prebeta`, target is `v1.6.13-prebeta`, target release does not already exist, and `patch prerelease` remains the correct release floor.
+- Release Scope / Artifact Plan Validation: `PASS`; scope covers the merged backlog-family governance repair, merged automation-catalog branch truth, FAM-001 legacy FB-049 runtime proof, and FAM-004 legacy FB-030 voice/audio runtime diagnostics proof. Planned artifacts remain planned tag `v1.6.13-prebeta`, release title `Pre-Beta v1.6.13`, inclusion-only Markdown release notes, GitHub-generated `## What's Changed`, and `**Full Changelog**:`.
+- Post-Release Canon Closure Plan: `PASS`; after separately approved release execution, included proof becomes released historical traceability, release debt clears, latest public prerelease advances to `v1.6.13-prebeta`, and no-active-branch/no-selected-next truth remains preserved.
+- PR #110 Closeout Validation: `PASS`; the one-time governance repair record is historical traceability only and branch authority index points only to this release-packaging carrier while this branch is open.
+- Release Execution Approval State: `NOT APPROVED`; no tag, GitHub Release, draft release, release artifact, or release publication may be created by this PR Readiness pass.
+- Selected-Next / Runtime Approval State: `NOT APPROVED`; no runtime branch, runtime package, selected-next runtime truth, FAM-006 selection, or single-slice waiver is authorized.
+- Validation Commands: `PASS`; branch governance validation, Python compile validation, and diff validation passed; automation observability completed with stale external automation-memory rows as review inputs, not repo-source blockers.
+
+## PR Readiness Stage 2 Record
+
+- Phase Admission: `PASS`
+- Active Seam: `PR Readiness Stage 2 - v1.6.13-prebeta Release Packaging PR Execution Gate`
+- Stage 2 USER Approval: `Granted for this release-packaging branch on 2026-05-04`
+- RR1 Source-Truth Sync: `PASS`; file-frozen RR1 validation results are now recorded in this branch authority record.
+- Release Package Completion: `PASS`; all five admitted release-support slices are Green / Complete, and `REL-PKG-001` is Complete.
+- Release Execution Approval State: `NOT APPROVED`
+- Tag Creation Approval State: `NOT APPROVED`
+- GitHub Release Creation Approval State: `NOT APPROVED`
+- Release Artifact Creation Approval State: `NOT APPROVED`
+- Runtime Branch Creation Approval State: `NOT APPROVED`
+- Runtime Package Admission Approval State: `NOT APPROVED`
+- Selected-Next Runtime Truth Approval State: `NOT APPROVED`
+- FAM-006 Selection State: `Recommendation-only / not selected`
+- PR Creation State: `Pending`
+- PR Watcher State: `Pending PR creation`
+- Next PR Readiness Seam: `PR Readiness Stage 2 - v1.6.13-prebeta Release Packaging Live PR Validation And Merge Watch`

--- a/Docs/branch_records/codex_v1_6_13_prebeta_release_packaging.md
+++ b/Docs/branch_records/codex_v1_6_13_prebeta_release_packaging.md
@@ -1,0 +1,206 @@
+# Branch Authority Record: codex/v1.6.13-prebeta-release-packaging
+
+## Branch Identity
+
+- Branch: `codex/v1.6.13-prebeta-release-packaging`
+- Workstream: `v1.6.13-prebeta release packaging with carried PR #110 branch-authority closeout`
+- Branch Class: `release packaging`
+
+## Purpose / Why It Exists
+
+This branch is the USER-approved real release-packaging carrier for `v1.6.13-prebeta`.
+
+It exists because PR #110 merged the one-time backlog governance repair, but merged `main` still carried stale branch-authority truth for that repair branch. The USER rejected a standalone governance cleanup branch and approved carrying the PR #110 branch-authority closeout inside this real release-packaging branch before release-readiness validation or release execution begins.
+
+This branch must not create runtime work, select FAM-006 or any other runtime FAM as selected-next truth, admit a runtime package, waive a single-slice package, create release artifacts, publish a release, or mutate `main` directly.
+
+## Current Phase
+
+- Phase: `Branch Readiness`
+
+## Phase Status
+
+- `Active Branch`: `codex/v1.6.13-prebeta-release-packaging`
+- Branch Readiness Stage: `Branch Readiness Stage 2 - Execution Gate`
+- Stage 2 USER Approval: `Granted for this release-packaging carrier branch on 2026-05-04`
+- Branch Readiness Stage 2 Admission: `Green`
+- Release Target: `v1.6.13-prebeta`
+- Release Floor: `patch prerelease`
+- Release Packaging Package: `REL-PKG-001 v1.6.13-prebeta release packaging`
+- Package Admission State: `Admitted`
+- Admitted Slice Count: `5`
+- Package Completion State: `In Progress`
+- Single-Slice Package User Approval: `Not required - the admitted release-packaging package has five concrete admitted slices`
+- PR #110 Closeout State: `Cleared on this branch before release-readiness work`
+- Runtime Package Admission: `Not approved`
+- Selected Next Runtime FAM: `None - not approved`
+- Selected Next Implementation Branch: `Not created`
+- Release Execution: `Not approved`
+- Release Artifacts: `Not created`
+
+## Branch Class
+
+- `release packaging`
+
+## Release-Bearing Markers
+
+- Release Target: `v1.6.13-prebeta`
+- Release Scope: merged backlog-family governance reform from PR #110, merged automation-catalog branch truth, FAM-001 legacy FB-049 runtime proof, and FAM-004 legacy FB-030 voice/audio runtime diagnostics proof.
+- Release Artifacts: planned tag `v1.6.13-prebeta`, release title `Pre-Beta v1.6.13`, inclusion-only Markdown release notes, GitHub-generated `## What's Changed`, and `**Full Changelog**:` section. Branch Readiness does not create, draft, tag, or publish these artifacts.
+
+## Blockers
+
+- None
+
+## Entry Basis
+
+- PR #110 merged on GitHub at `2026-05-04T16:45:56Z` via merge commit `86f68942b37c0947a9655d146017cb53d1fdc774`.
+- PR #110 final head SHA is `c74de00f6b16723ecf03e6298f34bc2b55bcf2d7`.
+- The PR #110 same-thread merge watcher verified `merged=true`, emitted the handoff in the approved Codex thread, and was retired after the terminal merge condition.
+- Merged `main` still listed `Docs/branch_records/codex_one_time_backlog_governance_repair.md` as active and that historical repair record still retained PR Readiness merge-watch truth.
+- USER approved entering Branch Readiness Stage 2, creating this branch from updated `main`, admitting a multi-slice `v1.6.13-prebeta` release-packaging package, and using it as the real carrier for the PR #110 closeout blocker.
+
+## Exit Criteria
+
+- `Docs/branch_records/index.md` lists only this branch authority record as active while the branch is open.
+- `Docs/branch_records/codex_one_time_backlog_governance_repair.md` is historical traceability, not active branch authority.
+- PR #110 merge proof, final head SHA, bot-review thread closeout, watcher `merged=true` handoff, and watcher retirement proof are preserved.
+- `PR Merge Verification Pending` is cleared for the one-time governance repair record.
+- Merged-main current-state truth remains stable: no active runtime workstream, no selected-next runtime truth, pending `v1.6.13-prebeta` release posture preserved, PR numbers evidence only, and legacy global FB IDs historical only.
+- The release-packaging package has multiple concrete admitted slices and does not rely on a single-slice cleanup.
+- Branch governance validation, Python compile validation, diff validation, and automation observability validation are green before handoff to Release Readiness validation.
+
+## Rollback Target
+
+- `Branch Readiness`
+
+Rollback Path: abandon this branch before merge to restore merged `main` to PR #110 merge commit `86f68942b37c0947a9655d146017cb53d1fdc774`; no direct-main mutation is required.
+
+## Next Legal Phase
+
+- `Release Readiness`
+
+Next Legal Phase Gate: `Allowed only after Branch Readiness Stage 2 validation is green and this branch is committed and pushed; release execution and artifact creation still require separate Release Readiness authorization.`
+
+## Branch Objective
+
+Clear the carried PR #110 branch-authority closeout blocker and admit the real `v1.6.13-prebeta` release-packaging carrier so the next pass can validate release target, floor, scope, artifacts, and post-release canon closure without opening runtime work.
+
+## Target End-State
+
+- Branch authority drift from PR #110 is closed as historical traceability.
+- `REL-PKG-001` is admitted as a multi-slice release-packaging package.
+- No runtime FAM, runtime package, selected-next successor, release artifact, tag, draft release, or public release is created during Branch Readiness.
+- The branch is ready to enter `Release Readiness` validation.
+
+## Backlog Completion Strategy
+
+Branch Completion Goal: complete all five admitted release-packaging slices before release execution can be considered.
+Known Future-Dependent Blockers: actual release artifact creation and publication remain future `Release Readiness` / release-execution work and are not authorized in Branch Readiness.
+Branch Closure Rule: the branch cannot advance beyond Branch Readiness until the carried authority closeout is recorded, release target/floor/scope/artifact plan validation is green, and validation handoff is ready.
+
+## Expected Seam Families And Risk Classes
+
+- PR #110 authority closeout: governance/source-of-truth risk; no runtime change.
+- Release target and floor validation: release-governance risk; no artifact creation.
+- Release scope and artifact plan validation: release-note and tag-plan risk; no publication.
+- Post-release canon closure plan: source-of-truth transition risk; no direct-main mutation.
+- Release Readiness handoff: validation and operator-output risk; no PR creation during Branch Readiness.
+
+## User Test Summary Strategy
+
+No desktop User Test Summary is required for this Branch Readiness pass because no runtime, UI, launcher, tray, voice/audio, or user-facing behavior changes are introduced. Release Readiness may still require operator-facing release validation output before execution.
+
+## Later-Phase Expectations
+
+Release Readiness must validate the latest public prerelease, release target, release floor, release scope, release artifact plan, post-release canon plan, and no-selected-next posture before any release execution. Release execution, release artifact creation, tag publication, and GitHub Release publication remain not approved by this Branch Readiness record.
+
+## Initial Workstream Seam Sequence
+
+Seam 1: `BR-S2-S1 - PR #110 Branch-Authority Closeout`
+Goal: clear stale active branch-authority posture from the merged one-time governance repair record and preserve PR #110 merge/watch proof as historical traceability.
+Scope: update branch authority routing and historical closeout truth only on this release-packaging branch.
+Non-Includes: no runtime branch, runtime package, selected-next truth, release artifact creation, tag, or release publication.
+
+Seam 2: `BR-S2-S2 - Release Target And Floor Validation`
+Goal: validate that `v1.6.13-prebeta` and `patch prerelease` remain the correct release target/floor for the merged proof package.
+Scope: source-truth validation only.
+Non-Includes: no release execution.
+
+Seam 3: `BR-S2-S3 - Release Scope And Artifact Plan Validation`
+Goal: validate inclusion-only release scope and planned artifact surfaces.
+Scope: plan validation only.
+Non-Includes: no release notes artifact, tag, or GitHub Release draft.
+
+Seam 4: `BR-S2-S4 - Post-Release Canon Closure Plan`
+Goal: validate the post-release truth transition plan for `v1.6.13-prebeta`.
+Scope: plan validation only.
+Non-Includes: no post-release canon mutation during Branch Readiness.
+
+Seam 5: `BR-S2-S5 - Release Readiness Handoff`
+Goal: prepare the governed handoff into Release Readiness validation.
+Scope: validation commands and source-of-truth handoff.
+Non-Includes: no PR creation, release execution, or release artifact creation.
+
+## Active Seam
+
+Active seam: `Branch Readiness Stage 2 - v1.6.13-prebeta Release Packaging Carrier Admission`
+
+## Release Packaging Package / Slice Plan
+
+Package ID: `REL-PKG-001`
+Package Name: `v1.6.13-prebeta release packaging`
+Package Type: `release-support`
+Package Admission State: `Admitted`
+Package Completion State: `In Progress`
+Single-Slice Drift Check: `PASS - five concrete admitted release-support slices are defined; Element Coverage rows do not count as slices.`
+
+| Slice ID | Package ID | Slice Name | Admission State | Slice Status | Completion State | Seam Trace |
+| --- | --- | --- | --- | --- | --- | --- |
+| `REL-SLC-001` | `REL-PKG-001` | PR #110 branch-authority closeout | Admitted | Green | Complete | `BR-S2-S1` |
+| `REL-SLC-002` | `REL-PKG-001` | v1.6.13-prebeta release target and floor validation | Admitted | Pending | Not Started | `BR-S2-S2` |
+| `REL-SLC-003` | `REL-PKG-001` | Release scope and artifact plan validation | Admitted | Pending | Not Started | `BR-S2-S3` |
+| `REL-SLC-004` | `REL-PKG-001` | Post-release canon closure plan | Admitted | Pending | Not Started | `BR-S2-S4` |
+| `REL-SLC-005` | `REL-PKG-001` | Validation and Release Readiness handoff | Admitted | Pending | Not Started | `BR-S2-S5` |
+
+## Element Coverage Review
+
+Element Coverage is a non-identity checklist only. It does not count as `Admission State: Admitted`, a slice, a seam, a package, a FAM, selected-next truth, or a release driver.
+
+- User-facing surface: release notes and public release copy only; no UI/runtime change.
+- Runtime/backend behavior: historical merged proof only; no new runtime delta.
+- Fail-safe/recovery: preserve existing runtime proof and release rollback path.
+- Security/privacy: no new runtime permission or data-surface change.
+- Voice/audio: preserve FAM-004 legacy FB-030 runtime diagnostics proof in release scope.
+- External integration: preserve merged automation-catalog proof only.
+- Local AI/capability packs: not in scope.
+- Packaging/install: release tag/title/notes plan validation only.
+- Monitoring/HUD: not in scope; FAM-006 remains recommendation-only, not selected-next truth.
+- Validation: branch governance, compile, diff, and automation observability validation.
+- Release impact: `v1.6.13-prebeta` release target/floor/scope/artifact plan validation.
+
+## Selected-Next / Runtime Non-Approval
+
+- Runtime branch creation: `Not approved`
+- Runtime package admission: `Not approved`
+- FAM-006 selected-next truth: `Not approved`
+- Any other runtime FAM selected-next truth: `Not approved`
+- Single-slice package waiver: `Not approved`
+- Release execution: `Not approved`
+- Release artifact creation: `Not approved`
+
+## Governance Drift Audit
+
+Governance Drift Found: `Yes - carried blocker from PR #110 post-merge authority closeout`
+Drift Type: stale active branch authority after merged PR.
+Repair Surface: this USER-approved real release-packaging carrier branch.
+Standalone Governance Repair: `Blocked`
+Repair Scope: branch authority index and historical branch-authority closeout only; no runtime work and no release execution.
+
+## Branch Readiness Stage 2 Validation Record
+
+- Branch Governance Validation: `PASS`; `python dev/orin_branch_governance_validation.py` passed after active/historical branch-authority routing was corrected.
+- Python Compile Validation: `PASS`; `python -m compileall -q dev` completed successfully.
+- Diff Validation: `PASS`; `git diff --check` completed successfully.
+- Automation Observability Validation: `REVIEW`; `dev/automation_observability_report.py` completed successfully and reported stale external automation-memory rows that remain review inputs, not repo-source blockers.
+- Release Readiness Handoff: `Ready`; next pass may validate release target, release floor, release scope, release artifact plan, and post-release canon plan without performing release execution unless separately approved.

--- a/Docs/branch_records/codex_v1_6_13_prebeta_release_packaging.md
+++ b/Docs/branch_records/codex_v1_6_13_prebeta_release_packaging.md
@@ -23,7 +23,7 @@ This branch must not create runtime work, select FAM-006 or any other runtime FA
 - `Active Branch`: `codex/v1.6.13-prebeta-release-packaging`
 - PR Readiness Stage: `PR Readiness Stage 2 - Execution Gate`
 - PR Readiness Stage 2 Approval: `Granted for this release-packaging branch on 2026-05-04`
-- Current PR Readiness Seam: `PR Readiness Stage 2 - v1.6.13-prebeta Release Packaging PR Execution Gate`
+- Current PR Readiness Seam: `PR Readiness Stage 2 - v1.6.13-prebeta Release Packaging Live PR Validation And Merge Watch`
 - Branch Readiness Stage: `Branch Readiness Stage 2 - Execution Gate`
 - Stage 2 USER Approval: `Granted for this release-packaging carrier branch on 2026-05-04`
 - Branch Readiness Stage 2 Admission: `Green`
@@ -36,9 +36,15 @@ This branch must not create runtime work, select FAM-006 or any other runtime FA
 - Package Completion State: `Complete`
 - Single-Slice Package User Approval: `Not required - the admitted release-packaging package has five concrete admitted slices`
 - PR #110 Closeout State: `Cleared on this branch before release-readiness work`
-- Live PR State: `Pending PR creation`
-- PR Watcher State: `Pending PR creation`
-- Bot Review Signal Status: `Pending live PR`
+- PR URL: `https://github.com/GiribaldiTTV/Nexus-Desktop-AI/pull/111`
+- Live PR State: `OPEN / non-draft / mergeable CLEAN`
+- Live PR Base: `main`
+- Live PR Head: `codex/v1.6.13-prebeta-release-packaging`
+- PR Creation Head SHA: `182727d8f7ff3162760d969c9e6928e680272398`
+- PR Watcher State: `Provisioned`
+- PR Watcher ID: `pr-111-same-thread-merge-watcher`
+- PR Watcher Route: `same Codex thread 019df2d2-6580-7b82-a49f-59f49da0911c`
+- Bot Review Signal Status: `Pending live bot signal`
 - Runtime Package Admission: `Not approved`
 - Selected Next Runtime FAM: `None - not approved`
 - Selected Next Implementation Branch: `Not created`
@@ -57,8 +63,6 @@ This branch must not create runtime work, select FAM-006 or any other runtime FA
 
 ## Blockers
 
-- `PR Creation Pending`
-- `PR Watcher Provisioning Unproven`
 - `Bot Review Signal Pending`
 - `PR Merge Verification Pending`
 
@@ -166,7 +170,7 @@ Non-Includes: no PR creation, release execution, or release artifact creation.
 
 ## Active Seam
 
-Active seam: `PR Readiness Stage 2 - v1.6.13-prebeta Release Packaging PR Execution Gate`
+Active seam: `PR Readiness Stage 2 - v1.6.13-prebeta Release Packaging Live PR Validation And Merge Watch`
 
 ## Release Packaging Package / Slice Plan
 
@@ -229,6 +233,35 @@ Release Window Split Waiver: None
 Release Execution Approval State: `NOT APPROVED`
 Release Artifact Creation Approval State: `NOT APPROVED`
 
+## PR Creation Details
+
+- PR URL: `https://github.com/GiribaldiTTV/Nexus-Desktop-AI/pull/111`
+- PR Number: `111`
+- PR Title: `[codex] v1.6.13-prebeta release packaging`
+- PR Base: `main`
+- PR Head: `codex/v1.6.13-prebeta-release-packaging`
+- PR Creation Head SHA: `182727d8f7ff3162760d969c9e6928e680272398`
+- PR State: `OPEN`
+- PR Draft State: `false`
+- PR Mergeability: `MERGEABLE`
+- PR Merge State: `CLEAN`
+- PR Review Decision: `Pending / empty`
+- PR Status Checks: `No status checks reported`
+- PR Summary: `Release-packaging source-truth sync for v1.6.13-prebeta; no release execution, tag creation, GitHub Release creation, release artifact creation, runtime branch, runtime package, or selected-next runtime truth.`
+
+## PR Watcher Provisioning
+
+- Watcher ID: `pr-111-same-thread-merge-watcher`
+- Watcher Kind: `heartbeat`
+- Watcher Status: `ACTIVE`
+- Watcher RRULE: `FREQ=MINUTELY;INTERVAL=1`
+- Watcher Config Path: `C:\Users\anden\.codex\automations\pr-111-same-thread-merge-watcher\automation.toml`
+- Watcher Target Thread: `019df2d2-6580-7b82-a49f-59f49da0911c`
+- Watcher Reporting Surface: `same Codex thread`
+- Watcher Routing Proof: `PASS - automation config records target_thread_id 019df2d2-6580-7b82-a49f-59f49da0911c for this thread`
+- Watcher Runtime Proof: `Pending first heartbeat run`
+- Watcher Teardown Rule: `Delete after watcher verifies PR #111 merged=true or USER explicitly stops the watcher`
+
 ## Branch Readiness Stage 2 Validation Record
 
 - Branch Governance Validation: `PASS`; `python dev/orin_branch_governance_validation.py` passed after active/historical branch-authority routing was corrected.
@@ -254,7 +287,7 @@ Release Artifact Creation Approval State: `NOT APPROVED`
 ## PR Readiness Stage 2 Record
 
 - Phase Admission: `PASS`
-- Active Seam: `PR Readiness Stage 2 - v1.6.13-prebeta Release Packaging PR Execution Gate`
+- Active Seam: `PR Readiness Stage 2 - v1.6.13-prebeta Release Packaging Live PR Validation And Merge Watch`
 - Stage 2 USER Approval: `Granted for this release-packaging branch on 2026-05-04`
 - RR1 Source-Truth Sync: `PASS`; file-frozen RR1 validation results are now recorded in this branch authority record.
 - Release Package Completion: `PASS`; all five admitted release-support slices are Green / Complete, and `REL-PKG-001` is Complete.
@@ -266,6 +299,8 @@ Release Artifact Creation Approval State: `NOT APPROVED`
 - Runtime Package Admission Approval State: `NOT APPROVED`
 - Selected-Next Runtime Truth Approval State: `NOT APPROVED`
 - FAM-006 Selection State: `Recommendation-only / not selected`
-- PR Creation State: `Pending`
-- PR Watcher State: `Pending PR creation`
+- PR Creation State: `Complete - PR #111`
+- Live PR Validation State: `PASS for open, non-draft, base/head, mergeability, and clean merge state`
+- Bot Review Signal State: `Pending live bot signal`
+- PR Watcher State: `Provisioned and routed; runtime proof pending first heartbeat run`
 - Next PR Readiness Seam: `PR Readiness Stage 2 - v1.6.13-prebeta Release Packaging Live PR Validation And Merge Watch`

--- a/Docs/branch_records/index.md
+++ b/Docs/branch_records/index.md
@@ -26,6 +26,7 @@ Do not use this layer to replace:
 - new governance-only branches are not used for Nexus work
 - Standalone docs/governance, emergency canon repair, and repair-only feature branches are blocked for future Nexus work.
 - Governance, docs, source-of-truth, and validator repairs must ride inside the next legitimate runtime-focused backlog branch during `Branch Readiness` or `PR Readiness`.
+- If USER explicitly admits a real release-support or release-packaging carrier before the next runtime-focused branch, blocker-clearing governance closeout may ride inside that carrier's `Branch Readiness` before release-readiness work begins.
 - If no runtime-focused branch is legally admitted yet, record the drift as a blocker and wait instead of creating a repair branch by inertia.
 - Historical repair-only branch records remain traceability only and do not authorize new repair-only branch creation.
 - The one-time `codex/one-time-backlog-governance-repair` branch is USER-admitted as `repair/dev-tooling-governance` to repair the blocker rule that allowed FB-027/PR #109 drift; it does not reopen governance-only branch creation as a default path.
@@ -61,10 +62,11 @@ Do not use this layer to replace:
 
 ## Active Branch Authority Records
 
-- `Docs/branch_records/codex_one_time_backlog_governance_repair.md`
+- `Docs/branch_records/codex_v1_6_13_prebeta_release_packaging.md`
 
 ## Historical Branch Authority Records
 
+- `Docs/branch_records/codex_one_time_backlog_governance_repair.md`
 - `Docs/branch_records/feature_fb_049_runtime_branch_readiness.md`
 - `Docs/branch_records/feature_pr105_post_merge_closeout_canon_repair.md`
 - `Docs/branch_records/feature_pr104_watcher_next_prompt_format_repair.md`


### PR DESCRIPTION
## Summary

This PR does not create a tag, draft or publish a GitHub Release, generate release artifacts, execute the release, select FAM-006, or admit any runtime package.

## What Changed

### Changes

- admits the v1.6.13-prebeta release-packaging carrier and closes the carried PR #110 branch-authority drift as historical traceability
- records RR1 validation for release target/floor, release scope, artifact plan, post-release canon plan, and Release Readiness handoff
- preserves no runtime branch, no runtime package, no selected-next runtime truth, no release execution, and no release artifacts

### Changes

- admits the v1.6.13-prebeta release-packaging carrier and closes the carried PR #110 branch-authority drift as historical traceability
- records RR1 validation for release target/floor, release scope, artifact plan, post-release canon plan, and Release Readiness handoff
- preserves no runtime branch, no runtime package, no selected-next runtime truth, no release execution, and no release artifacts
