### PR TITLE
Fix historical worktree receipt confinement lookup

### DIFF
--- a/dev/fixtures/branch_record_live_state_leakage/valid_external_state_historical_worktree_receipt_target.md
+++ b/dev/fixtures/branch_record_live_state_leakage/valid_external_state_historical_worktree_receipt_target.md
@@ -1,0 +1,35 @@
+# Branch Record: feature/fam-007-dev-owner-skeleton-readiness
+
+## Record State
+
+Record State: `Historical merged branch receipt`
+
+## Status
+
+Status: `PR #250 merged feature/fam-007-dev-owner-skeleton-readiness into main. This repo record preserves durable public-safe proof history only. It does not own current phase, active branch status, worktree assignment, PR state, release-window state, selected-next posture, active branch planning, or next-gate posture. Live operational truth belongs in Git/GitHub/helper-derived checks and C:\Nexus Governance State according to the external operational state contract.`
+
+## Branch Identity
+
+- Branch: `feature/fam-007-dev-owner-skeleton-readiness`
+- Worktree Receipt: `C:\Nexus Worktrees\FAM-007`
+- Branch Class: `implementation`
+- Family: `FAM-007`
+- Package: `PKG-007`
+- Target Family: `FAM-007`
+- Slot ID Receipt: `runtime-active-1`
+- Historical External Branch State Owner: `C:\Nexus Governance State\branches\feature_fam_007_dev_owner_skeleton_readiness\branch_state.md`
+- Historical External Branch Plan Owner: `C:\Nexus Governance State\branches\feature_fam_007_dev_owner_skeleton_readiness\branch_plan.md`
+
+## Current Phase
+
+Phase: `Historical Traceability`
+
+Stage: `Historical PR #250 merged receipt`
+
+Seam: `Not active - this file is durable receipt evidence only`
+
+## Phase Status
+
+- Branch Authority Marker: `Historical Branch`
+- Branch Authority State: `Historical merged receipt only; non-standing live branch lifecycle posture is external-state or Git/GitHub/helper-derived truth.`
+- Repo Live-State Boundary: `This record must not be updated as the active owner for current phase, current PR state, active branch status, active worktree assignment, selected-next state, release-window state, or temporary Codex handoff state.`

--- a/dev/orin_branch_governance_validation.py
+++ b/dev/orin_branch_governance_validation.py
@@ -19580,6 +19580,24 @@ def _run_worktree_confinement_regression_fixtures(require) -> None:
         f"{fixture}: broad historical receipt fixture must not rely on PR Readiness fallback wording",
     )
     _validate_historical_worktree_receipt_confinement(require, fixture, fixture_text)
+    external_target_fixture = (
+        BRANCH_RECORD_LIVE_STATE_LEAKAGE_FIXTURE_DIR
+        / "valid_external_state_historical_worktree_receipt_target.md"
+    )
+    external_target_text = _read_text(external_target_fixture)
+    require(
+        bool(external_target_text),
+        f"{external_target_fixture}: missing external-state historical receipt target fixture",
+    )
+    require(
+        _is_historical_worktree_receipt(external_target_text),
+        f"{external_target_fixture}: fixture must classify as a historical worktree receipt",
+    )
+    _validate_historical_worktree_receipt_confinement(
+        require,
+        external_target_fixture,
+        external_target_text,
+    )
     require(
         not _extract_exact_marker_value(identity, "Worktree"),
         f"{fixture}: `Worktree Receipt:` must not be parsed as active `Worktree:` assignment",
@@ -19617,10 +19635,18 @@ def _run_worktree_confinement_gate(require) -> None:
         branch_name,
     )
     if not record_text:
-        record_path, record_text = _external_branch_state_record_for_branch(
+        external_record_path, external_record_text = _external_branch_state_record_for_branch(
             branch_name,
             actual_root,
         )
+        if external_record_text and _is_historical_worktree_receipt(external_record_text):
+            _validate_historical_worktree_receipt_confinement(
+                require,
+                external_record_path,
+                external_record_text,
+            )
+            return
+        record_path, record_text = external_record_path, external_record_text
     if not record_text:
         historical_branch_record_paths = _collect_branch_record_paths(
             branch_record_index_text,


### PR DESCRIPTION
## Summary

Repair the standing Governance validator path that misclassified historical `Worktree Receipt:` evidence as active worktree-confinement authority.

## What Changed

### Summary Detail

- Add fixture coverage for an external-state historical worktree receipt target so future scans preserve durable historical receipts without treating them as live assignment state.

y.
- Add fixture coverage for an external-state historical worktree receipt target so future scans preserve durable historical receipts without treating them as live assignment state.

- Branch: `feature/release-readiness-source-truth-intake`
- Scope: Governance/source-truth validator repair for the historical FAM-007 worktree-receipt confinement false blocker.
- Changed files:
  - `dev/orin_branch_governance_validation.py`
  - `dev/fixtures/branch_record_live_state_leakage/valid_external_state_historical_worktree_receipt_target.md`

- Branch: `feature/release-readiness-source-truth-intake`
- Scope: Governance/source-truth validator repair for the historical FAM-007 worktree-receipt confinement false blocker.
- Changed files:
  - `dev/orin_branch_governance_validation.py`
  - `dev/fixtures/branch_record_live_state_leakage/valid_external_state_historical_worktree_receipt_target.md`
