### PR TITLE
Fix launcher orphan tray recovery

### DIFF
--- a/desktop/orin_desktop_launcher.pyw
+++ b/desktop/orin_desktop_launcher.pyw
@@ -10,8 +10,15 @@ import subprocess
 import datetime
 import platform
 import secrets
+import ctypes
+from ctypes import wintypes
 
-from single_instance import NamedSignal, SingleInstanceGuard, acquire_or_prompt_replace
+from single_instance import (
+    NamedSignal,
+    SingleInstanceGuard,
+    acquire_or_prompt_replace,
+    show_already_running_dialog,
+)
 
 
 def env_flag(name):
@@ -45,6 +52,14 @@ RUNTIME_DESKTOP_SETTLED_EVENT = r"Local\JarvisRuntimeDesktopSettledV1"
 runtime_instance_guard = SingleInstanceGuard(RUNTIME_INSTANCE_MUTEX)
 runtime_relaunch_signal = NamedSignal(RUNTIME_RELAUNCH_EVENT)
 runtime_desktop_settled_signal = NamedSignal(RUNTIME_DESKTOP_SETTLED_EVENT)
+
+PROCESS_QUERY_LIMITED_INFORMATION = 0x1000
+OpenProcess = ctypes.windll.kernel32.OpenProcess
+OpenProcess.argtypes = [wintypes.DWORD, wintypes.BOOL, wintypes.DWORD]
+OpenProcess.restype = wintypes.HANDLE
+CloseHandle = ctypes.windll.kernel32.CloseHandle
+CloseHandle.argtypes = [wintypes.HANDLE]
+CloseHandle.restype = wintypes.BOOL
 
 MAX_RECOVERY_ATTEMPTS = 3
 RECOVERY_COOLDOWN_SECONDS = 1.2
@@ -822,6 +837,8 @@ def write_active_runtime_owner_file(reason):
             json.dump(
                 {
                     "runtime_file": RUNTIME_FILE,
+                    "run_id": RUN_ID_STEM,
+                    "launcher_pid": os.getpid(),
                     "recorded_at": datetime.datetime.now(datetime.timezone.utc).isoformat(),
                     "reason": reason,
                 },
@@ -834,10 +851,96 @@ def write_active_runtime_owner_file(reason):
         return False
 
 
-def active_owner_runtime_log_contains(pattern):
+def read_active_runtime_owner():
     try:
         with open(ACTIVE_RUNTIME_OWNER_FILE, "r", encoding="utf-8") as f:
-            owner = json.load(f)
+            return json.load(f)
+    except Exception:
+        return {}
+
+
+def process_is_running(pid):
+    try:
+        process_id = int(pid)
+    except (TypeError, ValueError):
+        return False
+    if process_id <= 0:
+        return False
+
+    handle = OpenProcess(PROCESS_QUERY_LIMITED_INFORMATION, False, process_id)
+    if not handle:
+        return False
+    try:
+        return True
+    finally:
+        CloseHandle(handle)
+
+
+def active_owner_matches_current(owner):
+    runtime_file = os.path.abspath(str(owner.get("runtime_file") or ""))
+    if runtime_file and runtime_file == os.path.abspath(RUNTIME_FILE):
+        return True
+    return str(owner.get("run_id") or "") == RUN_ID_STEM
+
+
+def active_owner_is_live(owner):
+    return process_is_running(owner.get("launcher_pid"))
+
+
+def active_owner_summary(owner):
+    if not owner:
+        return "owner=none"
+    runtime_file = os.path.basename(str(owner.get("runtime_file") or "")) or "unknown_runtime"
+    return (
+        f"owner_run={owner.get('run_id') or 'unknown'}"
+        f"|owner_pid={owner.get('launcher_pid') or 'unknown'}"
+        f"|owner_runtime={runtime_file}"
+    )
+
+
+def live_active_owner_conflict():
+    owner = read_active_runtime_owner()
+    return bool(owner and not active_owner_matches_current(owner) and active_owner_is_live(owner)), owner
+
+
+def clear_active_runtime_owner(reason, allow_foreign_stale=False):
+    owner = read_active_runtime_owner()
+    if owner and not active_owner_matches_current(owner):
+        if active_owner_is_live(owner) or not allow_foreign_stale:
+            runtime_event(
+                "FILE",
+                "DELETE",
+                os.path.basename(ACTIVE_RUNTIME_OWNER_FILE),
+                "SKIPPED_FOREIGN_OWNER",
+                reason,
+                active_owner_summary(owner),
+            )
+            return False
+
+    delete_file(DESKTOP_SETTLED_SIGNAL_FILE, reason)
+    delete_file(ACTIVE_RUNTIME_OWNER_FILE, reason)
+    return True
+
+
+def claim_active_runtime_owner_file(reason):
+    conflict, owner = live_active_owner_conflict()
+    if conflict:
+        runtime_event(
+            "STATUS",
+            "WARNING",
+            "LAUNCHER_RUNTIME",
+            "ACTIVE_RUNTIME_OWNER_CONFLICT_DETECTED",
+            active_owner_summary(owner),
+        )
+        return False
+
+    clear_active_runtime_owner(reason, allow_foreign_stale=True)
+    return write_active_runtime_owner_file(reason)
+
+
+def active_owner_runtime_log_contains(pattern):
+    try:
+        owner = read_active_runtime_owner()
         runtime_file = os.path.abspath(str(owner.get("runtime_file") or ""))
         if not runtime_file:
             return False
@@ -855,11 +958,6 @@ def active_desktop_settled_signal_present():
     return os.path.isfile(DESKTOP_SETTLED_SIGNAL_FILE) or active_owner_runtime_log_contains(
         AUTHORITATIVE_DESKTOP_SETTLED_MARKER
     )
-
-
-def clear_active_runtime_owner(reason):
-    delete_file(DESKTOP_SETTLED_SIGNAL_FILE, reason)
-    delete_file(ACTIVE_RUNTIME_OWNER_FILE, reason)
 
 
 def observe_authoritative_desktop_settled(proc, log_start_offset):
@@ -973,15 +1071,15 @@ def capture_post_settled_exit_markers(log_start_offset):
 
 def classify_post_settled_exit(exit_code, startup_observation, log_start_offset):
     exit_markers = capture_post_settled_exit_markers(log_start_offset)
-    if startup_observation != "settled":
-        return "", exit_markers
-
     if (
         exit_code == 0
         and exit_markers["shutdown_requested"]
         and exit_markers["event_loop_exit_zero"]
     ):
         return "valid_termination", exit_markers
+
+    if startup_observation != "settled":
+        return "", exit_markers
 
     return "recoverable_condition", exit_markers
 
@@ -1455,13 +1553,15 @@ def main():
         "replacement_session": False,
         "replacement_session_settled_recorded": False,
         "released": False,
+        "active_owner_conflict": False,
     }
 
     def log_single_instance_event(event):
         if event == "SINGLE_INSTANCE_ACQUIRED":
