### PR TITLE
Governance Intake RRI-20260514-007 closeout

### DIFF
--- a/Docs/branch_records/feature_release_readiness_source_truth_intake.md
+++ b/Docs/branch_records/feature_release_readiness_source_truth_intake.md
@@ -21,22 +21,22 @@ This branch is the single standing governance lane for Release Readiness source-
 - Branch Authority Marker: `Active standing governance intake lane`
 - `Active Branch`: `feature/release-readiness-source-truth-intake`
 - Branch Authority State: `Active standing authority / idle or single-cycle Release Readiness digest or automation/worktree governance intake only`
-- Intake State: `Active - RRI-20260514-007 repairs automation observability and multi-worktree watcher governance so standing automations cannot misread stale neutral-main state as active lane truth`
+- Intake State: `Idle - latest cycle RRI-20260514-007 merged through PR #153, returned digest, and synced the standing branch`
 - Standing Authority Exception: `Allowed - merged-main No Active Branch means no active runtime, implementation, release packaging, or repair carrier; the single standing governance intake authority may remain active for Release Readiness digest intake or USER-approved automation/worktree governance intake only`
 - Bootstrap Setup: `RRI-20260514-001 records the one-time USER-approved exception that creates C:\Nexus Worktrees\Governance and the standing branch from origin/main; this record now remains the durable active standing authority while each future intake still requires sync to origin/main before work`
 - Bootstrap Exception Limit: `Closed after setup merge; after setup PR merge or any origin/main movement, ahead-of-main work requires a USER-approved active RRI cycle sourced from a Release Readiness digest, USER-approved automation/worktree governance intake, or a bot-review repair on an open standing-governance PR that already has USER approval`
-- Active RRI Cycle: `RRI-20260514-007`
-- Latest Closed RRI Cycle: `RRI-20260514-006`
-- Return Digest Status: `Pending - RRI-20260514-007 return digest must target this governance thread after PR merge/sync and report automation/worktree governance blockers cleared or remaining`
-- Active Cycle Identity: `RRI-20260514-007 originated from USER-approved automation multi-worktree governance pass; hold at PR Readiness Stage 1 with no PR creation until USER approval`
+- Active RRI Cycle: `None`
+- Latest Closed RRI Cycle: `RRI-20260514-007`
+- Return Digest Status: `Complete - RRI-20260514-007 repaired post-PR #152 active-authority closeout, selected-next/no-active distinction, and validator hardening; return digest is reported in this governance thread`
+- Active Cycle Identity: `None - idle after PR #153 merge and standing branch sync`
 
 ## PR Readiness Stage 1 Analysis Packet
 
 - PR Readiness Stage: `PR Readiness Stage 1 - Analysis Gate`
-- Pre-PR Live State: `No live PR for current RRI-20260514-007 head; PR Readiness Stage 2 / PR creation approval missing until USER explicitly approves PR creation`
-- Historical Merge Proof: `PR #151 is closed/merged historical proof for RRI-20260514-006 and must not be treated as the live PR for the current RRI-20260514-007 head`
+- Pre-PR Live State: `No live PR for an active RRI cycle; RRI-20260514-007 is closed historical proof after PR #153`
+- Historical Merge Proof: `PR #153 is closed/merged historical proof for RRI-20260514-007 and PR #151 is closed/merged historical proof for RRI-20260514-006; neither is a live PR for a new cycle`
 - Next Workstream User Waiver: `Not applicable - standing governance intake PRs do not select runtime successor workstreams, create runtime branches, or admit packages`
-- Stage 1 Outcome: `Stage 1 Ready For Stage 2 after validation passes; Stage 2 and PR creation remain blocked until USER approval`
+- Stage 1 Outcome: `Closed - RRI-20260514-007 merged and returned to idle`
 
 ## Branch Class
 
@@ -64,10 +64,10 @@ This branch is the single standing governance lane for Release Readiness source-
 - Worktree: `C:\Nexus Worktrees\Governance`
 - Intake Source: Release Readiness digest only for release-blocker intake; USER-approved automation/worktree governance intake may also use this standing lane when the repair is non-runtime, multi-worktree safety related, and held to the same one-cycle/PR-gated contract; bootstrap setup is the one-time USER-approved exception recorded by RRI-20260514-001, and bot-review repair on an open standing-governance PR may use a same-lane active RRI cycle only to repair that PR before merge.
 - Cycle ID Format: `RRI-YYYYMMDD-NNN`
