### PR TITLE
Governance Intake RRI-20260514-004

### DIFF
--- a/Docs/branch_records/feature_fam_006_dashboard_settings_panel.md
+++ b/Docs/branch_records/feature_fam_006_dashboard_settings_panel.md
@@ -54,6 +54,10 @@ Watcher / Live PR State Projection: `No live PR, watcher, merge-watch, PR URL, b
 
 FAM Overlap Routing: `FAM-007, provider/model/memory/shortcut/installer work, Overlay/display acceptance, external telemetry parity, AI Product Contract import, and Private Dev ORIN import remain separate pending USER decisions.`
 
+Release Candidate Anchor Projection: `Current fetched origin/main is the default release-candidate anchor unless USER explicitly selects another release target. Target commit 9cc529b3036bd4badf3bde86779eb6640b9e7bc9 includes PR #145 / PR #146 Release Readiness Candidate Anchor and Release Window Aggregation Ownership governance repairs; PR #142 merge commit fdcc76a8f80cf2ed91798962610f4112056a4bf6 is historical audit evidence only unless USER explicitly selects it as the release target. Candidate Includes Later Governance Repairs: YES.`
+
+Release Window Contributor Inventory: `Release Ownership Model: Aggregated release window. Release Window Contributors: FAM-006 PR #129 Dashboard render/layout hardening, FAM-006 PR #132 Dashboard IA/control follow-through, FAM-006 PR #142 Dashboard settings-panel runtime work, and FAM-007 PR #138 provider-boundary / no-provider shell scaffold. Merged-Unreleased Scope Inventory: PR #129, PR #132, PR #142, and PR #138 remain merged-unreleased implementation scope until USER-approved release execution. Last Runtime PR: PR #142 for FAM-006 Dashboard settings-panel payload in this lane. Post-Runtime Governance Repairs: PR #133, PR #139, PR #141, PR #143, PR #144, PR #145, and PR #146 are source-truth/governance/readiness support, not runtime release execution. FAM Contributor Routing: FAM-006 Dashboard blockers route to the FAM-006 lane; FAM-007 provider/runtime blockers route to the FAM-007 lane; release-window aggregation blockers route to Governance only when they are source-truth/validator drift.`
+
 Projected Post-Merge Validation: `After merge, run source-truth validation from updated main, confirm No Active Branch, confirm this record is historical, confirm merged-unreleased FAM-006 settings-panel release debt, and confirm issue/release/raw-evidence/FAM-007 gates remain pending.`
 
 ## Release Readiness Health Pass
@@ -73,6 +77,10 @@ Watcher / Live PR State Projection: `PASS - watcher and live PR state belong to 
 Branch Cleanup Plan: `PASS - cleanup is deferred until after merge verification; no branch deletion or worktree removal is authorized by this record.`
 
 FAM Overlap Routing: `PASS - FAM-007, provider/model/memory/shortcut/installer work, Overlay/display acceptance, external telemetry parity, AI Product Contract import, and Private Dev ORIN import remain separate pending USER decisions.`
+
+Release Candidate Anchor Projection: `PASS - current fetched origin/main is the release-candidate anchor by default, target commit 9cc529b3036bd4badf3bde86779eb6640b9e7bc9 includes later governance repairs, and PR #142 fdcc76a8f80cf2ed91798962610f4112056a4bf6 remains historical audit evidence only unless USER explicitly selects it as the release target.`
+
+Release Window Contributor Inventory: `PASS - release ownership is an aggregated release window with FAM-006 PR #129, PR #132, PR #142 and FAM-007 PR #138 as merged-unreleased implementation contributors; PR #133, PR #139, PR #141, PR #143, PR #144, PR #145, and PR #146 are governance/readiness support contributors; contributor-specific blockers route to their owning lanes.`
 
 Projected Post-Merge Validation: `PASS - after merge, validate updated main, confirm No Active Branch, confirm this record is historical, confirm merged-unreleased FAM-006 settings-panel release debt, and confirm pending USER gates remain intact.`
 