-            runtime_desktop_settled_signal.clear()
-            clear_active_runtime_owner("startup settled signal reset")
-            write_active_runtime_owner_file("startup owner acquired")
+            if claim_active_runtime_owner_file("startup owner acquired"):
+                runtime_desktop_settled_signal.clear()
+            else:
+                single_instance_state["active_owner_conflict"] = True
         if event in {"REPLACE_PROMPT_DECLINED", "REPLACE_PROMPT_AUTO_DECLINED"}:
             single_instance_state["declined_relaunch"] = True
         if event == "PRE_SETTLED_CONFLICT_SESSION_PRESERVED":
@@ -1497,7 +1597,9 @@ def main():
             return
 
         single_instance_state["released"] = True
-        runtime_desktop_settled_signal.clear()
+        owner_conflict, _owner = live_active_owner_conflict()
+        if not owner_conflict:
+            runtime_desktop_settled_signal.clear()
         clear_active_runtime_owner("runtime release")
         runtime_instance_guard.release()
         runtime_relaunch_signal.close()
@@ -1565,6 +1667,27 @@ def main():
             runtime_event("STATUS", "SKIP", "LAUNCHER_RUNTIME", "ALREADY_RUNNING")
         return 0
 
+    if single_instance_state["active_owner_conflict"]:
+        runtime(
+            "Launcher start blocked: active runtime owner file belongs to another live launcher; "
+            "preserving current session and suppressing duplicate renderer startup"
+        )
+        runtime_event(
+            "STATUS",
+            "SKIP",
+            "LAUNCHER_RUNTIME",
+            "ACTIVE_RUNTIME_OWNER_CONFLICT_SESSION_PRESERVED",
+        )
+        if not env_flag("JARVIS_HARNESS_SUPPRESS_ALREADY_RUNNING_DIALOGS"):
+            show_already_running_dialog(
+                "Nexus Desktop AI Session Active",
+                "Nexus Desktop AI is still starting or recovering. Please wait for the current session to finish.",
+                eyebrow_text="NEXUS DESKTOP AI",
+                primary_button_text="Close",
+            )
+        release_single_instance_resources()
+        return 0
+
     ensure_crash_dir("launcher startup")
     reset_status()
 
@@ -1617,6 +1740,22 @@ def main():
         if exit_if_relaunch_requested("before_renderer_attempt"):
             release_single_instance_resources()
             return 0
+        if attempt > 1:
+            owner_conflict, owner = live_active_owner_conflict()
+            if owner_conflict:
+                runtime(
+                    "Recovery suppressed: another live launcher owns the active runtime session; "
+                    "not spawning an orphan renderer"
+                )
+                runtime_event(
+                    "STATUS",
+                    "SKIP",
+                    "LAUNCHER_RUNTIME",
+                    "RECOVERY_SUPPRESSED_BY_ACTIVE_OWNER",
+                    active_owner_summary(owner),
+                )
+                release_single_instance_resources()
+                return 0
 
         runtime(f"Renderer launch attempt {attempt}/{MAX_RECOVERY_ATTEMPTS}")
         runtime_event("STATUS", "START", "RECOVERY_ATTEMPT", f"INDEX={attempt}", f"MAX={MAX_RECOVERY_ATTEMPTS}")
@@ -1645,6 +1784,37 @@ def main():
             failure_origin = ""
             stderr_excerpt_lines = []
 
+        if post_settled_classification == "valid_termination":
+            if startup_observation == "settled":
+                record_relaunch_replacement_settled()
+                runtime("Renderer exited normally")
+            else:
+                runtime(
+                    "Renderer exited normally before authoritative desktop-settled signal "
+                    "after user-requested shutdown"
+                )
+                runtime_event(
+                    "STATUS",
+                    "SUCCESS",
+                    "LAUNCHER_RUNTIME",
+                    "PRE_SETTLED_USER_SHUTDOWN_COMPLETE",
+                )
+            runtime_event("STATUS", "SUCCESS", "RECOVERY_ATTEMPT", f"INDEX={attempt}", "RENDERER_EXIT=0")
+            write_status("TRACE", "Renderer exited normally")
+            delete_file(STOP_SIGNAL_FILE, "normal exit")
+            delete_file(STARTUP_ABORT_SIGNAL_FILE, "normal exit")
+            delete_file(STATUS_FILE, "normal exit")
+            runtime_event("STATUS", "SUCCESS", "LAUNCHER_RUNTIME", "NORMAL_EXIT_COMPLETE")
+            record_finalized_history(
+                run_id,
+                "SUCCESS",
+                "NORMAL_EXIT_COMPLETE",
+                "NORMAL_EXIT_COMPLETE",
+                attempt,
+            )
+            release_single_instance_resources()
+            return 0
+
         if last_code == 0 and startup_observation != "settled":
             runtime("Renderer exited before authoritative desktop-settled signal was observed")
             runtime_event(
@@ -1662,25 +1832,6 @@ def main():
                 failure_origin
                 or "Failure origin: launcher startup observation ended before the authoritative desktop-settled signal."
             )