-- Active RRI Cycle: `RRI-20260514-007`
-- Latest Closed RRI Cycle: `RRI-20260514-006`
-- Return Digest Status: `Pending - RRI-20260514-007 return digest must target this governance thread after PR merge/sync and report automation/worktree governance blockers cleared or remaining`
-- Active Cycle Identity: `RRI-20260514-007 originated from USER-approved automation multi-worktree governance pass; hold at PR Readiness Stage 1 with no PR creation until USER approval`
+- Active RRI Cycle: `None`
+- Latest Closed RRI Cycle: `RRI-20260514-007`
+- Return Digest Status: `Complete - RRI-20260514-007 repaired post-PR #152 active-authority closeout, selected-next/no-active distinction, and validator hardening; return digest is reported in this governance thread`
+- Active Cycle Identity: `None - idle after PR #153 merge and standing branch sync`
 - One Active Cycle: Required - a second digest queues until the active cycle merges, returns its digest, and the branch syncs to origin/main.
 - Sync Rule: Before each new intake the branch must be clean and match origin/main; otherwise `Standing Governance Intake Not Rebased` blocks work.
 - Bootstrap Exception Limit: Required - the RRI-20260514-001 setup exception cannot authorize future ahead-of-main work after origin/main moves beyond the recorded branch creation base.
@@ -188,11 +188,11 @@ No runtime User Test Summary is required. Operator validation is repo-side: `git
 
 ## Active Seam
 
-Active seam: `RRI-20260514-007 - multi-worktree automation observability governance`
+Active seam: `None - standing lane idle after RRI-20260514-007`
 
-Seam Goal: `Make standing automations and automation observability worktree-aware so stale neutral-main, wrong-lane cwd, historical prompt assumptions, and watcher/automation memory drift are reported as bounded repair candidates before they confuse active FAM or Governance lanes.`
+Seam Goal: `Idle until the next USER-approved Release Readiness digest or automation/worktree governance intake. RRI-20260514-007 repaired post-PR #152 active-authority closeout, selected-next/no-active distinction, and validator hardening.`
 
-Seam Scope: `This authority record, governance docs, helper registry text, dev/automation_observability_report.py, and dev/orin_branch_governance_validation.py support for the standing lane.`
+Seam Scope: `None active. Historical RRI-20260514-007 scope included this authority record, governance docs, helper registry text, dev/orin_branch_governance_validation.py, and registered source-truth validator support.`
 
 Seam Non-Includes: `runtime/provider/model/memory/voice/Core/shortcut/installer work, release execution, issue work, FAM-006 or FAM-007 mutation, broad docs churn, or direct-main mutation.`
 

--- a/Docs/feature_backlog.md
+++ b/Docs/feature_backlog.md
@@ -64,7 +64,7 @@ FB-038 remains released and closed in `v1.4.1-prebeta`.
 
 Released Historical Scope: FAM-006 Monitoring HUD Dashboard Product Surface released in v1.7.0-prebeta through PR #118; FAM-006 Dashboard render/layout hardening PR #129, Dashboard IA/control follow-through PR #132, Dashboard settings-panel runtime PR #142, and FAM-007 PR #138 provider-boundary / no-provider shell scaffold support released in v1.7.1-prebeta; FAM-001 legacy FB-049 Active-session pre-settled incoming-launch conflict truth, FAM-004 legacy FB-030 voice/audio runtime diagnostics proof, merged governance/automation proof package, PR #112 source-truth closeout / merge-target authority hardening proof, and PR #113 source-truth closeout / merge-target authority hardening proof released in v1.6.13-prebeta.
 Repo State: No Active Branch.
-Merged-Main Repo State: No Active Branch after PR #152; the standing release-readiness intake lane exists separately at `feature/release-readiness-source-truth-intake` / `C:\Nexus Worktrees\Governance` with Active RRI Cycle: RRI-20260514-007 during this repair.
+Merged-Main Repo State: No Active Branch after PR #152; the standing release-readiness intake lane exists separately at `feature/release-readiness-source-truth-intake` / `C:\Nexus Worktrees\Governance` with Active RRI Cycle: None after RRI-20260514-007 closeout.
 Latest Public Prerelease: v1.7.1-prebeta.
 Latest Public Release Commit: 47134640381909e9eec7127d4e826ee68b182ffb.
 Latest Public Prerelease Publication: https://github.com/GiribaldiTTV/Nexus-Desktop-AI/releases/tag/v1.7.1-prebeta.


### PR DESCRIPTION
## Summary

Closes the standing governance intake cycle after PR #153 so the reusable governance branch returns to idle source truth.

## What Changed

- Records `Active RRI Cycle: None` for `feature/release-readiness-source-truth-intake` after RRI-20260514-007.
- Updates the latest closed cycle to `RRI-20260514-007` and marks the return digest complete.
- Keeps merged-main runtime/product posture as `No Active Branch` while preserving the standing governance intake authority as the only active-authority exception.

- Records `Active RRI Cycle: None` for `feature/release-readiness-source-truth-intake` after RRI-20260514-007.
- Updates the latest closed cycle to `RRI-20260514-007` and marks the return digest complete.
- Keeps merged-main runtime/product posture as `No Active Branch` while preserving the standing governance intake authority as the only active-authority exception.