--- a/Docs/branch_records/feature_release_readiness_source_truth_intake.md
+++ b/Docs/branch_records/feature_release_readiness_source_truth_intake.md
@@ -21,14 +21,14 @@ This branch is the single standing governance lane for Release Readiness source-
 - Branch Authority Marker: `Active standing governance intake lane`
 - `Active Branch`: `feature/release-readiness-source-truth-intake`
 - Branch Authority State: `Active standing authority / idle or single-cycle Release Readiness intake only`
-- Intake State: `Idle - RRI-20260514-003 merged candidate-anchor governance and closeout hardening records multi-worktree release-window aggregation before return digest`
+- Intake State: `Active - RRI-20260514-004 repairs Release Readiness health-gate projection for FAM-006 merged-unreleased release-candidate markers and the standing governance intake No Active Branch exception`
 - Standing Authority Exception: `Allowed - merged-main No Active Branch means no active runtime, implementation, release packaging, or repair carrier; the single standing governance intake authority may remain active for Release Readiness digest intake only`
 - Bootstrap Setup: `RRI-20260514-001 records the one-time USER-approved exception that creates C:\Nexus Worktrees\Governance and the standing branch from origin/main; this record now remains the durable active standing authority while each future intake still requires sync to origin/main before work`
 - Bootstrap Exception Limit: `Closed after setup merge; after setup PR merge or any origin/main movement, ahead-of-main work requires a USER-approved active RRI cycle sourced from a Release Readiness digest`
-- Active RRI Cycle: `None`
+- Active RRI Cycle: `RRI-20260514-004`
 - Latest Closed RRI Cycle: `RRI-20260514-003`
-- Return Digest Status: `Closeout Pending - RRI-20260514-003 return digest must target originating branch feature/fam-006-dashboard-settings-panel at C:\Nexus Worktrees\FAM-006 after this closeout PR merges and the branch syncs`
-- Latest Closed Cycle Identity: `RRI-20260514-003 originated from feature/fam-006-dashboard-settings-panel at C:\Nexus Worktrees\FAM-006`
+- Return Digest Status: `Pending - RRI-20260514-004 return digest must target originating branch feature/fam-006-dashboard-settings-panel at C:\Nexus Worktrees\FAM-006 after merge/sync`
+- Active Cycle Identity: `RRI-20260514-004 originated from feature/fam-006-dashboard-settings-panel at C:\Nexus Worktrees\FAM-006`
 
 ## Branch Class
 
@@ -56,10 +56,10 @@ This branch is the single standing governance lane for Release Readiness source-
 - Worktree: `C:\Nexus Worktrees\Governance`
 - Intake Source: Release Readiness digest only; bootstrap setup is the one-time USER-approved exception recorded by RRI-20260514-001.
 - Cycle ID Format: `RRI-YYYYMMDD-NNN`
-- Active RRI Cycle: `None`
+- Active RRI Cycle: `RRI-20260514-004`
 - Latest Closed RRI Cycle: `RRI-20260514-003`
-- Return Digest Status: `Closeout Pending - RRI-20260514-003 return digest must target originating branch feature/fam-006-dashboard-settings-panel at C:\Nexus Worktrees\FAM-006 after this closeout PR merges and the branch syncs`
-- Latest Closed Cycle Identity: `RRI-20260514-003 originated from feature/fam-006-dashboard-settings-panel at C:\Nexus Worktrees\FAM-006`
+- Return Digest Status: `Pending - RRI-20260514-004 return digest must target originating branch feature/fam-006-dashboard-settings-panel at C:\Nexus Worktrees\FAM-006 after merge/sync`
+- Active Cycle Identity: `RRI-20260514-004 originated from feature/fam-006-dashboard-settings-panel at C:\Nexus Worktrees\FAM-006`
 - One Active Cycle: Required - a second digest queues until the active cycle merges, returns its digest, and the branch syncs to origin/main.
 - Sync Rule: Before each new intake the branch must be clean and match origin/main; otherwise `Standing Governance Intake Not Rebased` blocks work.
 - Bootstrap Exception Limit: Required - the RRI-20260514-001 setup exception cannot authorize future ahead-of-main work after origin/main moves beyond the recorded branch creation base.