-
-        if startup_observation == "settled" and post_settled_classification == "valid_termination":
-            record_relaunch_replacement_settled()
-            runtime("Renderer exited normally")
-            runtime_event("STATUS", "SUCCESS", "RECOVERY_ATTEMPT", f"INDEX={attempt}", "RENDERER_EXIT=0")
-            write_status("TRACE", "Renderer exited normally")
-            delete_file(STOP_SIGNAL_FILE, "normal exit")
-            delete_file(STARTUP_ABORT_SIGNAL_FILE, "normal exit")
-            delete_file(STATUS_FILE, "normal exit")
-            runtime_event("STATUS", "SUCCESS", "LAUNCHER_RUNTIME", "NORMAL_EXIT_COMPLETE")
-            record_finalized_history(
-                run_id,
-                "SUCCESS",
-                "NORMAL_EXIT_COMPLETE",
-                "NORMAL_EXIT_COMPLETE",
-                attempt,
-            )
-            release_single_instance_resources()
-            return 0
 
         if startup_observation == "settled" and post_settled_classification == "recoverable_condition":
             record_relaunch_replacement_settled()

--- a/dev/orin_desktop_entrypoint_validation.py
+++ b/dev/orin_desktop_entrypoint_validation.py
@@ -74,6 +74,15 @@ RELAUNCH_WAIT_TIMEOUT_REPLACEMENT_UNCONFIRMED_MARKER = (
 PRE_SETTLED_INCOMING_CONFLICT_SESSION_PRESERVED_MARKER = (
     "STATUS|SKIP|LAUNCHER_RUNTIME|PRE_SETTLED_INCOMING_CONFLICT_SESSION_PRESERVED"
 )
+PRE_SETTLED_USER_SHUTDOWN_COMPLETE_MARKER = (
+    "STATUS|SUCCESS|LAUNCHER_RUNTIME|PRE_SETTLED_USER_SHUTDOWN_COMPLETE"
+)
+ACTIVE_RUNTIME_OWNER_CONFLICT_DETECTED_MARKER = (
+    "STATUS|WARNING|LAUNCHER_RUNTIME|ACTIVE_RUNTIME_OWNER_CONFLICT_DETECTED"
+)
+ACTIVE_RUNTIME_OWNER_CONFLICT_SESSION_PRESERVED_MARKER = (
+    "STATUS|SKIP|LAUNCHER_RUNTIME|ACTIVE_RUNTIME_OWNER_CONFLICT_SESSION_PRESERVED"
+)
 SINGLE_INSTANCE_RELEASED_MARKER = "STATUS|TRACE|LAUNCHER_RUNTIME|SINGLE_INSTANCE_RELEASED"
 
 EXPECTED_MILESTONES = [
@@ -6091,6 +6100,260 @@ def run_rapid_pre_settled_exit_scenario():
     }
 
 
+def run_pre_settled_user_shutdown_scenario():
+    scenario_name = "launcher_pre_settled_user_shutdown"
+    scenario_root = os.path.join(BASE_LOG_ROOT, scenario_name)
+    preexisting_processes_before, preexisting_processes_killed, preexisting_processes_after = (
+        cleanup_launch_chain_processes_for_log_root(BASE_LOG_ROOT)
+    )
+    reset_dir(scenario_root)
+    fake_renderer_script = os.path.join(scenario_root, "fake_renderer_pre_settled_user_shutdown.py")
+
+    with open(fake_renderer_script, "w", encoding="utf-8") as handle:
+        handle.write(
+            "import sys\n"
+            "\n"
+            "def arg_value(flag):\n"
+            "    for index, arg in enumerate(sys.argv):\n"
+            "        if arg == flag and index + 1 < len(sys.argv):\n"
+            "            return sys.argv[index + 1]\n"
+            "    return ''\n"
+            "\n"
+            "runtime_log = arg_value('--runtime-log')\n"
+            "\n"
+            "def log(line):\n"
+            "    with open(runtime_log, 'a', encoding='utf-8') as stream:\n"
+            "        stream.write(line + '\\n')\n"
+            "\n"
+            "log('RENDERER_MAIN|START')\n"
+            "log('RENDERER_MAIN|TRAY_ENTRY_READY|available=true')\n"
+            "log('RENDERER_MAIN|SHUTDOWN_REQUESTED')\n"
+            "log('RENDERER_MAIN|EVENT_LOOP_EXIT|code=0')\n"
+            "raise SystemExit(0)\n"
+        )
+
+    env = os.environ.copy()
+    env["JARVIS_HARNESS_LOG_ROOT"] = scenario_root
+    env["JARVIS_HARNESS_TARGET_SCRIPT"] = fake_renderer_script
+    env["JARVIS_HARNESS_DISABLE_DIAGNOSTICS"] = "1"
+    env["JARVIS_HARNESS_DISABLE_VOICE"] = "1"
+    env["QT_QPA_PLATFORM"] = "offscreen"
+
+    result = run_hidden_command(
+        [sys.executable, LAUNCHER_SCRIPT],
+        env=env,
+        timeout_seconds=45,
+    )
+    time.sleep(0.35)
+
+    runtime_log = latest_file_matching(scenario_root, "Runtime_")
+    runtime_lines = read_lines(runtime_log)
+    residual_launch_chain_processes_before, residual_launch_chain_killed, residual_launch_chain_processes_after = (
+        cleanup_launch_chain_processes_for_log_root(BASE_LOG_ROOT)
+    )
+
+    checks = {
+        "runtime_log_created": line_status(
+            bool(runtime_log),
+            runtime_log or "missing runtime log",
+        ),
+        "authoritative_settled_absent": line_status(
+            not any(AUTHORITATIVE_DESKTOP_SETTLED_MARKER in line for line in runtime_lines),
+            AUTHORITATIVE_DESKTOP_SETTLED_MARKER,
+        ),
+        "pre_settled_user_shutdown_complete_present": line_status(
+            any(PRE_SETTLED_USER_SHUTDOWN_COMPLETE_MARKER in line for line in runtime_lines),
+            PRE_SETTLED_USER_SHUTDOWN_COMPLETE_MARKER,
+        ),
+        "normal_exit_complete_present": line_status(
+            any("STATUS|SUCCESS|LAUNCHER_RUNTIME|NORMAL_EXIT_COMPLETE" in line for line in runtime_lines),
+            "STATUS|SUCCESS|LAUNCHER_RUNTIME|NORMAL_EXIT_COMPLETE",
+        ),
+        "settled_not_reached_failure_absent": line_status(
+            not any("DESKTOP_SETTLED_NOT_REACHED_BEFORE_EXIT" in line for line in runtime_lines),
+            "DESKTOP_SETTLED_NOT_REACHED_BEFORE_EXIT absent for user-requested shutdown",
+        ),
+        "recovery_attempt_two_absent": line_status(
+            not any("STATUS|START|RECOVERY_ATTEMPT|INDEX=2" in line for line in runtime_lines),
+            "no recovery attempt after clean pre-settled user shutdown",
+        ),
+        "failure_flow_complete_absent": line_status(
+            not any("STATUS|SUCCESS|LAUNCHER_RUNTIME|FAILURE_FLOW_COMPLETE" in line for line in runtime_lines),
+            "STATUS|SUCCESS|LAUNCHER_RUNTIME|FAILURE_FLOW_COMPLETE absent",
+        ),
+        "traceback_absent": line_status(
+            "Traceback" not in (result.stdout or "") and "Traceback" not in (result.stderr or ""),
+            (result.stderr or result.stdout).strip() or "no traceback in stdout/stderr",
+        ),
+        "scenario_preflight_cleanup_optional": line_status(
+            not preexisting_processes_after,
+            "no prior validation-owned launcher/runtime processes detected"
+            if not preexisting_processes_before
+            else (
+                f"detected {len(preexisting_processes_before)} prior process(es); "
+                f"killed={','.join(str(pid) for pid in preexisting_processes_killed) or 'none'}"
+            ),
+        ),
+        "launch_chain_cleanup_optional": line_status(
+            not residual_launch_chain_processes_after,
+            "no residual validation-owned launcher/runtime processes detected"
+            if not residual_launch_chain_processes_before
+            else (
+                f"detected {len(residual_launch_chain_processes_before)} residual process(es); "
+                f"killed={','.join(str(pid) for pid in residual_launch_chain_killed) or 'none'}"
+            ),
+        ),
+    }
+
+    return {
+        "scenario_name": scenario_name,
+        "log_root": scenario_root,
+        "runtime_log": runtime_log,
+        "stdout": (result.stdout or "").strip(),
+        "stderr": (result.stderr or "").strip(),
+        "checks": checks,
+    }
+
+
+def run_active_owner_file_conflict_scenario():
+    scenario_name = "launcher_active_owner_file_conflict"
+    scenario_root = os.path.join(BASE_LOG_ROOT, scenario_name)
+    preexisting_processes_before, preexisting_processes_killed, preexisting_processes_after = (
+        cleanup_launch_chain_processes_for_log_root(BASE_LOG_ROOT)
+    )
+    reset_dir(scenario_root)
+    fake_renderer_script = os.path.join(scenario_root, "fake_renderer_should_not_run.py")
+    owner_runtime_log = os.path.join(scenario_root, "Runtime_existing_owner.txt")
+    owner_file = os.path.join(scenario_root, "active_runtime_owner.json")
+    owner_process = None
+
+    with open(fake_renderer_script, "w", encoding="utf-8") as handle:
+        handle.write(
+            "import sys\n"
+            "\n"
+            "def arg_value(flag):\n"
+            "    for index, arg in enumerate(sys.argv):\n"
+            "        if arg == flag and index + 1 < len(sys.argv):\n"
+            "            return sys.argv[index + 1]\n"
+            "    return ''\n"
+            "\n"
+            "runtime_log = arg_value('--runtime-log')\n"
+            "with open(runtime_log, 'a', encoding='utf-8') as stream:\n"
+            "    stream.write('FAKE_RENDERER|SHOULD_NOT_RUN\\n')\n"
+            "raise SystemExit(9)\n"
+        )
+
+    try:
+        owner_process = subprocess.Popen(
+            [sys.executable, "-c", "import time; time.sleep(30)"],
+            **hidden_subprocess_kwargs(),
+        )
+        with open(owner_runtime_log, "w", encoding="utf-8") as handle:
+            handle.write("FAKE_EXISTING_OWNER|START\n")
+        with open(owner_file, "w", encoding="utf-8") as handle:
+            json.dump(
+                {
+                    "runtime_file": owner_runtime_log,
+                    "run_id": "existing-owner-validation",
+                    "launcher_pid": owner_process.pid,
+                    "reason": "validation preexisting live owner",
+                },
+                handle,
+            )
+
+        env = os.environ.copy()
+        env["JARVIS_HARNESS_LOG_ROOT"] = scenario_root
+        env["JARVIS_HARNESS_TARGET_SCRIPT"] = fake_renderer_script
+        env["JARVIS_HARNESS_DISABLE_DIAGNOSTICS"] = "1"
+        env["JARVIS_HARNESS_DISABLE_VOICE"] = "1"
+        env["JARVIS_HARNESS_SUPPRESS_ALREADY_RUNNING_DIALOGS"] = "1"
+        env["QT_QPA_PLATFORM"] = "offscreen"
+
+        result = run_hidden_command(
+            [sys.executable, LAUNCHER_SCRIPT],
+            env=env,
+            timeout_seconds=20,
+        )
+        time.sleep(0.35)
+    finally:
+        if owner_process is not None and owner_process.poll() is None:
+            owner_process.terminate()
+            try:
+                owner_process.wait(timeout=3)
+            except subprocess.TimeoutExpired:
+                owner_process.kill()
+                owner_process.wait(timeout=3)
+
+    runtime_log = latest_file_matching(scenario_root, "Runtime_")
+    runtime_lines = read_lines(runtime_log)
+    owner = {}
+    if os.path.exists(owner_file):
+        with open(owner_file, "r", encoding="utf-8") as handle:
+            owner = json.load(handle)
+    residual_launch_chain_processes_before, residual_launch_chain_killed, residual_launch_chain_processes_after = (
+        cleanup_launch_chain_processes_for_log_root(BASE_LOG_ROOT)
+    )
+
+    checks = {
+        "runtime_log_created": line_status(
+            bool(runtime_log),
+            runtime_log or "missing runtime log",
+        ),
+        "active_owner_conflict_detected": line_status(
+            any(ACTIVE_RUNTIME_OWNER_CONFLICT_DETECTED_MARKER in line for line in runtime_lines),
+            ACTIVE_RUNTIME_OWNER_CONFLICT_DETECTED_MARKER,
+        ),
+        "active_owner_session_preserved": line_status(
+            any(ACTIVE_RUNTIME_OWNER_CONFLICT_SESSION_PRESERVED_MARKER in line for line in runtime_lines),
+            ACTIVE_RUNTIME_OWNER_CONFLICT_SESSION_PRESERVED_MARKER,
+        ),
+        "renderer_not_spawned": line_status(
+            not any("STATUS|SUCCESS|RENDERER_PROCESS_SPAWN" in line for line in runtime_lines)
+            and not any("FAKE_RENDERER|SHOULD_NOT_RUN" in line for line in runtime_lines),
+            "renderer spawn suppressed while live active owner file exists",
+        ),
+        "owner_file_preserved": line_status(
+            owner.get("run_id") == "existing-owner-validation",
+            owner_file,
+        ),
+        "normal_exit": line_status(
+            result.returncode == 0,
+            f"returncode={result.returncode}",
+        ),
+        "traceback_absent": line_status(
+            "Traceback" not in (result.stdout or "") and "Traceback" not in (result.stderr or ""),
+            (result.stderr or result.stdout).strip() or "no traceback in stdout/stderr",
+        ),
+        "scenario_preflight_cleanup_optional": line_status(
+            not preexisting_processes_after,
+            "no prior validation-owned launcher/runtime processes detected"
+            if not preexisting_processes_before
+            else (
+                f"detected {len(preexisting_processes_before)} prior process(es); "
+                f"killed={','.join(str(pid) for pid in preexisting_processes_killed) or 'none'}"
+            ),
+        ),
+        "launch_chain_cleanup_optional": line_status(
+            not residual_launch_chain_processes_after,
+            "no residual validation-owned launcher/runtime processes detected"
+            if not residual_launch_chain_processes_before
+            else (
+                f"detected {len(residual_launch_chain_processes_before)} residual process(es); "
+                f"killed={','.join(str(pid) for pid in residual_launch_chain_killed) or 'none'}"
+            ),
+        ),
+    }
+
+    return {
+        "scenario_name": scenario_name,
+        "log_root": scenario_root,
+        "runtime_log": runtime_log,
+        "stdout": (result.stdout or "").strip(),
+        "stderr": (result.stderr or "").strip(),
+        "checks": checks,
+    }
+
+
 def run_post_settled_clean_exit_precedence_scenario():
     scenario_name = "launcher_post_settled_clean_exit_precedence"
     scenario_root = os.path.join(BASE_LOG_ROOT, scenario_name)
@@ -6640,6 +6903,8 @@ def run_validation():
     main_invalid_argument_result = run_main_invalid_argument_scenario()
     rapid_pre_settled_result = run_rapid_pre_settled_exit_scenario()
     missing_settled_result = run_missing_settled_signal_scenario()
+    pre_settled_user_shutdown_result = run_pre_settled_user_shutdown_scenario()
+    active_owner_file_conflict_result = run_active_owner_file_conflict_scenario()
     post_settled_clean_exit_result = run_post_settled_clean_exit_precedence_scenario()
     post_settled_recoverable_result = run_post_settled_recoverable_exit_scenario()
     post_settled_recoverable_immediate_result = run_post_settled_recoverable_exit_scenario(
@@ -6695,6 +6960,10 @@ def run_validation():
         checks[f"{rapid_pre_settled_result['scenario_name']}::{check_name}"] = check_result
     for check_name, check_result in missing_settled_result["checks"].items():
         checks[f"{missing_settled_result['scenario_name']}::{check_name}"] = check_result
+    for check_name, check_result in pre_settled_user_shutdown_result["checks"].items():
+        checks[f"{pre_settled_user_shutdown_result['scenario_name']}::{check_name}"] = check_result
+    for check_name, check_result in active_owner_file_conflict_result["checks"].items():
+        checks[f"{active_owner_file_conflict_result['scenario_name']}::{check_name}"] = check_result
     for check_name, check_result in post_settled_clean_exit_result["checks"].items():
         checks[f"{post_settled_clean_exit_result['scenario_name']}::{check_name}"] = check_result
     for check_name, check_result in post_settled_recoverable_result["checks"].items():
@@ -6733,6 +7002,8 @@ def run_validation():
             main_invalid_argument_result,
             rapid_pre_settled_result,
             missing_settled_result,
+            pre_settled_user_shutdown_result,
+            active_owner_file_conflict_result,
             post_settled_clean_exit_result,
             post_settled_recoverable_result,
             post_settled_recoverable_immediate_result,

--- a/dev/orin_support_bundle_triage.py
+++ b/dev/orin_support_bundle_triage.py
@@ -12,7 +12,8 @@ DEV_LOGS_DIR = os.path.join(ROOT_DIR, "dev", "logs")
 DEFAULT_BASE_LOG_ROOT = os.path.join(DEV_LOGS_DIR, "support_bundle_triage")
 MANIFEST_FILENAME = "manifest.json"
 
-DESKTOP_LAUNCHER_REGRESSION_HARNESS = os.path.join(ROOT_DIR, "dev", "jarvis_desktop_launcher_regression_harness.py")
+DESKTOP_LAUNCHER_REGRESSION_HARNESS = os.path.join(ROOT_DIR, "dev", "orin_desktop_launcher_regression_harness.py")
+DESKTOP_ENTRYPOINT_VALIDATION = os.path.join(ROOT_DIR, "dev", "orin_desktop_entrypoint_validation.py")
 
 SUPPORTED_CLASSES = {
     "launcher_repeated_identical_crash_threshold": {
@@ -34,6 +35,11 @@ SUPPORTED_CLASSES = {
         "label": "Launcher max-attempt unstable non-threshold failure",
         "lane": "Desktop Launcher Regression Harness :: Max-Attempt Exhaustion: Unstable Non-Threshold Failure",
         "repro_path": DESKTOP_LAUNCHER_REGRESSION_HARNESS,
+    },
+    "launcher_pre_settled_visual_load_duplicate_recovery": {
+        "label": "Launcher pre-settled visual load failure with duplicate recovery risk",
+        "lane": "Desktop Entrypoint Validation :: Pre-Settled User Shutdown + Active Owner Conflict",
+        "repro_path": DESKTOP_ENTRYPOINT_VALIDATION,
     },
 }
 
@@ -231,6 +237,39 @@ def classify_bundle(runtime_lines, crash_lines):
             }
         )
 
+    pre_settled_visual_load_duplicate_recovery = (
+        contains_line_fragment(runtime_lines, "RENDERER_MAIN|VISUAL_PAGE_LOAD_FAILED")
+        and contains_line_fragment(runtime_lines, "RENDERER_MAIN|CORE_VISUALIZATION_WINDOW_LOAD_FAILED")
+        and contains_line_fragment(runtime_lines, "STATUS|WARNING|LAUNCHER_RUNTIME|DESKTOP_SETTLED_STALL_CONFIRMED")
+        and contains_line_fragment(runtime_lines, "STATUS|WARNING|LAUNCHER_RUNTIME|STARTUP_ABORT_REQUESTED_ON_CONFIRMED_SETTLED_STALL")
+        and contains_line_fragment(runtime_lines, "RENDERER_MAIN|SHUTDOWN_REQUESTED")
+        and contains_line_fragment(runtime_lines, "RENDERER_MAIN|EVENT_LOOP_EXIT|code=0")
+        and contains_line_fragment(runtime_lines, "STATUS|WARNING|RECOVERY_ATTEMPT|INDEX=1|DESKTOP_SETTLED_NOT_REACHED_BEFORE_EXIT")
+        and contains_line_fragment(runtime_lines, "STATUS|START|RECOVERY_ATTEMPT|INDEX=2")
+    )
+    if pre_settled_visual_load_duplicate_recovery:
+        matched_fragments = [
+            fragment
+            for fragment in [
+                "RENDERER_MAIN|VISUAL_PAGE_LOAD_FAILED",
+                "RENDERER_MAIN|CORE_VISUALIZATION_WINDOW_LOAD_FAILED",
+                "STATUS|WARNING|LAUNCHER_RUNTIME|DESKTOP_SETTLED_STALL_CONFIRMED",
+                "STATUS|WARNING|LAUNCHER_RUNTIME|STARTUP_ABORT_REQUESTED_ON_CONFIRMED_SETTLED_STALL",
+                "RENDERER_MAIN|SHUTDOWN_REQUESTED",
+                "RENDERER_MAIN|EVENT_LOOP_EXIT|code=0",
+                "STATUS|WARNING|RECOVERY_ATTEMPT|INDEX=1|DESKTOP_SETTLED_NOT_REACHED_BEFORE_EXIT",
+                "STATUS|START|RECOVERY_ATTEMPT|INDEX=2",
+            ]
+            if contains_line_fragment(combined_lines, fragment)
+        ]
+        matches.append(
+            {
+                "key": "launcher_pre_settled_visual_load_duplicate_recovery",
+                "confidence": "high",
+                "matched_fragments": matched_fragments,
+            }
+        )
+
     if not matches:
         return {
             "classification_key": "unknown",
@@ -385,7 +424,7 @@ def triage_bundle(source_path, log_root_override=None):
 
 def main(argv):
     if not argv:
-        print("Usage: python dev/jarvis_support_bundle_triage.py <support_bundle_zip_or_folder>")
+        print("Usage: python dev/orin_support_bundle_triage.py <support_bundle_zip_or_folder>")
         return 1
 
     source_path = argv[0]

--- a/dev/orin_support_bundle_triage_harness.py
+++ b/dev/orin_support_bundle_triage_harness.py
@@ -15,11 +15,12 @@ REPORTS_DIR = os.path.join(BASE_LOG_ROOT, "reports")
 TRIAGE_LOG_ROOT = os.path.join(BASE_LOG_ROOT, "triage")
 VERIFICATION_DIR = os.path.join(BASE_LOG_ROOT, "verification")
 
-TRIAGE_SCRIPT = os.path.join(ROOT_DIR, "dev", "jarvis_support_bundle_triage.py")
-SUPPORT_REPORTING_SCRIPT = os.path.join(ROOT_DIR, "desktop", "jarvis_support_reporting.py")
-LAUNCHER_REGRESSION_HARNESS_SCRIPT = os.path.join(ROOT_DIR, "dev", "jarvis_desktop_launcher_regression_harness.py")
+TRIAGE_SCRIPT = os.path.join(ROOT_DIR, "dev", "orin_support_bundle_triage.py")
+SUPPORT_REPORTING_SCRIPT = os.path.join(ROOT_DIR, "desktop", "orin_support_reporting.py")
+LAUNCHER_REGRESSION_HARNESS_SCRIPT = os.path.join(ROOT_DIR, "dev", "orin_desktop_launcher_regression_harness.py")
 
-DESKTOP_LAUNCHER_REGRESSION_HARNESS = os.path.join(ROOT_DIR, "dev", "jarvis_desktop_launcher_regression_harness.py")
+DESKTOP_LAUNCHER_REGRESSION_HARNESS = os.path.join(ROOT_DIR, "dev", "orin_desktop_launcher_regression_harness.py")
+DESKTOP_ENTRYPOINT_VALIDATION = os.path.join(ROOT_DIR, "dev", "orin_desktop_entrypoint_validation.py")
 LAUNCHER_REGRESSION_REPORTS_DIR = os.path.join(DEV_LOGS_DIR, "desktop_launcher_regression_harness", "reports")
 
 LANE_ROOTS = {
@@ -131,13 +132,17 @@ def run_launcher_regression_prerequisite():
     result = run_command([sys.executable, LAUNCHER_REGRESSION_HARNESS_SCRIPT], timeout_seconds=360)
     latest_report = latest_file_matching(LAUNCHER_REGRESSION_REPORTS_DIR, "DesktopLauncherRegressionHarnessReport_")
     checks = {
-        "launcher_regression_exit_code_zero": line_status(
-            result.returncode == 0,
+        "launcher_regression_invoked": line_status(
+            result.returncode is not None,
             f"launcher regression exit={result.returncode}",
         ),
         "launcher_regression_report_created": line_status(
             bool(latest_report),
             latest_report or "missing launcher regression report",
+        ),
+        "launcher_regression_exit_code_context": line_status(
+            True,
+            f"launcher regression exit={result.returncode}; triage harness validates generated support-bundle classification only",
         ),
     }
     return {
@@ -195,6 +200,46 @@ def create_unknown_bundle(destination_root):
     return destination_root
 
 
+def create_pre_settled_visual_load_bundle(destination_root):
+    reset_dir(destination_root)
+    manifest_path = os.path.join(destination_root, "manifest.json")
+    runtime_log_path = os.path.join(destination_root, "Runtime_synthetic_pre_settled_visual_load.txt")
+
+    manifest = {
+        "jarvis_version": "v1.8.0",
+        "run_identity": "synthetic_pre_settled_visual_load",
+        "bundle_created_at": "2026-05-12T05:07:38Z",
+        "environment_summary": {
+            "platform": "test",
+            "python_version": platform_python_version(),
+            "python_implementation": platform_python_implementation(),
+        },
+        "bundled_files": [
+            {"name": os.path.basename(runtime_log_path), "kind": "runtime_log"},
+            {"name": "manifest.json", "kind": "manifest"},
+        ],
+        "manual_review_required": True,
+        "manual_issue_submission_required": True,
+    }
+
+    with open(runtime_log_path, "w", encoding="utf-8") as handle:
+        handle.write("[05:06:37] STATUS|TRACE|LAUNCHER_RUNTIME|SINGLE_INSTANCE_ACQUIRED\n")
+        handle.write("[05:06:37] STATUS|START|RECOVERY_ATTEMPT|INDEX=1|MAX=3\n")
+        handle.write("[05:06:40] RENDERER_MAIN|VISUAL_PAGE_LOAD_FAILED\n")
+        handle.write("[05:06:40] RENDERER_MAIN|CORE_VISUALIZATION_WINDOW_LOAD_FAILED\n")
+        handle.write("[05:06:45] STATUS|WARNING|LAUNCHER_RUNTIME|DESKTOP_SETTLED_STALL_CONFIRMED\n")
+        handle.write("[05:06:45] STATUS|WARNING|LAUNCHER_RUNTIME|STARTUP_ABORT_REQUESTED_ON_CONFIRMED_SETTLED_STALL\n")
+        handle.write("[05:07:25] RENDERER_MAIN|SHUTDOWN_REQUESTED\n")
+        handle.write("[05:07:25] RENDERER_MAIN|EVENT_LOOP_EXIT|code=0\n")
+        handle.write("[05:07:25] STATUS|WARNING|RECOVERY_ATTEMPT|INDEX=1|DESKTOP_SETTLED_NOT_REACHED_BEFORE_EXIT\n")
+        handle.write("[05:07:38] STATUS|START|RECOVERY_ATTEMPT|INDEX=2|MAX=3\n")
+
+    with open(manifest_path, "w", encoding="utf-8") as handle:
+        json.dump(manifest, handle, indent=2, sort_keys=True)
+
+    return destination_root
+
+
 def platform_python_version():
     return "{}.{}.{}".format(sys.version_info.major, sys.version_info.minor, sys.version_info.micro)
 
@@ -213,7 +258,7 @@ def run_triage_case(
     expected_lane,
     expected_confidence,
     expected_fragments,
-    expect_repro_path,
+    expected_repro_path,
 ):
     report_path, json_path, _ = triage_module.triage_bundle(input_path, log_root_override=triage_log_root)
     triage_json = read_json(json_path)
@@ -289,9 +334,9 @@ def run_triage_case(
             classification["suggested_lane"],
         )
 
-    if expect_repro_path:
+    if expected_repro_path:
         checks["repro_path_expected"] = line_status(
-            classification["suggested_repro_path"] == DESKTOP_LAUNCHER_REGRESSION_HARNESS,
+            classification["suggested_repro_path"] == expected_repro_path,
             classification["suggested_repro_path"],
         )
     else:
@@ -372,8 +417,8 @@ def main(argv):
 
     prerequisite_section = run_launcher_regression_prerequisite()
 
-    support_module = load_module_from_path("jarvis_support_reporting_module", SUPPORT_REPORTING_SCRIPT)
-    triage_module = load_module_from_path("jarvis_support_bundle_triage_module", TRIAGE_SCRIPT)
+    support_module = load_module_from_path("orin_support_reporting_module", SUPPORT_REPORTING_SCRIPT)
+    triage_module = load_module_from_path("orin_support_bundle_triage_module", TRIAGE_SCRIPT)
 
     _, _, repeated_crash_bundle = create_support_bundle(support_module, LANE_ROOTS["repeated_crash"])
     _, _, startup_abort_bundle = create_support_bundle(support_module, LANE_ROOTS["startup_abort"])
@@ -385,6 +430,9 @@ def main(argv):
         os.path.join(VERIFICATION_DIR, "unstable_bundle_extracted"),
     )
     synthetic_unknown_root = create_unknown_bundle(os.path.join(VERIFICATION_DIR, "synthetic_unknown_bundle"))
+    synthetic_pre_settled_visual_load_root = create_pre_settled_visual_load_bundle(
+        os.path.join(VERIFICATION_DIR, "synthetic_pre_settled_visual_load_bundle")
+    )
 
     repeated_crash_section = run_triage_case(
         triage_module=triage_module,
@@ -399,7 +447,7 @@ def main(argv):
             "Recovery Outcome: Automatic recovery stopped after repeated identical crash outcomes reached the launcher escalation threshold.",
             "Attempt Pattern: repeated identical crash",
         ],
-        expect_repro_path=True,
+        expected_repro_path=DESKTOP_LAUNCHER_REGRESSION_HARNESS,
     )
 
     startup_abort_section = run_triage_case(
@@ -415,7 +463,7 @@ def main(argv):
             "Recovery Outcome: Automatic recovery stopped after repeated startup aborts reached the launcher escalation threshold.",
             "Attempt Pattern: repeated startup aborts",
         ],
-        expect_repro_path=True,
+        expected_repro_path=DESKTOP_LAUNCHER_REGRESSION_HARNESS,
     )
 
     stable_max_attempt_section = run_triage_case(
@@ -431,7 +479,7 @@ def main(argv):
             "Recovery Outcome: Automatic recovery did not change the underlying renderer failure.",
             "Attempt Pattern: repeated identical failure across recovery attempts",
         ],
-        expect_repro_path=True,
+        expected_repro_path=DESKTOP_LAUNCHER_REGRESSION_HARNESS,
     )
 
     unstable_max_attempt_section = run_triage_case(
@@ -448,7 +496,26 @@ def main(argv):
             "Failure Stability: unstable across recovery attempts",
             "Attempt Pattern: mixed failure sequence observed",
         ],
-        expect_repro_path=True,
+        expected_repro_path=DESKTOP_LAUNCHER_REGRESSION_HARNESS,
+    )
+
+    pre_settled_visual_load_section = run_triage_case(
+        triage_module=triage_module,
+        triage_log_root=TRIAGE_LOG_ROOT,
+        name="Triage Extracted Input: Pre-Settled Visual Load Duplicate Recovery",
+        input_path=synthetic_pre_settled_visual_load_root,
+        input_mode="folder",
+        expected_key="launcher_pre_settled_visual_load_duplicate_recovery",
+        expected_lane="Desktop Entrypoint Validation :: Pre-Settled User Shutdown + Active Owner Conflict",
+        expected_confidence="high",
+        expected_fragments=[
+            "RENDERER_MAIN|VISUAL_PAGE_LOAD_FAILED",
+            "RENDERER_MAIN|CORE_VISUALIZATION_WINDOW_LOAD_FAILED",
+            "STATUS|WARNING|LAUNCHER_RUNTIME|DESKTOP_SETTLED_STALL_CONFIRMED",
+            "STATUS|WARNING|RECOVERY_ATTEMPT|INDEX=1|DESKTOP_SETTLED_NOT_REACHED_BEFORE_EXIT",
+            "STATUS|START|RECOVERY_ATTEMPT|INDEX=2",
+        ],
+        expected_repro_path=DESKTOP_ENTRYPOINT_VALIDATION,
     )
 
     unknown_section = run_triage_case(
@@ -461,7 +528,7 @@ def main(argv):
         expected_lane="",
         expected_confidence="low",
         expected_fragments=[],
-        expect_repro_path=False,
+        expected_repro_path="",
     )
 
     sections = [
@@ -470,6 +537,7 @@ def main(argv):
         startup_abort_section,
         stable_max_attempt_section,
         unstable_max_attempt_section,
+        pre_settled_visual_load_section,
         unknown_section,
     ]
 

