### PR TITLE
Align FAM-006 HUD validators with compact pointers

### DIFF
--- a/dev/orin_monitoring_hud_internal_sandbox_validation.py
+++ b/dev/orin_monitoring_hud_internal_sandbox_validation.py
@@ -191,9 +191,10 @@ def _validate_static_surface(failures: list[str]) -> None:
             "Sensor Library",
             "Overlay Profile",
             "Recording Profile",
-            "Docs/branch_records/feature_fam_006_overlay_display_acceptance_foundation.md",
-            "Docs/branch_records/feature_fam_006_overlay_profile_runtime_foundation.md",
-            "PR #194",
+            "Docs/family_visions/FAM-006_monitoring_and_hud.md",
+            "Docs/branch_records/feature_fam_006_active_overlay_recording_runtime_foundation.md",
+            "runtime recording implementation remains future-gated",
+            "canonical detail owners, not this compact backlog registry",
         ):
             _require_contains(
                 feature_backlog,
@@ -202,11 +203,10 @@ def _validate_static_surface(failures: list[str]) -> None:
                 failures,
             )
         for needle in (
-            "Overlay Display Acceptance Foundation is released in `v1.7.19-prebeta` via PR #207",
-            "Overlay Profile foundation evidence are released receipts",
-            "future monitoring/HUD scope remains USER-gated",
-            "Docs/branch_records/feature_fam_006_overlay_display_acceptance_foundation.md",
-            "Docs/branch_records/feature_fam_006_overlay_profile_runtime_foundation.md",
+            "durable planning and release receipts preserved; future recording runtime remains USER-gated",
+            "Docs/family_visions/FAM-006_monitoring_and_hud.md",
+            "Docs/branch_records/feature_fam_006_active_overlay_recording_runtime_foundation.md",
+            "Selected-next, branch-creation, live release-window, live PR, and current worktree assignment truth are not owned by this roadmap",
         ):
             _require_contains(
                 prebeta_roadmap,

--- a/dev/orin_monitoring_hud_surface_validation.py
+++ b/dev/orin_monitoring_hud_surface_validation.py
@@ -166,9 +166,10 @@ def validate() -> list[str]:
             "Sensor Library",
             "Overlay Profile",
             "Recording Profile",
-            "Docs/branch_records/feature_fam_006_overlay_display_acceptance_foundation.md",
-            "Docs/branch_records/feature_fam_006_overlay_profile_runtime_foundation.md",
-            "PR #194",
+            "Docs/family_visions/FAM-006_monitoring_and_hud.md",
+            "Docs/branch_records/feature_fam_006_active_overlay_recording_runtime_foundation.md",
+            "runtime recording implementation remains future-gated",
+            "canonical detail owners, not this compact backlog registry",
         ):
             _require_contains(
                 feature_backlog,
@@ -177,11 +178,10 @@ def validate() -> list[str]:
                 failures,
             )
         for needle in (
-            "Overlay Display Acceptance Foundation is released in `v1.7.19-prebeta` via PR #207",
-            "Overlay Profile foundation evidence are released receipts",
-            "future monitoring/HUD scope remains USER-gated",
-            "Docs/branch_records/feature_fam_006_overlay_display_acceptance_foundation.md",
-            "Docs/branch_records/feature_fam_006_overlay_profile_runtime_foundation.md",
+            "durable planning and release receipts preserved; future recording runtime remains USER-gated",
+            "Docs/family_visions/FAM-006_monitoring_and_hud.md",
+            "Docs/branch_records/feature_fam_006_active_overlay_recording_runtime_foundation.md",
+            "Selected-next, branch-creation, live release-window, live PR, and current worktree assignment truth are not owned by this roadmap",
         ):
             _require_contains(
                 prebeta_roadmap,


### PR DESCRIPTION
## Summary

Aligns FAM-006 HUD validators with the compact backlog and roadmap pointer model after the External Operational State Store transition.

## What Changed

### Summary Detail

- Keeps compact repo docs as routing surfaces to the family vision and canonical detail owner instead of requiring retired branch/PR receipt strings to be duplicated.

n.
- Keeps compact repo docs as routing surfaces to the family vision and canonical detail owner instead of requiring retired branch/PR receipt strings to be duplicated.

- All registered worktrees were fast-forwarded to origin/main@358252942791d1e76752ff217247158bf73e0e0b before this repair.
- The extra FAM-006 HUD validation pass exposed stale validator expectations for compact pointer files, while the repo docs correctly routed detailed history to canonical owners.
- This patch changes only dev/orin_monitoring_hud_surface_validation.py and dev/orin_monitoring_hud_internal_sandbox_validation.py; it does not mutate runtime behavior or source-truth docs.

- All registered worktrees were fast-forwarded to origin/main@358252942791d1e76752ff217247158bf73e0e0b before this repair.
- The extra FAM-006 HUD validation pass exposed stale validator expectations for compact pointer files, while the repo docs correctly routed detailed history to canonical owners.
- This patch changes only dev/orin_monitoring_hud_surface_validation.py and dev/orin_monitoring_hud_internal_sandbox_validation.py; it does not mutate runtime behavior or source-truth docs.
