### PR TITLE
Skip dev logs in governance efficiency text scan

### DIFF
--- a/dev/orin_governance_efficiency_validation.py
+++ b/dev/orin_governance_efficiency_validation.py
@@ -336,6 +336,8 @@ def _all_text_files() -> list[Path]:
         if not root.exists():
             continue
         for path in root.rglob("*"):
+            if root_name == "dev" and path.relative_to(root).parts[:1] == ("logs",):
+                continue
             if path.is_file() and path.suffix.lower() in {".md", ".py", ".ps1", ".txt"}:
                 candidates.append(path)
     readme = ROOT / "README.md"


### PR DESCRIPTION
## Summary

This tiny repair keeps `dev/orin_governance_efficiency_validation.py` from treating historical `dev/logs/**` artifacts as source-truth text files during stale vision-reference scanning.

## What Changed

### Summary Detail

The scan still covers `Docs/`, source/helper files under `dev/`, and `README.md`, but skips runtime/probe logs that may be Windows-encoded, UTF-16, or otherwise non-UTF-8 historical evidence.

### Summary Detail