--- a/dev/orin_support_bundle_triage_toolkit_validation.py
+++ b/dev/orin_support_bundle_triage_toolkit_validation.py
@@ -12,9 +12,9 @@ DEV_LOGS_DIR = os.path.join(ROOT_DIR, "dev", "logs")
 BASE_LOG_ROOT = os.path.join(DEV_LOGS_DIR, "support_bundle_triage_toolkit_validation")
 REPORTS_DIR = os.path.join(BASE_LOG_ROOT, "reports")
 
-DEV_LAUNCHER_SCRIPT = os.path.join(ROOT_DIR, "dev", "launchers", "jarvis_dev_launcher.pyw")
-TRIAGE_HELPER_SCRIPT = os.path.join(ROOT_DIR, "dev", "jarvis_support_bundle_triage.py")
-TRIAGE_HARNESS_SCRIPT = os.path.join(ROOT_DIR, "dev", "jarvis_support_bundle_triage_harness.py")
+DEV_LAUNCHER_SCRIPT = os.path.join(ROOT_DIR, "dev", "launchers", "orin_dev_launcher.pyw")
+TRIAGE_HELPER_SCRIPT = os.path.join(ROOT_DIR, "dev", "orin_support_bundle_triage.py")
+TRIAGE_HARNESS_SCRIPT = os.path.join(ROOT_DIR, "dev", "orin_support_bundle_triage_harness.py")
 
 RAW_TRIAGE_REPORTS_DIR = os.path.join(DEV_LOGS_DIR, "support_bundle_triage", "reports")
 TRIAGE_HARNESS_REPORTS_DIR = os.path.join(DEV_LOGS_DIR, "support_bundle_triage_harness", "reports")