@@ -176,9 +176,9 @@ No runtime User Test Summary is required. Operator validation is repo-side: `git
 
 ## Active Seam
 
-Active seam: `None - standing governance intake idle after RRI-20260514-003 closeout`
+Active seam: `RRI-20260514-004 - Release Readiness health-gate projection repair`
 
-Seam Goal: `Preserve RRI-20260514-003 candidate-anchor governance and add closeout hardening for multi-worktree release-window ownership before returning a digest to the originating lane.`
+Seam Goal: `Add missing FAM-006 release-candidate anchor / release-window contributor health markers and align the health gate with the standing governance intake exception under No Active Branch.`
 
 Seam Scope: `This authority record, governance docs, helper registry text, and dev/orin_branch_governance_validation.py.`
 

--- a/dev/orin_branch_governance_validation.py
+++ b/dev/orin_branch_governance_validation.py
@@ -14356,7 +14356,13 @@ def _run_merge_target_authority_projection_gate(
     if "No Active Branch" not in post_merge_state:
         return
 
-    remaining_active_record_paths = sorted(active_branch_record_paths)
+    # Merged-main `No Active Branch` allows the single standing governance intake
+    # authority record; it is not a runtime/implementation/release carrier.
+    remaining_active_record_paths = sorted(
+        record_path
+        for record_path in active_branch_record_paths
+        if record_path != STANDING_GOVERNANCE_INTAKE_RECORD.as_posix()
+    )
     require(
         not remaining_active_record_paths,
         (


### PR DESCRIPTION
## Summary

Adds the missing FAM-006 Release Readiness health-gate markers for the current release candidate anchor and release-window contributor inventory.

## What Changed

### Summary Detail

- Aligns the release-readiness health gate with the standing governance intake exception allowed under merged-main `No Active Branch`.

- Opens RRI-20260514-004 as a bounded Release Readiness source-truth/validator repair for the FAM-006 originating lane.

y.
- Aligns the release-readiness health gate with the standing governance intake exception allowed under merged-main `No Active Branch`.
- Opens RRI-20260514-004 as a bounded Release Readiness source-truth/validator repair for the FAM-006 originating lane.

- Branch: `feature/release-readiness-source-truth-intake`
- Worktree: `C:\Nexus Worktrees\Governance`
- Cycle: `RRI-20260514-004`
- Originating lane identity: `feature/fam-006-dashboard-settings-panel` at `C:\Nexus Worktrees\FAM-006`
- Scope is limited to `Docs/branch_records/feature_fam_006_dashboard_settings_panel.md`, `Docs/branch_records/feature_release_readiness_source_truth_intake.md`, and `dev/orin_branch_governance_validation.py`.
- No runtime, provider, model, memory, voice, Core, shortcut, installer, release execution, tag, GitHub Release, artifact, issue closeout, branch cleanup, or raw evidence changes are included.

- Branch: `feature/release-readiness-source-truth-intake`
- Worktree: `C:\Nexus Worktrees\Governance`
- Cycle: `RRI-20260514-004`
- Originating lane identity: `feature/fam-006-dashboard-settings-panel` at `C:\Nexus Worktrees\FAM-006`
- Scope is limited to `Docs/branch_records/feature_fam_006_dashboard_settings_panel.md`, `Docs/branch_records/feature_release_readiness_source_truth_intake.md`, and `dev/orin_branch_governance_validation.py`.
- No runtime, provider, model, memory, voice, Core, shortcut, installer, release execution, tag, GitHub Release, artifact, issue closeout, branch cleanup, or raw evidence changes are included.