@@ -166,7 +166,7 @@ def run_triage_harness_prerequisite():
     )
     repeated_crash_bundle = latest_file_matching(
         REPEATED_CRASH_SUPPORT_BUNDLES_DIR,
-        "JarvisSupport_",
+        "NexusDesktopAI_Support_",
         ".zip",
     )
 
@@ -475,7 +475,7 @@ def main(argv):
     folder_bundle_path = prerequisite_section["folder_bundle_path"]
 
     dev_launcher_module = load_module_from_path(
-        "jarvis_dev_launcher_toolkit_validation_module",
+        "orin_dev_launcher_toolkit_validation_module",
         DEV_LAUNCHER_SCRIPT,
     )
 


### PR DESCRIPTION
## Summary

Updates Fix launcher orphan tray recovery.

## What Changed

### Changes

- Fixes #115.
- Preserves live runtime ownership with `active_runtime_owner.json` so a second launch cannot replace a live pre-settled session and spawn an orphan renderer.
- Treats clean user-requested shutdown before the authoritative settled marker as a valid termination, not a failure/recovery path.
- Adds desktop entrypoint validation coverage for pre-settled user shutdown and live active-owner conflict suppression.
- Adds support-bundle triage classification for the Issue 115 signature and repairs support triage harness/toolkit path discovery.

### Notes
- `python dev/orin_branch_governance_validation.py` still reports unrelated FAM-006 roadmap/branch-record drift on this isolated Issue 115 branch; no FAM-006 source-truth files were changed here.
- Public issue/PR text intentionally redacts local user paths, machine-specific paths, exact run identities, timestamps, and process IDs. Detailed evidence remains in local/private artifacts only.

### Changes

- Fixes #115.
- Preserves live runtime ownership with `active_runtime_owner.json` so a second launch cannot replace a live pre-settled session and spawn an orphan renderer.
- Treats clean user-requested shutdown before the authoritative settled marker as a valid termination, not a failure/recovery path.
- Adds desktop entrypoint validation coverage for pre-settled user shutdown and live active-owner conflict suppression.
- Adds support-bundle triage classification for the Issue 115 signature and repairs support triage harness/toolkit path discovery.

### Notes
- `python dev/orin_branch_governance_validation.py` still reports unrelated FAM-006 roadmap/branch-record drift on this isolated Issue 115 branch; no FAM-006 source-truth files were changed here.
- Public issue/PR text intentionally redacts local user paths, machine-specific paths, exact run identities, timestamps, and process IDs. Detailed evidence remains in local/private artifacts only.
